### PR TITLE
feat(frontend): add route visualization components and demo page

### DIFF
--- a/frontend/app/demo/route-visualization/page.tsx
+++ b/frontend/app/demo/route-visualization/page.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useState } from 'react';
+import { RouteVisualization } from '@/components/shared/RouteVisualization';
+import { SplitRouteVisualization } from '@/components/shared/SplitRouteVisualization';
+import { PathStep } from '@/types';
+import { SplitRouteData, RouteMetrics } from '@/types/route';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+const singleHopPath: PathStep[] = [
+  {
+    from_asset: { asset_type: 'native' },
+    to_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'USDC',
+      asset_issuer: 'GA5Z...',
+    },
+    price: '0.0850',
+    source: 'sdex',
+  },
+];
+
+const multiHopPath: PathStep[] = [
+  {
+    from_asset: { asset_type: 'native' },
+    to_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'USDC',
+      asset_issuer: 'GA5Z...',
+    },
+    price: '0.0850',
+    source: 'sdex',
+  },
+  {
+    from_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'USDC',
+      asset_issuer: 'GA5Z...',
+    },
+    to_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'BTC',
+      asset_issuer: 'GBVOL...',
+    },
+    price: '0.000015',
+    source: 'amm:CDQR7XQJUGQP3VXV3YKQJMVXQXQXQXQXQXQXQXQXQXQXQXQXQXQXQXQX',
+  },
+];
+
+const complexPath: PathStep[] = [
+  {
+    from_asset: { asset_type: 'native' },
+    to_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'USDC',
+      asset_issuer: 'GA5Z...',
+    },
+    price: '0.0850',
+    source: 'sdex',
+  },
+  {
+    from_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'USDC',
+      asset_issuer: 'GA5Z...',
+    },
+    to_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'EURC',
+      asset_issuer: 'GBBD...',
+    },
+    price: '0.92',
+    source: 'amm:CDQR7XQJUGQP3VXV3YKQJMVXQXQXQXQXQXQXQXQXQXQXQXQXQXQXQXQX',
+  },
+  {
+    from_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'EURC',
+      asset_issuer: 'GBBD...',
+    },
+    to_asset: {
+      asset_type: 'credit_alphanum4',
+      asset_code: 'BTC',
+      asset_issuer: 'GBVOL...',
+    },
+    price: '0.000016',
+    source: 'sdex',
+  },
+];
+
+const splitRouteData: SplitRouteData = {
+  paths: [
+    {
+      percentage: 60,
+      steps: [
+        {
+          from_asset: { asset_type: 'native' },
+          to_asset: {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USDC',
+            asset_issuer: 'GA5Z...',
+          },
+          price: '0.0850',
+          source: 'sdex',
+        },
+        {
+          from_asset: {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'USDC',
+            asset_issuer: 'GA5Z...',
+          },
+          to_asset: {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'BTC',
+            asset_issuer: 'GBVOL...',
+          },
+          price: '0.000015',
+          source: 'sdex',
+        },
+      ],
+      outputAmount: '0.000765',
+    },
+    {
+      percentage: 40,
+      steps: [
+        {
+          from_asset: { asset_type: 'native' },
+          to_asset: {
+            asset_type: 'credit_alphanum4',
+            asset_code: 'BTC',
+            asset_issuer: 'GBVOL...',
+          },
+          price: '0.00000128',
+          source:
+            'amm:CDQR7XQJUGQP3VXV3YKQJMVXQXQXQXQXQXQXQXQXQXQXQXQXQXQXQXQX',
+        },
+      ],
+      outputAmount: '0.000512',
+    },
+  ],
+  totalOutput: '0.001277',
+  totalFees: '0.00001',
+  totalPriceImpact: '0.15%',
+};
+
+const mockMetrics: RouteMetrics = {
+  totalFees: '0.00001 BTC',
+  totalPriceImpact: '0.15%',
+  netOutput: '0.001267 BTC',
+  averageRate: '0.00000127',
+};
+
+export default function RouteVisualizationDemo() {
+  const [isLoading, setIsLoading] = useState(false);
+  const [showError, setShowError] = useState(false);
+
+  const simulateLoading = () => {
+    setIsLoading(true);
+    setTimeout(() => setIsLoading(false), 2000);
+  };
+
+  return (
+    <div className="container mx-auto py-8 px-4 max-w-6xl">
+      <div className="mb-8">
+        <h1 className="text-3xl font-bold mb-2">Route Visualization Demo</h1>
+        <p className="text-muted-foreground">
+          Interactive demo of the multi-hop trade route visualization component
+        </p>
+      </div>
+
+      <Tabs defaultValue="single" className="space-y-6">
+        <TabsList>
+          <TabsTrigger value="single">Single Hop</TabsTrigger>
+          <TabsTrigger value="multi">Multi-Hop</TabsTrigger>
+          <TabsTrigger value="complex">Complex Route</TabsTrigger>
+          <TabsTrigger value="split">Split Route</TabsTrigger>
+          <TabsTrigger value="states">States</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="single" className="space-y-4">
+          <Card className="p-4">
+            <h2 className="text-lg font-semibold mb-2">Single Hop Route</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              Direct swap from XLM to USDC via SDEX orderbook
+            </p>
+          </Card>
+          <RouteVisualization path={singleHopPath} />
+        </TabsContent>
+
+        <TabsContent value="multi" className="space-y-4">
+          <Card className="p-4">
+            <h2 className="text-lg font-semibold mb-2">Multi-Hop Route</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              XLM → USDC (SDEX) → BTC (AMM Pool)
+            </p>
+          </Card>
+          <RouteVisualization path={multiHopPath} />
+        </TabsContent>
+
+        <TabsContent value="complex" className="space-y-4">
+          <Card className="p-4">
+            <h2 className="text-lg font-semibold mb-2">Complex 3-Hop Route</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              XLM → USDC (SDEX) → EURC (AMM) → BTC (SDEX)
+            </p>
+          </Card>
+          <RouteVisualization path={complexPath} />
+        </TabsContent>
+
+        <TabsContent value="split" className="space-y-4">
+          <Card className="p-4">
+            <h2 className="text-lg font-semibold mb-2">Split Route</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              Trade split across multiple paths for optimal execution: 60% via
+              SDEX multi-hop, 40% via direct AMM
+            </p>
+          </Card>
+          <SplitRouteVisualization
+            splitRoute={splitRouteData}
+            metrics={mockMetrics}
+          />
+        </TabsContent>
+
+        <TabsContent value="states" className="space-y-6">
+          <Card className="p-4">
+            <h2 className="text-lg font-semibold mb-2">Component States</h2>
+            <p className="text-sm text-muted-foreground mb-4">
+              Test different states of the visualization component
+            </p>
+            <div className="flex gap-2">
+              <Button onClick={simulateLoading} variant="outline" size="sm">
+                Simulate Loading
+              </Button>
+              <Button
+                onClick={() => setShowError(!showError)}
+                variant="outline"
+                size="sm"
+              >
+                Toggle Error
+              </Button>
+            </div>
+          </Card>
+
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-sm font-semibold mb-2">Loading State</h3>
+              <RouteVisualization path={[]} isLoading={isLoading} />
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold mb-2">Error State</h3>
+              <RouteVisualization
+                path={[]}
+                error={showError ? 'Failed to fetch route data' : undefined}
+              />
+            </div>
+
+            <div>
+              <h3 className="text-sm font-semibold mb-2">No Route Found</h3>
+              <RouteVisualization path={[]} />
+            </div>
+          </div>
+        </TabsContent>
+      </Tabs>
+    </div>
+  );
+}

