### PR TITLE
[116] [frontend] Multi-hop route visualization (responsive, accessible)

### DIFF
--- a/frontend/components/shared/RouteVisualization.tsx
+++ b/frontend/components/shared/RouteVisualization.tsx
@@ -1,12 +1,17 @@
 'use client';
 
-import { useState } from 'react';
-import { PathStep, Asset } from '@/types';
+import { useEffect, useId, useState } from 'react';
+import { PathStep } from '@/types';
 import { ChevronDown, ChevronUp, Info, ArrowRight } from 'lucide-react';
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
+import {
+  describeTradeRoute,
+  getAssetCode,
+  parseSource,
+} from '@/lib/route-helpers';
 
 interface RouteVisualizationProps {
   path: PathStep[];
@@ -16,7 +21,7 @@ interface RouteVisualizationProps {
 }
 
 interface RouteNode {
-  asset: Asset;
+  asset: PathStep['from_asset'];
   amount?: string;
   isSource: boolean;
   isDestination: boolean;
@@ -28,23 +33,18 @@ interface RouteEdge {
   poolName?: string;
 }
 
-function getAssetCode(asset: Asset): string {
-  if (asset.asset_type === 'native') return 'XLM';
-  return asset.asset_code || 'UNKNOWN';
-}
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
 
-function parseSource(source: string): { isSDEX: boolean; poolName?: string } {
-  if (source === 'sdex') {
-    return { isSDEX: true };
-  }
-  if (source.startsWith('amm:')) {
-    const poolAddress = source.substring(4);
-    return {
-      isSDEX: false,
-      poolName: `Pool ${poolAddress.substring(0, 8)}...`,
-    };
-  }
-  return { isSDEX: false, poolName: source };
+  useEffect(() => {
+    const mq = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => setReduced(mq.matches);
+    sync();
+    mq.addEventListener('change', sync);
+    return () => mq.removeEventListener('change', sync);
+  }, []);
+
+  return reduced;
 }
 
 function buildRouteGraph(path: PathStep[]): {
@@ -89,26 +89,44 @@ function buildRouteGraph(path: PathStep[]): {
 // Sub-Components
 // ---------------------------------------------------------------------------
 
-function RouteNodeComponent({ node }: { node: RouteNode }) {
+function RouteNodeComponent({
+  node,
+  label: labelProp,
+}: {
+  node: RouteNode;
+  /** Accessible name; defaults from asset code when omitted */
+  label?: string;
+}) {
   const assetCode = getAssetCode(node.asset);
+  const label = labelProp ?? `Route node ${assetCode}`;
 
   return (
-    <div className="flex flex-col items-center gap-2 min-w-[80px]">
+    <div
+      className="flex flex-col items-center gap-2 min-w-[5.5rem] sm:min-w-[6rem]"
+      role="group"
+      aria-label={label}
+    >
       <div
         className={cn(
-          'flex items-center justify-center w-12 h-12 rounded-full border-2 bg-background',
+          'flex items-center justify-center size-12 sm:size-14 rounded-full border-2 bg-background shrink-0',
           node.isSource && 'border-blue-500 ring-2 ring-blue-500/20',
           node.isDestination && 'border-green-500 ring-2 ring-green-500/20',
-          !node.isSource && !node.isDestination && 'border-neutral-300'
+          !node.isSource && !node.isDestination && 'border-neutral-300 dark:border-neutral-600'
         )}
+        aria-hidden="true"
       >
-        <span className="text-sm font-semibold">
-          {assetCode.substring(0, 3)}
-        </span>
+        <span className="text-sm font-semibold">{assetCode.substring(0, 3)}</span>
       </div>
-      <span className="text-xs font-medium text-center">{assetCode}</span>
+      <span
+        className="text-xs font-medium text-center max-w-[6rem] truncate"
+        aria-hidden="true"
+      >
+        {assetCode}
+      </span>
       {node.amount && (
-        <span className="text-xs text-muted-foreground">{node.amount}</span>
+        <span className="text-xs text-muted-foreground" aria-hidden="true">
+          {node.amount}
+        </span>
       )}
     </div>
   );
@@ -116,21 +134,24 @@ function RouteNodeComponent({ node }: { node: RouteNode }) {
 
 function RouteEdgeComponent({
   edge,
-  isAnimated,
+  showAnimation,
 }: {
   edge: RouteEdge;
-  isAnimated: boolean;
+  showAnimation: boolean;
 }) {
   return (
-    <div className="flex flex-col items-center justify-center px-4 relative">
-      <div className="relative w-full h-[2px] overflow-hidden">
+    <div
+      className="flex flex-col items-center justify-center px-2 sm:px-4 relative min-w-[4rem] sm:min-w-[5rem]"
+      aria-hidden="true"
+    >
+      <div className="relative w-full h-0.5 overflow-hidden rounded-full">
         <div
           className={cn(
-            'absolute inset-0',
+            'absolute inset-0 rounded-full',
             edge.isSDEX ? 'bg-blue-500' : 'bg-purple-500'
           )}
         />
-        {isAnimated && (
+        {showAnimation && (
           <div
             className={cn(
               'absolute inset-0 w-8 h-full opacity-60 animate-flow',
@@ -139,18 +160,48 @@ function RouteEdgeComponent({
           />
         )}
       </div>
-      <ArrowRight className="absolute w-4 h-4 text-muted-foreground" />
+      <ArrowRight
+        className="absolute w-4 h-4 text-muted-foreground"
+        aria-hidden="true"
+      />
       <Badge
         variant="secondary"
         className={cn(
-          'mt-2 text-xs',
+          'mt-2 text-xs max-w-[5.5rem] truncate',
           edge.isSDEX
-            ? 'bg-blue-100 text-blue-700'
-            : 'bg-purple-100 text-purple-700'
+            ? 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-200'
+            : 'bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-200'
         )}
+        title={edge.isSDEX ? 'SDEX' : edge.poolName || 'AMM'}
       >
         {edge.isSDEX ? 'SDEX' : edge.poolName || 'AMM'}
       </Badge>
+    </div>
+  );
+}
+
+function RouteVerticalConnector({ edge }: { edge: RouteEdge }) {
+  const venue = edge.isSDEX ? 'SDEX' : edge.poolName || 'AMM';
+
+  return (
+    <div
+      className="flex flex-col items-center py-2 w-full max-w-[12rem]"
+      role="presentation"
+    >
+      <div className="h-6 w-0.5 bg-border rounded-full" aria-hidden="true" />
+      <Badge
+        variant="secondary"
+        className={cn(
+          'my-1 text-xs max-w-[min(100%,10rem)] truncate',
+          edge.isSDEX
+            ? 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-200'
+            : 'bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-200'
+        )}
+        title={venue}
+      >
+        {edge.isSDEX ? 'SDEX' : edge.poolName || 'AMM'}
+      </Badge>
+      <div className="h-6 w-0.5 bg-border rounded-full" aria-hidden="true" />
     </div>
   );
 }
@@ -162,7 +213,7 @@ function RouteDetails({ step, index }: { step: PathStep; index: number }) {
 
   return (
     <div className="p-3 border rounded-lg bg-muted/30">
-      <div className="flex items-center justify-between mb-2">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-2">
         <span className="text-sm font-medium">
           Hop {index + 1}: {fromCode} → {toCode}
         </span>
@@ -170,14 +221,14 @@ function RouteDetails({ step, index }: { step: PathStep; index: number }) {
           {isSDEX ? 'SDEX' : poolName || 'AMM Pool'}
         </Badge>
       </div>
-      <div className="grid grid-cols-2 gap-2 text-xs">
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2 text-xs">
         <div>
           <span className="text-muted-foreground">Exchange Rate:</span>
           <p className="font-medium">{parseFloat(step.price).toFixed(6)}</p>
         </div>
         <div>
           <span className="text-muted-foreground">Source:</span>
-          <p className="font-medium">{step.source}</p>
+          <p className="font-medium break-all">{step.source}</p>
         </div>
       </div>
     </div>
@@ -191,41 +242,47 @@ export function RouteVisualization({
   className,
 }: RouteVisualizationProps) {
   const [isExpanded, setIsExpanded] = useState(false);
-  const [isAnimated] = useState(true);
+  const reducedMotion = usePrefersReducedMotion();
+  const titleId = useId();
+  const summaryId = useId();
+  const detailsPanelId = useId();
+  const showEdgeAnimation = !reducedMotion;
 
-  // Loading state
   if (isLoading) {
     return (
-      <Card className={cn('p-6', className)}>
-        <div className="flex is-center gap-4 overflow-x-auto">
-          <Skeleton className="w-12 h-12 rounded-full" />
-          <Skeleton className="w-24 h-8" />
-          <Skeleton className="w-12 h-12 rounded-full" />
-          <Skeleton className="w-24 h-8" />
-          <Skeleton className="w-12 h-12 rounded-full" />
+      <Card
+        className={cn('p-6', className)}
+        role="status"
+        aria-busy="true"
+        aria-label="Loading trade route"
+      >
+        <div className="flex items-center gap-4 overflow-x-auto pb-2">
+          <Skeleton className="size-12 sm:size-14 rounded-full shrink-0" />
+          <Skeleton className="w-20 sm:w-24 h-8 shrink-0" />
+          <Skeleton className="size-12 sm:size-14 rounded-full shrink-0" />
+          <Skeleton className="w-20 sm:w-24 h-8 shrink-0" />
+          <Skeleton className="size-12 sm:size-14 rounded-full shrink-0" />
         </div>
       </Card>
     );
   }
 
-  // Error state
   if (error) {
     return (
-      <Card className={cn('p-6 border-destructive', className)}>
+      <Card className={cn('p-6 border-destructive', className)} role="alert">
         <div className="flex items-center gap-2 text-destructive">
-          <Info className="w-5 h-5" />
+          <Info className="w-5 h-5 shrink-0" aria-hidden="true" />
           <span className="text-sm font-medium">{error}</span>
         </div>
       </Card>
     );
   }
 
-  // No route found
   if (!path || path.length === 0) {
     return (
-      <Card className={cn('p-6', className)}>
+      <Card className={cn('p-6', className)} role="status">
         <div className="flex flex-col items-center justify-center gap-2 text-muted-foreground">
-          <Info className="w-8 h-8" />
+          <Info className="w-8 h-8" aria-hidden="true" />
           <span className="text-sm">No route found</span>
         </div>
       </Card>
@@ -234,81 +291,122 @@ export function RouteVisualization({
 
   const { nodes, edges } = buildRouteGraph(path);
   const hopCount = path.length;
+  const routeSummary = describeTradeRoute(path);
 
   return (
-    <Card className={cn('p-6', className)}>
-      {/* Header */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-2">
-          <h3 className="text-sm font-semibold">Trade Route</h3>
-          <Badge variant="outline">
-            {hopCount} {hopCount === 1 ? 'Hop' : 'Hops'}
-          </Badge>
+    <Card className={cn('p-4 sm:p-6', className)}>
+      <section aria-labelledby={titleId} aria-describedby={summaryId}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between mb-4">
+          <div className="flex flex-wrap items-center gap-2 min-w-0">
+            <h3 id={titleId} className="text-sm font-semibold">
+              Trade Route
+            </h3>
+            <Badge variant="outline">
+              {hopCount} {hopCount === 1 ? 'Hop' : 'Hops'}
+            </Badge>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsExpanded(!isExpanded)}
+            aria-expanded={isExpanded}
+            aria-controls={detailsPanelId}
+            className={cn(
+              'inline-flex items-center justify-center gap-1 min-h-11 min-w-11 px-3 py-2 -mr-2 sm:mr-0',
+              'text-xs text-muted-foreground hover:text-foreground transition-colors',
+              'rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+            )}
+          >
+            <span>{isExpanded ? 'Hide' : 'Show'} route details</span>
+            {isExpanded ? (
+              <ChevronUp className="w-4 h-4 shrink-0" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="w-4 h-4 shrink-0" aria-hidden="true" />
+            )}
+          </button>
         </div>
-        <button
-          onClick={() => setIsExpanded(!isExpanded)}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+
+        <p id={summaryId} className="sr-only">
+          {routeSummary}
+        </p>
+
+        <div
+          className="hidden lg:flex items-center justify-start gap-0 overflow-x-auto pb-2 -mx-1 px-1 scroll-smooth snap-x snap-mandatory"
+          tabIndex={0}
+          role="group"
+          aria-label="Route diagram, scroll horizontally on small windows"
         >
-          Details
-          {isExpanded ? (
-            <ChevronUp className="w-4 h-4" />
-          ) : (
-            <ChevronDown className="w-4 h-4" />
-          )}
-        </button>
-      </div>
-
-      {/* Route Diagram - Desktop (Horizontal) */}
-      <div className="hidden md:flex items-center justify-start gap-0 overflow-x-auto pb-2">
-        {nodes.map((node, index) => (
-          <div key={index} className="flex items-center">
-            <RouteNodeComponent node={node} />
-            {index < edges.length && (
-              <RouteEdgeComponent edge={edges[index]} isAnimated={isAnimated} />
-            )}
-          </div>
-        ))}
-      </div>
-
-      {/* Route Diagram - Mobile (Vertical) */}
-      <div className="flex md:hidden flex-col items-center gap-2">
-        {nodes.map((node, index) => (
-          <div key={index} className="flex flex-col items-center w-full">
-            <RouteNodeComponent node={node} />
-            {index < edges.length && (
-              <div className="flex flex-col items-center py-2">
-                <div className="h-8 w-[2px] bg-linear-to-b from-transparent via-current to-transparent opacity-30" />
-                <Badge
-                  variant="secondary"
-                  className={cn(
-                    'text-xs',
-                    edges[index].isSDEX
-                      ? 'bg-blue-100 text-blue-700'
-                      : 'bg-purple-100 text-purple-700'
-                  )}
-                >
-                  {edges[index].isSDEX
-                    ? 'SDEX'
-                    : edges[index].poolName || 'AMM'}
-                </Badge>
-                <div className="h-8 w-[2px] bg-linear-to-b from-transparent via-current to-transparent opacity-30" />
+          {nodes.map((node, index) => {
+            const position =
+              index === 0
+                ? 'Start'
+                : index === nodes.length - 1
+                  ? 'Destination'
+                  : 'Intermediate';
+            return (
+              <div
+                key={index}
+                className="flex items-center snap-start shrink-0"
+              >
+                <RouteNodeComponent
+                  node={node}
+                  label={`${position} asset: ${getAssetCode(node.asset)}`}
+                />
+                {index < edges.length && (
+                  <RouteEdgeComponent
+                    edge={edges[index]}
+                    showAnimation={showEdgeAnimation}
+                  />
+                )}
               </div>
-            )}
-          </div>
-        ))}
-      </div>
-
-      {/* Expanded Details */}
-      {isExpanded && (
-        <div className="mt-6 space-y-3 border-t pt-4">
-          <h4 className="text-sm font-semibold mb-3">Route Details</h4>
-          {path.map((step, index) => (
-            <RouteDetails key={index} step={step} index={index} />
-          ))}
+            );
+          })}
         </div>
-      )}
 
-      {/* Animation CSS */}
+        <ol
+          className="flex lg:hidden flex-col items-center list-none m-0 p-0 gap-0 w-full"
+          aria-label="Route steps"
+        >
+          {nodes.map((node, index) => {
+            const position =
+              index === 0
+                ? 'Start'
+                : index === nodes.length - 1
+                  ? 'Destination'
+                  : 'Intermediate';
+            return (
+              <li
+                key={index}
+                className="flex flex-col items-center w-full max-w-md mx-auto"
+              >
+                <RouteNodeComponent
+                  node={node}
+                  label={`Step ${index + 1} of ${nodes.length}: ${position}, ${getAssetCode(node.asset)}`}
+                />
+                {index < edges.length && (
+                  <RouteVerticalConnector edge={edges[index]} />
+                )}
+              </li>
+            );
+          })}
+        </ol>
+
+        {isExpanded && (
+          <div
+            id={detailsPanelId}
+            className="mt-6 space-y-3 border-t pt-4"
+            role="region"
+            aria-label="Per-hop route details"
+          >
+            <h4 className="text-sm font-semibold mb-3">Route Details</h4>
+            <div className="space-y-3">
+              {path.map((step, index) => (
+                <RouteDetails key={index} step={step} index={index} />
+              ))}
+            </div>
+          </div>
+        )}
+      </section>
+
       <style jsx>{`
         @keyframes flow {
           0% {
@@ -320,6 +418,11 @@ export function RouteVisualization({
         }
         .animate-flow {
           animation: flow 2s linear infinite;
+        }
+        @media (prefers-reduced-motion: reduce) {
+          .animate-flow {
+            animation: none;
+          }
         }
       `}</style>
     </Card>

--- a/frontend/components/shared/SplitRouteVisualization.tsx
+++ b/frontend/components/shared/SplitRouteVisualization.tsx
@@ -1,8 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useId, useState } from 'react';
 import { SplitRouteData, RouteMetrics } from '@/types/route';
-import { PathStep, Asset } from '@/types';
+import { PathStep } from '@/types';
 import {
   ChevronDown,
   ChevronUp,
@@ -14,6 +14,11 @@ import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { Skeleton } from '@/components/ui/skeleton';
 import { cn } from '@/lib/utils';
+import {
+  describeTradeRoute,
+  getAssetCode,
+  parseSource,
+} from '@/lib/route-helpers';
 
 interface SplitRouteVisualizationProps {
   splitRoute: SplitRouteData;
@@ -21,25 +26,6 @@ interface SplitRouteVisualizationProps {
   isLoading?: boolean;
   error?: string;
   className?: string;
-}
-
-function getAssetCode(asset: Asset): string {
-  if (asset.asset_type === 'native') return 'XLM';
-  return asset.asset_code || 'UNKNOWN';
-}
-
-function parseSource(source: string): { isSDEX: boolean; poolName?: string } {
-  if (source === 'sdex') {
-    return { isSDEX: true };
-  }
-  if (source.startsWith('amm:')) {
-    const poolAddress = source.substring(4);
-    return {
-      isSDEX: false,
-      poolName: `Pool ${poolAddress.substring(0, 8)}...`,
-    };
-  }
-  return { isSDEX: false, poolName: source };
 }
 
 function PathVisualization({
@@ -57,83 +43,127 @@ function PathVisualization({
   const destAsset = steps[steps.length - 1].to_asset;
   const sourceCode = getAssetCode(sourceAsset);
   const destCode = getAssetCode(destAsset);
+  const pathSummary = describeTradeRoute(steps);
 
   return (
-    <div className="relative p-4 border rounded-lg bg-muted/20">
-      {/* Path Header */}
-      <div className="flex items-center justify-between mb-3">
-        <div className="flex items-center gap-2">
-          <Badge variant="outline" className="text-xs">
+    <section
+      className="relative p-3 sm:p-4 border rounded-lg bg-muted/20"
+      aria-label={`Path ${pathIndex + 1}, ${percentage}% of trade. ${pathSummary}`}
+    >
+      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between mb-3">
+        <div className="flex flex-wrap items-center gap-2 min-w-0">
+          <Badge variant="outline" className="text-xs shrink-0">
             Path {pathIndex + 1}
           </Badge>
-          <span className="text-xs text-muted-foreground">
+          <span className="text-xs text-muted-foreground truncate">
             {sourceCode} → {destCode}
           </span>
         </div>
-        <Badge className="bg-blue-500 text-white">{percentage}%</Badge>
+        <Badge className="bg-blue-500 text-white shrink-0 self-start sm:self-auto">
+          {percentage}% of trade
+        </Badge>
       </div>
 
-      {/* Steps */}
-      <div className="flex items-center gap-2 overflow-x-auto">
+      <div
+        className="flex items-stretch gap-0 overflow-x-auto pb-2 -mx-1 px-1 scroll-smooth snap-x snap-mandatory"
+        tabIndex={0}
+        role="list"
+        aria-label={`Hops for path ${pathIndex + 1}`}
+      >
         {steps.map((step, index) => {
           const { isSDEX, poolName } = parseSource(step.source);
           const fromCode = getAssetCode(step.from_asset);
           const toCode = getAssetCode(step.to_asset);
 
           return (
-            <div key={index} className="flex items-center gap-2 shrink-0">
+            <div
+              key={index}
+              role="listitem"
+              className="flex items-center gap-1 sm:gap-2 shrink-0 snap-start"
+            >
               {index === 0 && (
-                <div className="flex flex-col items-center">
-                  <div className="w-8 h-8 rounded-full border-2 border-blue-500 flex items-center justify-center bg-background">
+                <div
+                  className="flex flex-col items-center gap-1"
+                  role="group"
+                  aria-label={`Start: ${fromCode}`}
+                >
+                  <div
+                    className="size-11 sm:size-12 rounded-full border-2 border-blue-500 flex items-center justify-center bg-background shrink-0"
+                    aria-hidden="true"
+                  >
                     <span className="text-xs font-semibold">
                       {fromCode.substring(0, 2)}
                     </span>
                   </div>
-                  <span className="text-xs mt-1">{fromCode}</span>
+                  <span
+                    className="text-xs max-w-[4rem] truncate"
+                    aria-hidden="true"
+                  >
+                    {fromCode}
+                  </span>
                 </div>
               )}
 
-              <div className="flex flex-col items-center px-2">
+              <div className="flex flex-col items-center px-1 sm:px-2" aria-hidden="true">
                 <ArrowRight className="w-4 h-4 text-muted-foreground" />
                 <Badge
                   variant="secondary"
                   className={cn(
-                    'text-xs mt-1',
+                    'text-xs mt-1 max-w-[5rem] truncate',
                     isSDEX
-                      ? 'bg-blue-100 text-blue-700'
-                      : 'bg-purple-100 text-purple-700'
+                      ? 'bg-blue-100 text-blue-700 dark:bg-blue-950 dark:text-blue-200'
+                      : 'bg-purple-100 text-purple-700 dark:bg-purple-950 dark:text-purple-200'
                   )}
+                  title={isSDEX ? 'SDEX' : poolName || 'AMM'}
                 >
                   {isSDEX ? 'SDEX' : poolName || 'AMM'}
                 </Badge>
               </div>
 
-              <div className="flex flex-col items-center">
+              <div
+                className="flex flex-col items-center gap-1"
+                role="group"
+                aria-label={
+                  index === steps.length - 1
+                    ? `Destination: ${toCode}`
+                    : `Intermediate: ${toCode}`
+                }
+              >
                 <div
                   className={cn(
-                    'w-8 h-8 rounded-full border-2 flex items-center justify-center bg-background',
+                    'size-11 sm:size-12 rounded-full border-2 flex items-center justify-center bg-background shrink-0',
                     index === steps.length - 1
                       ? 'border-green-500'
-                      : 'border-neutral-300'
+                      : 'border-neutral-300 dark:border-neutral-600'
                   )}
+                  aria-hidden="true"
                 >
                   <span className="text-xs font-semibold">
                     {toCode.substring(0, 2)}
                   </span>
                 </div>
-                <span className="text-xs mt-1">{toCode}</span>
+                <span
+                  className="text-xs max-w-[4rem] truncate"
+                  aria-hidden="true"
+                >
+                  {toCode}
+                </span>
               </div>
             </div>
           );
         })}
       </div>
-    </div>
+    </section>
   );
 }
 
 function MetricsSummary({ metrics }: { metrics: RouteMetrics }) {
   return (
-    <div className="grid grid-cols-2 md:grid-cols-4 gap-4 p-4 border rounded-lg bg-muted/10">
+    <div
+      className="grid grid-cols-2 lg:grid-cols-4 gap-3 sm:gap-4 p-3 sm:p-4 border rounded-lg bg-muted/10"
+      role="group"
+      aria-label="Route metrics summary"
+    >
       <div>
         <span className="text-xs text-muted-foreground">Total Fees</span>
         <p className="text-sm font-semibold">{metrics.totalFees}</p>
@@ -162,35 +192,45 @@ export function SplitRouteVisualization({
   className,
 }: SplitRouteVisualizationProps) {
   const [isExpanded, setIsExpanded] = useState(false);
+  const titleId = useId();
+  const summaryId = useId();
+  const detailsPanelId = useId();
 
-  // Loading state
+  const splitSummary =
+    splitRoute?.paths
+      .map((p, i) => `Path ${i + 1}: ${describeTradeRoute(p.steps)}`)
+      .join(' ') ?? '';
+
   if (isLoading) {
     return (
-      <Card className={cn('p-6', className)}>
+      <Card
+        className={cn('p-6', className)}
+        role="status"
+        aria-busy="true"
+        aria-label="Loading split route"
+      >
         <Skeleton className="w-full h-32 mb-4" />
         <Skeleton className="w-full h-32" />
       </Card>
     );
   }
 
-  // Error state
   if (error) {
     return (
-      <Card className={cn('p-6 border-destructive', className)}>
+      <Card className={cn('p-6 border-destructive', className)} role="alert">
         <div className="flex items-center gap-2 text-destructive">
-          <Info className="w-5 h-5" />
+          <Info className="w-5 h-5 shrink-0" aria-hidden="true" />
           <span className="text-sm font-medium">{error}</span>
         </div>
       </Card>
     );
   }
 
-  // No route found
   if (!splitRoute || splitRoute.paths.length === 0) {
     return (
-      <Card className={cn('p-6', className)}>
+      <Card className={cn('p-6', className)} role="status">
         <div className="flex flex-col items-center justify-center gap-2 text-muted-foreground">
-          <Info className="w-8 h-8" />
+          <Info className="w-8 h-8" aria-hidden="true" />
           <span className="text-sm">No route found</span>
         </div>
       </Card>
@@ -204,101 +244,117 @@ export function SplitRouteVisualization({
   );
 
   return (
-    <Card className={cn('p-6', className)}>
-      {/* Header */}
-      <div className="flex items-center justify-between mb-4">
-        <div className="flex items-center gap-2">
-          <h3 className="text-sm font-semibold">Trade Route</h3>
-          {isSplit && (
-            <Badge variant="default" className="bg-blue-500">
-              <Split className="w-3 h-3 mr-1" />
-              Split Route
+    <Card className={cn('p-4 sm:p-6', className)}>
+      <section aria-labelledby={titleId} aria-describedby={summaryId}>
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between mb-4">
+          <div className="flex flex-wrap items-center gap-2 min-w-0">
+            <h3 id={titleId} className="text-sm font-semibold">
+              Trade Route
+            </h3>
+            {isSplit && (
+              <Badge variant="default" className="bg-blue-500 shrink-0">
+                <Split className="w-3 h-3 mr-1" aria-hidden="true" />
+                Split Route
+              </Badge>
+            )}
+            <Badge variant="outline">
+              {totalHops} {totalHops === 1 ? 'Hop' : 'Hops'}
             </Badge>
-          )}
-          <Badge variant="outline">
-            {totalHops} {totalHops === 1 ? 'Hop' : 'Hops'}
-          </Badge>
+          </div>
+          <button
+            type="button"
+            onClick={() => setIsExpanded(!isExpanded)}
+            aria-expanded={isExpanded}
+            aria-controls={detailsPanelId}
+            className={cn(
+              'inline-flex items-center justify-center gap-1 min-h-11 min-w-11 px-3 py-2 -mr-2 sm:mr-0',
+              'text-xs text-muted-foreground hover:text-foreground transition-colors',
+              'rounded-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background'
+            )}
+          >
+            <span>{isExpanded ? 'Hide' : 'Show'} detailed breakdown</span>
+            {isExpanded ? (
+              <ChevronUp className="w-4 h-4 shrink-0" aria-hidden="true" />
+            ) : (
+              <ChevronDown className="w-4 h-4 shrink-0" aria-hidden="true" />
+            )}
+          </button>
         </div>
-        <button
-          onClick={() => setIsExpanded(!isExpanded)}
-          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
-        >
-          Details
-          {isExpanded ? (
-            <ChevronUp className="w-4 h-4" />
-          ) : (
-            <ChevronDown className="w-4 h-4" />
-          )}
-        </button>
-      </div>
 
-      {/* Split Paths */}
-      <div className="space-y-3">
-        {splitRoute.paths.map((path, index) => (
-          <PathVisualization
-            key={index}
-            steps={path.steps}
-            percentage={path.percentage}
-            pathIndex={index}
-          />
-        ))}
-      </div>
+        <p id={summaryId} className="sr-only">
+          {splitSummary}
+        </p>
 
-      {/* Metrics Summary */}
-      {metrics && (
-        <div className="mt-4">
-          <MetricsSummary metrics={metrics} />
-        </div>
-      )}
-
-      {/* Expanded Details */}
-      {isExpanded && (
-        <div className="mt-6 space-y-4 border-t pt-4">
-          <h4 className="text-sm font-semibold">Detailed Breakdown</h4>
-          {splitRoute.paths.map((path, pathIndex) => (
-            <div key={pathIndex} className="space-y-2">
-              <div className="flex items-center gap-2">
-                <Badge variant="outline">Path {pathIndex + 1}</Badge>
-                <span className="text-xs text-muted-foreground">
-                  {path.percentage}% allocation
-                </span>
-                {path.outputAmount && (
-                  <span className="text-xs text-muted-foreground">
-                    Output: {path.outputAmount}
-                  </span>
-                )}
-              </div>
-              {path.steps.map((step, stepIndex) => {
-                const { isSDEX, poolName } = parseSource(step.source);
-                const fromCode = getAssetCode(step.from_asset);
-                const toCode = getAssetCode(step.to_asset);
-
-                return (
-                  <div
-                    key={stepIndex}
-                    className="pl-4 p-3 border-l-2 border-muted"
-                  >
-                    <div className="flex items-center justify-between mb-1">
-                      <span className="text-sm font-medium">
-                        Hop {stepIndex + 1}: {fromCode} → {toCode}
-                      </span>
-                      <Badge
-                        variant={isSDEX ? 'default' : 'secondary'}
-                        className="text-xs"
-                      >
-                        {isSDEX ? 'SDEX' : poolName || 'AMM'}
-                      </Badge>
-                    </div>
-                    <div className="text-xs text-muted-foreground">
-                      Rate: {parseFloat(step.price).toFixed(6)}
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
+        <div className="space-y-3">
+          {splitRoute.paths.map((path, index) => (
+            <PathVisualization
+              key={index}
+              steps={path.steps}
+              percentage={path.percentage}
+              pathIndex={index}
+            />
           ))}
         </div>
-      )}
+
+        {metrics && (
+          <div className="mt-4">
+            <MetricsSummary metrics={metrics} />
+          </div>
+        )}
+
+        {isExpanded && (
+          <div
+            id={detailsPanelId}
+            className="mt-6 space-y-4 border-t pt-4"
+            role="region"
+            aria-label="Detailed per-path hops"
+          >
+            <h4 className="text-sm font-semibold">Detailed Breakdown</h4>
+            {splitRoute.paths.map((path, pathIndex) => (
+              <div key={pathIndex} className="space-y-2">
+                <div className="flex flex-wrap items-center gap-2">
+                  <Badge variant="outline">Path {pathIndex + 1}</Badge>
+                  <span className="text-xs text-muted-foreground">
+                    {path.percentage}% allocation
+                  </span>
+                  {path.outputAmount && (
+                    <span className="text-xs text-muted-foreground">
+                      Output: {path.outputAmount}
+                    </span>
+                  )}
+                </div>
+                {path.steps.map((step, stepIndex) => {
+                  const { isSDEX, poolName } = parseSource(step.source);
+                  const fromCode = getAssetCode(step.from_asset);
+                  const toCode = getAssetCode(step.to_asset);
+
+                  return (
+                    <div
+                      key={stepIndex}
+                      className="pl-3 sm:pl-4 p-3 border-l-2 border-muted"
+                    >
+                      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between mb-1">
+                        <span className="text-sm font-medium">
+                          Hop {stepIndex + 1}: {fromCode} → {toCode}
+                        </span>
+                        <Badge
+                          variant={isSDEX ? 'default' : 'secondary'}
+                          className="text-xs w-fit"
+                        >
+                          {isSDEX ? 'SDEX' : poolName || 'AMM'}
+                        </Badge>
+                      </div>
+                      <div className="text-xs text-muted-foreground">
+                        Rate: {parseFloat(step.price).toFixed(6)}
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+            ))}
+          </div>
+        )}
+      </section>
     </Card>
   );
 }

--- a/frontend/components/shared/TransactionConfirmationModal.tsx
+++ b/frontend/components/shared/TransactionConfirmationModal.tsx
@@ -9,6 +9,7 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { PathStep } from "@/types";
+import { describeTradeRoute } from "@/lib/route-helpers";
 import { TransactionStatus } from "@/types/transaction";
 import {
   ArrowDown,
@@ -161,19 +162,32 @@ export function TransactionConfirmationModal({
                   <span className="text-muted-foreground">Network Fee</span>
                   <span>{networkFee} XLM</span>
                 </div>
-                <div className="flex justify-between items-center pt-2">
-                  <span className="text-muted-foreground">Route</span>
-                  <div className="flex items-center gap-1 text-xs">
+                <div className="flex flex-col gap-1 sm:flex-row sm:justify-between sm:items-center pt-2">
+                  <span className="text-muted-foreground shrink-0">Route</span>
+                  <div
+                    className="flex flex-wrap items-center gap-x-0.5 gap-y-1 text-xs sm:justify-end sm:max-w-[min(100%,16rem)]"
+                    aria-label={`Execution route: ${describeTradeRoute(routePath)}`}
+                  >
                     {routePath.map((step, idx) => {
-                      const from = step.from_asset.asset_type === 'native' ? 'XLM' : step.from_asset.asset_code;
-                      const to = step.to_asset.asset_type === 'native' ? 'XLM' : step.to_asset.asset_code;
-                       return (
-                         <span key={idx} className="flex items-center gap-1">
-                           {idx === 0 && <span>{from}</span>}
-                           <ChevronRight className="w-3 h-3 text-muted-foreground" />
-                           <span>{to}</span>
-                         </span>
-                       )
+                      const from =
+                        step.from_asset.asset_type === "native"
+                          ? "XLM"
+                          : step.from_asset.asset_code;
+                      const to =
+                        step.to_asset.asset_type === "native"
+                          ? "XLM"
+                          : step.to_asset.asset_code;
+                      return (
+                        <span
+                          key={idx}
+                          className="inline-flex items-center gap-0.5"
+                          aria-hidden="true"
+                        >
+                          {idx === 0 && <span>{from}</span>}
+                          <ChevronRight className="w-3 h-3 text-muted-foreground shrink-0" />
+                          <span>{to}</span>
+                        </span>
+                      );
                     })}
                   </div>
                 </div>

--- a/frontend/lib/route-helpers.ts
+++ b/frontend/lib/route-helpers.ts
@@ -1,0 +1,43 @@
+import type { Asset, PathStep } from '@/types';
+
+export function getAssetCode(asset: Asset): string {
+  if (asset.asset_type === 'native') return 'XLM';
+  return asset.asset_code || 'UNKNOWN';
+}
+
+export function parseSource(source: string): {
+  isSDEX: boolean;
+  poolName?: string;
+} {
+  if (source === 'sdex') {
+    return { isSDEX: true };
+  }
+  if (source.startsWith('amm:')) {
+    const poolAddress = source.substring(4);
+    return {
+      isSDEX: false,
+      poolName: `Pool ${poolAddress.substring(0, 8)}...`,
+    };
+  }
+  return { isSDEX: false, poolName: source };
+}
+
+/** Plain-language description for screen readers and aria-labels */
+export function describeTradeRoute(path: PathStep[]): string {
+  if (!path.length) return 'No route available.';
+
+  const hopDescriptions = path.map((step, i) => {
+    const from = getAssetCode(step.from_asset);
+    const to = getAssetCode(step.to_asset);
+    const { isSDEX, poolName } = parseSource(step.source);
+    const venue = isSDEX
+      ? 'Stellar DEX order book'
+      : poolName || 'AMM liquidity pool';
+    return `Hop ${i + 1}: ${from} to ${to} through ${venue}`;
+  });
+
+  const start = getAssetCode(path[0].from_asset);
+  const end = getAssetCode(path[path.length - 1].to_asset);
+
+  return `Route from ${start} to ${end}, ${path.length} ${path.length === 1 ? 'hop' : 'hops'}. ${hopDescriptions.join('. ')}.`;
+}


### PR DESCRIPTION
## Summary
Implements responsive, accessible multi-hop route visualization for the frontend (issue #116).

## Changes
- \rontend/lib/route-helpers.ts\: shared \describeTradeRoute\ for screen readers and ARIA labels
- \RouteVisualization\: \lg\ horizontal flow with scroll/snap, vertical stack below \lg\, \prefers-reduced-motion\, landmark/ARIA for details toggle and summaries
- \SplitRouteVisualization\: list semantics, touch-friendly nodes, responsive metrics grid, same a11y patterns
- \TransactionConfirmationModal\: wrapping route row + \ria-label\ with full route description

Closes #116

Made with [Cursor](https://cursor.com)