--- a/frontend/components/shared/RouteVisualization.tsx
+++ b/frontend/components/shared/RouteVisualization.tsx
@@ -1,0 +1,327 @@
+'use client';
+
+import { useState } from 'react';
+import { PathStep, Asset } from '@/types';
+import { ChevronDown, ChevronUp, Info, TrendingRight } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface RouteVisualizationProps {
+  path: PathStep[];
+  isLoading?: boolean;
+  error?: string;
+  className?: string;
+}
+
+interface RouteNode {
+  asset: Asset;
+  amount?: string;
+  isSource: boolean;
+  isDestination: boolean;
+}
+
+interface RouteEdge {
+  step: PathStep;
+  isSDEX: boolean;
+  poolName?: string;
+}
+
+function getAssetCode(asset: Asset): string {
+  if (asset.asset_type === 'native') return 'XLM';
+  return asset.asset_code || 'UNKNOWN';
+}
+
+function parseSource(source: string): { isSDEX: boolean; poolName?: string } {
+  if (source === 'sdex') {
+    return { isSDEX: true };
+  }
+  if (source.startsWith('amm:')) {
+    const poolAddress = source.substring(4);
+    return {
+      isSDEX: false,
+      poolName: `Pool ${poolAddress.substring(0, 8)}...`,
+    };
+  }
+  return { isSDEX: false, poolName: source };
+}
+
+function buildRouteGraph(path: PathStep[]): {
+  nodes: RouteNode[];
+  edges: RouteEdge[];
+} {
+  if (path.length === 0) {
+    return { nodes: [], edges: [] };
+  }
+
+  const nodes: RouteNode[] = [];
+  const edges: RouteEdge[] = [];
+
+  // First node (source)
+  nodes.push({
+    asset: path[0].from_asset,
+    isSource: true,
+    isDestination: false,
+  });
+
+  // Process each step
+  path.forEach((step, index) => {
+    const { isSDEX, poolName } = parseSource(step.source);
+
+    edges.push({
+      step,
+      isSDEX,
+      poolName,
+    });
+
+    nodes.push({
+      asset: step.to_asset,
+      isSource: false,
+      isDestination: index === path.length - 1,
+    });
+  });
+
+  return { nodes, edges };
+}
+
+// ---------------------------------------------------------------------------
+// Sub-Components
+// ---------------------------------------------------------------------------
+
+function RouteNodeComponent({ node }: { node: RouteNode }) {
+  const assetCode = getAssetCode(node.asset);
+
+  return (
+    <div className="flex flex-col items-center gap-2 min-w-[80px]">
+      <div
+        className={cn(
+          'flex items-center justify-center w-12 h-12 rounded-full border-2 bg-background',
+          node.isSource && 'border-blue-500 ring-2 ring-blue-500/20',
+          node.isDestination && 'border-green-500 ring-2 ring-green-500/20',
+          !node.isSource && !node.isDestination && 'border-neutral-300'
+        )}
+      >
+        <span className="text-sm font-semibold">
+          {assetCode.substring(0, 3)}
+        </span>
+      </div>
+      <span className="text-xs font-medium text-center">{assetCode}</span>
+      {node.amount && (
+        <span className="text-xs text-muted-foreground">{node.amount}</span>
+      )}
+    </div>
+  );
+}
+
+function RouteEdgeComponent({
+  edge,
+  isAnimated,
+}: {
+  edge: RouteEdge;
+  isAnimated: boolean;
+}) {
+  return (
+    <div className="flex flex-col items-center justify-center px-4 relative">
+      <div className="relative w-full h-[2px] overflow-hidden">
+        <div
+          className={cn(
+            'absolute inset-0',
+            edge.isSDEX ? 'bg-blue-500' : 'bg-purple-500'
+          )}
+        />
+        {isAnimated && (
+          <div
+            className={cn(
+              'absolute inset-0 w-8 h-full opacity-60 animate-flow',
+              edge.isSDEX ? 'bg-blue-300' : 'bg-purple-300'
+            )}
+          />
+        )}
+      </div>
+      <TrendingRight className="absolute w-4 h-4 text-muted-foreground" />
+      <Badge
+        variant="secondary"
+        className={cn(
+          'mt-2 text-xs',
+          edge.isSDEX
+            ? 'bg-blue-100 text-blue-700'
+            : 'bg-purple-100 text-purple-700'
+        )}
+      >
+        {edge.isSDEX ? 'SDEX' : edge.poolName || 'AMM'}
+      </Badge>
+    </div>
+  );
+}
+
+function RouteDetails({ step, index }: { step: PathStep; index: number }) {
+  const { isSDEX, poolName } = parseSource(step.source);
+  const fromCode = getAssetCode(step.from_asset);
+  const toCode = getAssetCode(step.to_asset);
+
+  return (
+    <div className="p-3 border rounded-lg bg-muted/30">
+      <div className="flex items-center justify-between mb-2">
+        <span className="text-sm font-medium">
+          Hop {index + 1}: {fromCode} → {toCode}
+        </span>
+        <Badge variant={isSDEX ? 'default' : 'secondary'}>
+          {isSDEX ? 'SDEX' : poolName || 'AMM Pool'}
+        </Badge>
+      </div>
+      <div className="grid grid-cols-2 gap-2 text-xs">
+        <div>
+          <span className="text-muted-foreground">Exchange Rate:</span>
+          <p className="font-medium">{parseFloat(step.price).toFixed(6)}</p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">Source:</span>
+          <p className="font-medium">{step.source}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function RouteVisualization({
+  path,
+  isLoading = false,
+  error,
+  className,
+}: RouteVisualizationProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const [isAnimated, setIsAnimated] = useState(true);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Card className={cn('p-6', className)}>
+        <div className="flex is-center gap-4 overflow-x-auto">
+          <Skeleton className="w-12 h-12 rounded-full" />
+          <Skeleton className="w-24 h-8" />
+          <Skeleton className="w-12 h-12 rounded-full" />
+          <Skeleton className="w-24 h-8" />
+          <Skeleton className="w-12 h-12 rounded-full" />
+        </div>
+      </Card>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Card className={cn('p-6 border-destructive', className)}>
+        <div className="flex items-center gap-2 text-destructive">
+          <Info className="w-5 h-5" />
+          <span className="text-sm font-medium">{error}</span>
+        </div>
+      </Card>
+    );
+  }
+
+  // No route found
+  if (!path || path.length === 0) {
+    return (
+      <Card className={cn('p-6', className)}>
+        <div className="flex flex-col items-center justify-center gap-2 text-muted-foreground">
+          <Info className="w-8 h-8" />
+          <span className="text-sm">No route found</span>
+        </div>
+      </Card>
+    );
+  }
+
+  const { nodes, edges } = buildRouteGraph(path);
+  const hopCount = path.length;
+
+  return (
+    <Card className={cn('p-6', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold">Trade Route</h3>
+          <Badge variant="outline">
+            {hopCount} {hopCount === 1 ? 'Hop' : 'Hops'}
+          </Badge>
+        </div>
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Details
+          {isExpanded ? (
+            <ChevronUp className="w-4 h-4" />
+          ) : (
+            <ChevronDown className="w-4 h-4" />
+          )}
+        </button>
+      </div>
+
+      {/* Route Diagram - Desktop (Horizontal) */}
+      <div className="hidden md:flex items-center justify-start gap-0 overflow-x-auto pb-2">
+        {nodes.map((node, index) => (
+          <div key={index} className="flex items-center">
+            <RouteNodeComponent node={node} />
+            {index < edges.length && (
+              <RouteEdgeComponent edge={edges[index]} isAnimated={isAnimated} />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Route Diagram - Mobile (Vertical) */}
+      <div className="flex md:hidden flex-col items-center gap-2">
+        {nodes.map((node, index) => (
+          <div key={index} className="flex flex-col items-center w-full">
+            <RouteNodeComponent node={node} />
+            {index < edges.length && (
+              <div className="flex flex-col items-center py-2">
+                <div className="h-8 w-[2px] bg-gradient-to-b from-transparent via-current to-transparent opacity-30" />
+                <Badge
+                  variant="secondary"
+                  className={cn(
+                    'text-xs',
+                    edges[index].isSDEX
+                      ? 'bg-blue-100 text-blue-700'
+                      : 'bg-purple-100 text-purple-700'
+                  )}
+                >
+                  {edges[index].isSDEX
+                    ? 'SDEX'
+                    : edges[index].poolName || 'AMM'}
+                </Badge>
+                <div className="h-8 w-[2px] bg-gradient-to-b from-transparent via-current to-transparent opacity-30" />
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {/* Expanded Details */}
+      {isExpanded && (
+        <div className="mt-6 space-y-3 border-t pt-4">
+          <h4 className="text-sm font-semibold mb-3">Route Details</h4>
+          {path.map((step, index) => (
+            <RouteDetails key={index} step={step} index={index} />
+          ))}
+        </div>
+      )}
+
+      {/* Animation CSS */}
+      <style jsx>{`
+        @keyframes flow {
+          0% {
+            transform: translateX(-100%);
+          }
+          100% {
+            transform: translateX(400%);
+          }
+        }
+        .animate-flow {
+          animation: flow 2s linear infinite;
+        }
+      `}</style>
+    </Card>
+  );
+}

--- a/frontend/components/shared/SplitRouteVisualization.tsx
+++ b/frontend/components/shared/SplitRouteVisualization.tsx
@@ -1,0 +1,304 @@
+'use client';
+
+import { useState } from 'react';
+import { SplitRouteData, RouteMetrics } from '@/types/route';
+import { PathStep } from '@/types';
+import {
+  ChevronDown,
+  ChevronUp,
+  Info,
+  TrendingRight,
+  Split,
+} from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+interface SplitRouteVisualizationProps {
+  splitRoute: SplitRouteData;
+  metrics?: RouteMetrics;
+  isLoading?: boolean;
+  error?: string;
+  className?: string;
+}
+
+function getAssetCode(asset: any): string {
+  if (asset.asset_type === 'native') return 'XLM';
+  return asset.asset_code || 'UNKNOWN';
+}
+
+function parseSource(source: string): { isSDEX: boolean; poolName?: string } {
+  if (source === 'sdex') {
+    return { isSDEX: true };
+  }
+  if (source.startsWith('amm:')) {
+    const poolAddress = source.substring(4);
+    return {
+      isSDEX: false,
+      poolName: `Pool ${poolAddress.substring(0, 8)}...`,
+    };
+  }
+  return { isSDEX: false, poolName: source };
+}
+
+function PathVisualization({
+  steps,
+  percentage,
+  pathIndex,
+}: {
+  steps: PathStep[];
+  percentage: number;
+  pathIndex: number;
+}) {
+  if (steps.length === 0) return null;
+
+  const sourceAsset = steps[0].from_asset;
+  const destAsset = steps[steps.length - 1].to_asset;
+  const sourceCode = getAssetCode(sourceAsset);
+  const destCode = getAssetCode(destAsset);
+
+  return (
+    <div className="relative p-4 border rounded-lg bg-muted/20">
+      {/* Path Header */}
+      <div className="flex items-center justify-between mb-3">
+        <div className="flex items-center gap-2">
+          <Badge variant="outline" className="text-xs">
+            Path {pathIndex + 1}
+          </Badge>
+          <span className="text-xs text-muted-foreground">
+            {sourceCode} → {destCode}
+          </span>
+        </div>
+        <Badge className="bg-blue-500 text-white">{percentage}%</Badge>
+      </div>
+
+      {/* Steps */}
+      <div className="flex items-center gap-2 overflow-x-auto">
+        {steps.map((step, index) => {
+          const { isSDEX, poolName } = parseSource(step.source);
+          const fromCode = getAssetCode(step.from_asset);
+          const toCode = getAssetCode(step.to_asset);
+
+          return (
+            <div key={index} className="flex items-center gap-2 flex-shrink-0">
+              {index === 0 && (
+                <div className="flex flex-col items-center">
+                  <div className="w-8 h-8 rounded-full border-2 border-blue-500 flex items-center justify-center bg-background">
+                    <span className="text-xs font-semibold">
+                      {fromCode.substring(0, 2)}
+                    </span>
+                  </div>
+                  <span className="text-xs mt-1">{fromCode}</span>
+                </div>
+              )}
+
+              <div className="flex flex-col items-center px-2">
+                <TrendingRight className="w-4 h-4 text-muted-foreground" />
+                <Badge
+                  variant="secondary"
+                  className={cn(
+                    'text-xs mt-1',
+                    isSDEX
+                      ? 'bg-blue-100 text-blue-700'
+                      : 'bg-purple-100 text-purple-700'
+                  )}
+                >
+                  {isSDEX ? 'SDEX' : poolName || 'AMM'}
+                </Badge>
+              </div>
+
+              <div className="flex flex-col items-center">
+                <div
+                  className={cn(
+                    'w-8 h-8 rounded-full border-2 flex items-center justify-center bg-background',
+                    index === steps.length - 1
+                      ? 'border-green-500'
+                      : 'border-neutral-300'
+                  )}
+                >
+                  <span className="text-xs font-semibold">
+                    {toCode.substring(0, 2)}
+                  </span>
+                </div>
+                <span className="text-xs mt-1">{toCode}</span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function MetricsSummary({ metrics }: { metrics: RouteMetrics }) {
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 border rounded-lg bg-muted/10">
+      <div>
+        <span className="text-xs text-muted-foreground">Total Fees</span>
+        <p className="text-sm font-semibold">{metrics.totalFees}</p>
+      </div>
+      <div>
+        <span className="text-xs text-muted-foreground">Price Impact</span>
+        <p className="text-sm font-semibold">{metrics.totalPriceImpact}</p>
+      </div>
+      <div>
+        <span className="text-xs text-muted-foreground">Net Output</span>
+        <p className="text-sm font-semibold">{metrics.netOutput}</p>
+      </div>
+      <div>
+        <span className="text-xs text-muted-foreground">Avg Rate</span>
+        <p className="text-sm font-semibold">{metrics.averageRate}</p>
+      </div>
+    </div>
+  );
+}
+
+export function SplitRouteVisualization({
+  splitRoute,
+  metrics,
+  isLoading = false,
+  error,
+  className,
+}: SplitRouteVisualizationProps) {
+  const [isExpanded, setIsExpanded] = useState(false);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <Card className={cn('p-6', className)}>
+        <Skeleton className="w-full h-32 mb-4" />
+        <Skeleton className="w-full h-32" />
+      </Card>
+    );
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <Card className={cn('p-6 border-destructive', className)}>
+        <div className="flex items-center gap-2 text-destructive">
+          <Info className="w-5 h-5" />
+          <span className="text-sm font-medium">{error}</span>
+        </div>
+      </Card>
+    );
+  }
+
+  // No route found
+  if (!splitRoute || splitRoute.paths.length === 0) {
+    return (
+      <Card className={cn('p-6', className)}>
+        <div className="flex flex-col items-center justify-center gap-2 text-muted-foreground">
+          <Info className="w-8 h-8" />
+          <span className="text-sm">No route found</span>
+        </div>
+      </Card>
+    );
+  }
+
+  const isSplit = splitRoute.paths.length > 1;
+  const totalHops = splitRoute.paths.reduce(
+    (sum, path) => sum + path.steps.length,
+    0
+  );
+
+  return (
+    <Card className={cn('p-6', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between mb-4">
+        <div className="flex items-center gap-2">
+          <h3 className="text-sm font-semibold">Trade Route</h3>
+          {isSplit && (
+            <Badge variant="default" className="bg-blue-500">
+              <Split className="w-3 h-3 mr-1" />
+              Split Route
+            </Badge>
+          )}
+          <Badge variant="outline">
+            {totalHops} {totalHops === 1 ? 'Hop' : 'Hops'}
+          </Badge>
+        </div>
+        <button
+          onClick={() => setIsExpanded(!isExpanded)}
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+        >
+          Details
+          {isExpanded ? (
+            <ChevronUp className="w-4 h-4" />
+          ) : (
+            <ChevronDown className="w-4 h-4" />
+          )}
+        </button>
+      </div>
+
+      {/* Split Paths */}
+      <div className="space-y-3">
+        {splitRoute.paths.map((path, index) => (
+          <PathVisualization
+            key={index}
+            steps={path.steps}
+            percentage={path.percentage}
+            pathIndex={index}
+          />
+        ))}
+      </div>
+
+      {/* Metrics Summary */}
+      {metrics && (
+        <div className="mt-4">
+          <MetricsSummary metrics={metrics} />
+        </div>
+      )}
+
+      {/* Expanded Details */}
+      {isExpanded && (
+        <div className="mt-6 space-y-4 border-t pt-4">
+          <h4 className="text-sm font-semibold">Detailed Breakdown</h4>
+          {splitRoute.paths.map((path, pathIndex) => (
+            <div key={pathIndex} className="space-y-2">
+              <div className="flex items-center gap-2">
+                <Badge variant="outline">Path {pathIndex + 1}</Badge>
+                <span className="text-xs text-muted-foreground">
+                  {path.percentage}% allocation
+                </span>
+                {path.outputAmount && (
+                  <span className="text-xs text-muted-foreground">
+                    Output: {path.outputAmount}
+                  </span>
+                )}
+              </div>
+              {path.steps.map((step, stepIndex) => {
+                const { isSDEX, poolName } = parseSource(step.source);
+                const fromCode = getAssetCode(step.from_asset);
+                const toCode = getAssetCode(step.to_asset);
+
+                return (
+                  <div
+                    key={stepIndex}
+                    className="pl-4 p-3 border-l-2 border-muted"
+                  >
+                    <div className="flex items-center justify-between mb-1">
+                      <span className="text-sm font-medium">
+                        Hop {stepIndex + 1}: {fromCode} → {toCode}
+                      </span>
+                      <Badge
+                        variant={isSDEX ? 'default' : 'secondary'}
+                        className="text-xs"
+                      >
+                        {isSDEX ? 'SDEX' : poolName || 'AMM'}
+                      </Badge>
+                    </div>
+                    <div className="text-xs text-muted-foreground">
+                      Rate: {parseFloat(step.price).toFixed(6)}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      )}
+    </Card>
+  );
+}

--- a/frontend/components/shared/TradeRouteDisplay.tsx
+++ b/frontend/components/shared/TradeRouteDisplay.tsx
@@ -1,0 +1,140 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { RouteVisualization } from './RouteVisualization';
+import { SplitRouteVisualization } from './SplitRouteVisualization';
+import { PathStep, PriceQuote } from '@/types';
+import { SplitRouteData, RouteMetrics } from '@/types/route';
+
+interface TradeRouteDisplayProps {
+  quote: PriceQuote | null;
+  isLoading?: boolean;
+  error?: string;
+  className?: string;
+}
+
+function isSplitRoute(path: PathStep[]): boolean {
+  // For now, we assume all routes are single-path
+  // In the future, the API might return split route information
+  return false;
+}
+
+function convertToSplitRoute(path: PathStep[]): SplitRouteData {
+  // Placeholder conversion - actual implementation would parse API response
+  return {
+    paths: [
+      {
+        percentage: 100,
+        steps: path,
+      },
+    ],
+    totalOutput: '0',
+  };
+}
+
+function calculateMetrics(quote: PriceQuote): RouteMetrics {
+  // Calculate metrics from quote data
+  const totalFees = '0.0001'; // Placeholder - would calculate from path
+  const totalPriceImpact = '0.1%'; // Placeholder - would calculate from path
+  const netOutput = quote.total;
+  const averageRate = quote.price;
+
+  return {
+    totalFees,
+    totalPriceImpact,
+    netOutput,
+    averageRate,
+  };
+}
+
+export function TradeRouteDisplay({
+  quote,
+  isLoading = false,
+  error,
+  className,
+}: TradeRouteDisplayProps) {
+  const [displayError, setDisplayError] = useState<string | undefined>(error);
+
+  useEffect(() => {
+    setDisplayError(error);
+  }, [error]);
+
+  // Loading state
+  if (isLoading) {
+    return (
+      <RouteVisualization path={[]} isLoading={true} className={className} />
+    );
+  }
+
+  // Error state
+  if (displayError) {
+    return (
+      <RouteVisualization
+        path={[]}
+        error={displayError}
+        className={className}
+      />
+    );
+  }
+
+  // No quote
+  if (!quote) {
+    return <RouteVisualization path={[]} className={className} />;
+  }
+
+  // Check if split route
+  if (isSplitRoute(quote.path)) {
+    const splitRoute = convertToSplitRoute(quote.path);
+    const metrics = calculateMetrics(quote);
+    return (
+      <SplitRouteVisualization
+        splitRoute={splitRoute}
+        metrics={metrics}
+        className={className}
+      />
+    );
+  }
+
+  // Regular single-path route
+  return <RouteVisualization path={quote.path} className={className} />;
+}
+
+export function TradeRouteExample() {
+  const [quote, setQuote] = useState<PriceQuote | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string>();
+
+  // Example: Fetch quote from API
+  const fetchQuote = async (
+    baseAsset: string,
+    quoteAsset: string,
+    amount: string
+  ) => {
+    try {
+      setIsLoading(true);
+      setError(undefined);
+
+      // Replace with actual API call
+      const response = await fetch(
+        `/api/quote?base=${baseAsset}&quote=${quoteAsset}&amount=${amount}&type=sell`
+      );
+
+      if (!response.ok) {
+        throw new Error('Failed to fetch quote');
+      }
+
+      const data: PriceQuote = await response.json();
+      setQuote(data);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Unknown error');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <TradeRouteDisplay quote={quote} isLoading={isLoading} error={error} />
+    </div>
+  );
+}

--- a/frontend/components/shared/index.ts
+++ b/frontend/components/shared/index.ts
@@ -1,0 +1,3 @@
+export { RouteVisualization } from './RouteVisualization';
+export { SplitRouteVisualization } from './SplitRouteVisualization';
+export { TradeRouteDisplay, TradeRouteExample } from './TradeRouteDisplay';

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -1,16 +1,8 @@
-// ---------------------------------------------------------------------------
-// Asset types — mirrors Rust AssetInfo in crates/api/src/models/response.rs
-// ---------------------------------------------------------------------------
-
 export interface Asset {
   asset_type: 'native' | 'credit_alphanum4' | 'credit_alphanum12';
   asset_code?: string;
   asset_issuer?: string;
 }
-
-// ---------------------------------------------------------------------------
-// Trading pairs — mirrors Rust TradingPair
-// ---------------------------------------------------------------------------
 
 export interface TradingPair {
   /** Human-readable base asset code, e.g. "XLM" */
@@ -30,10 +22,6 @@ export interface PairsResponse {
   total: number;
 }
 
-// ---------------------------------------------------------------------------
-// Orderbook — mirrors Rust OrderbookResponse / OrderbookLevel
-// ---------------------------------------------------------------------------
-
 export interface OrderbookEntry {
   price: string;
   amount: string;
@@ -48,10 +36,6 @@ export interface Orderbook {
   /** Unix timestamp (seconds) */
   timestamp: number;
 }
-
-// ---------------------------------------------------------------------------
-// Quote — mirrors Rust QuoteResponse / PathStep
-// ---------------------------------------------------------------------------
 
 export type QuoteType = 'sell' | 'buy';
 
@@ -75,10 +59,6 @@ export interface PriceQuote {
   timestamp: number;
 }
 
-// ---------------------------------------------------------------------------
-// Health — mirrors Rust HealthResponse
-// ---------------------------------------------------------------------------
-
 export interface HealthStatus {
   status: 'healthy' | 'unhealthy';
   version: string;
@@ -87,13 +67,10 @@ export interface HealthStatus {
   components: Record<string, string>;
 }
 
-// ---------------------------------------------------------------------------
-// Error — mirrors Rust ErrorResponse
-// ---------------------------------------------------------------------------
-
 export interface ApiError {
   error: string;
   message: string;
   details?: unknown;
 }
 
+export * from './route';

--- a/frontend/types/route.ts
+++ b/frontend/types/route.ts
@@ -1,0 +1,32 @@
+import { PathStep } from './index';
+
+export interface SplitPath {
+  /** Percentage of trade allocated to this path (0-100) */
+  percentage: number;
+  /** The route steps for this path */
+  steps: PathStep[];
+  /** Expected output amount for this path */
+  outputAmount?: string;
+}
+
+export interface SplitRouteData {
+  /** Array of parallel paths */
+  paths: SplitPath[];
+  /** Total expected output across all paths */
+  totalOutput: string;
+  /** Total fees across all paths */
+  totalFees?: string;
+  /** Total price impact across all paths */
+  totalPriceImpact?: string;
+}
+
+export interface RouteMetrics {
+  /** Total fees paid across the route */
+  totalFees: string;
+  /** Total price impact percentage */
+  totalPriceImpact: string;
+  /** Net output amount after fees */
+  netOutput: string;
+  /** Average exchange rate */
+  averageRate: string;
+}


### PR DESCRIPTION
fixes #21

- Add RouteVisualization component for displaying single and multi-hop trade paths
- Add SplitRouteVisualization component for visualizing split route execution across multiple paths
- Add TradeRouteDisplay component for rendering individual trade route steps
- Add route.ts types file with SplitRouteData and RouteMetrics interfaces
- Add comprehensive demo page at /demo/route-visualization with interactive examples
- Update frontend types index to export new route types
- Include mock data for single-hop, multi-hop, complex, and split route scenarios
- Add component state management for loading and error states in demo