### PR TITLE
feat(sdk-js): Add WebSocket subscription API for live quote updates

### DIFF
--- a/sdk-js/src/index.ts
+++ b/sdk-js/src/index.ts
@@ -1,2 +1,3 @@
 export * from './client.js';
 export * from './types.js';
+export * from './websocket.js';

--- a/sdk-js/src/websocket.test.ts
+++ b/sdk-js/src/websocket.test.ts
@@ -1,0 +1,328 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { StellarRouteWebSocket, createWebSocketClient, WebSocketState } from './websocket.js';
+
+// Mock WebSocket
+class MockWebSocket {
+  static instances: MockWebSocket[] = [];
+  
+  readyState: number = WebSocket.CONNECTING;
+  onopen: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  
+  constructor(public url: string) {
+    MockWebSocket.instances.push(this);
+    // Simulate async connection
+    setTimeout(() => {
+      this.readyState = WebSocket.OPEN;
+      this.onopen?.({ type: 'open' } as Event);
+    }, 10);
+  }
+  
+  send(data: string) {
+    // Echo back subscription confirmations
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.action === 'subscribe') {
+        setTimeout(() => {
+          this.onmessage?.({
+            data: JSON.stringify({
+              type: 'subscription_confirmed',
+              subscription: parsed.subscription,
+              timestamp: Date.now(),
+            }),
+          } as MessageEvent);
+        }, 5);
+      }
+    } catch {
+      // Ignore parse errors
+    }
+  }
+  
+  close(code = 1000, reason = '') {
+    this.readyState = WebSocket.CLOSED;
+    this.onclose?.({ code, reason, type: 'close' } as CloseEvent);
+  }
+}
+
+// Setup mock
+vi.stubGlobal('WebSocket', MockWebSocket);
+
+describe('StellarRouteWebSocket', () => {
+  let client: StellarRouteWebSocket;
+  
+  beforeEach(() => {
+    MockWebSocket.instances = [];
+    client = createWebSocketClient('ws://localhost:8080', {
+      connectionTimeoutMs: 100,
+      initialBackoffMs: 50,
+      maxReconnectAttempts: 2,
+    });
+  });
+  
+  afterEach(async () => {
+    await client.disconnect();
+  });
+  
+  describe('connection management', () => {
+    it('should connect successfully', async () => {
+      await client.connect();
+      expect(client.isConnected()).toBe(true);
+      expect(client.getState()).toBe('connected');
+    });
+    
+    it('should emit connection state events', async () => {
+      const states: WebSocketState[] = [];
+      client.addEventListener((event) => {
+        if (event.type === 'connection_state') {
+          states.push(event.state);
+        }
+      });
+      
+      await client.connect();
+      
+      expect(states).toContain('connecting');
+      expect(states).toContain('connected');
+    });
+    
+    it('should disconnect cleanly', async () => {
+      await client.connect();
+      await client.disconnect();
+      
+      expect(client.isConnected()).toBe(false);
+      expect(client.getState()).toBe('disconnected');
+    });
+    
+    it('should not reconnect after explicit disconnect', async () => {
+      await client.connect();
+      const ws = MockWebSocket.instances[0];
+      
+      await client.disconnect();
+      ws.close();
+      
+      // Wait for potential reconnect
+      await new Promise((r) => setTimeout(r, 100));
+      
+      expect(MockWebSocket.instances.length).toBe(1);
+    });
+  });
+  
+  describe('subscription management', () => {
+    it('should subscribe to quote updates', async () => {
+      await client.connect();
+      
+      const id = client.subscribeToQuote('XLM', 'USDC');
+      expect(id).toBeTruthy();
+      expect(client.getSubscriptions().size).toBe(1);
+    });
+    
+    it('should subscribe to orderbook updates', async () => {
+      await client.connect();
+      
+      const id = client.subscribeToOrderbook('XLM', 'USDC');
+      expect(id).toBeTruthy();
+      expect(client.getSubscriptions().size).toBe(1);
+    });
+    
+    it('should unsubscribe correctly', async () => {
+      await client.connect();
+      
+      const id = client.subscribeToQuote('XLM', 'USDC');
+      expect(client.getSubscriptions().size).toBe(1);
+      
+      client.unsubscribe(id);
+      expect(client.getSubscriptions().size).toBe(0);
+    });
+    
+    it('should unsubscribe from all subscriptions', async () => {
+      await client.connect();
+      
+      client.subscribeToQuote('XLM', 'USDC');
+      client.subscribeToOrderbook('XLM', 'USDC');
+      expect(client.getSubscriptions().size).toBe(2);
+      
+      client.unsubscribeAll();
+      expect(client.getSubscriptions().size).toBe(0);
+    });
+    
+    it('should emit subscription confirmed event', async () => {
+      await client.connect();
+      
+      const events: unknown[] = [];
+      client.addEventListener((event) => events.push(event));
+      
+      client.subscribeToQuote('XLM', 'USDC');
+      
+      // Wait for mock to send confirmation
+      await new Promise((r) => setTimeout(r, 20));
+      
+      expect(events.some((e: unknown) => (e as {type: string}).type === 'subscription_confirmed')).toBe(true);
+    });
+  });
+  
+  describe('event handling', () => {
+    it('should handle quote update events', async () => {
+      await client.connect();
+      const ws = MockWebSocket.instances[0];
+      
+      const events: unknown[] = [];
+      client.addEventListener((event) => events.push(event));
+      
+      // Simulate server message
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: 'quote_update',
+          subscription: { type: 'quote', base: 'XLM', quote: 'USDC' },
+          data: {
+            base_asset: { asset_type: 'native' },
+            quote_asset: { asset_code: 'USDC', asset_issuer: 'test' },
+            amount: '100',
+            price: '0.12',
+            total: '12',
+            quote_type: 'sell',
+            path: [],
+            timestamp: Date.now(),
+          },
+          timestamp: Date.now(),
+        }),
+      } as MessageEvent);
+      
+      expect(events.length).toBe(1);
+      expect((events[0] as {type: string}).type).toBe('quote_update');
+    });
+    
+    it('should handle orderbook update events', async () => {
+      await client.connect();
+      const ws = MockWebSocket.instances[0];
+      
+      const events: unknown[] = [];
+      client.addEventListener((event) => events.push(event));
+      
+      // Simulate server message
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: 'orderbook_update',
+          subscription: { type: 'orderbook', base: 'XLM', quote: 'USDC' },
+          data: {
+            base_asset: { asset_type: 'native' },
+            quote_asset: { asset_code: 'USDC', asset_issuer: 'test' },
+            bids: [],
+            asks: [],
+            timestamp: Date.now(),
+          },
+          timestamp: Date.now(),
+        }),
+      } as MessageEvent);
+      
+      expect(events.length).toBe(1);
+      expect((events[0] as {type: string}).type).toBe('orderbook_update');
+    });
+    
+    it('should handle error events', async () => {
+      await client.connect();
+      const ws = MockWebSocket.instances[0];
+      
+      const events: unknown[] = [];
+      client.addEventListener((event) => events.push(event));
+      
+      // Simulate server error
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: 'error',
+          code: 'invalid_subscription',
+          message: 'Invalid trading pair',
+          timestamp: Date.now(),
+        }),
+      } as MessageEvent);
+      
+      expect(events.length).toBe(1);
+      const errorEvent = events[0] as {type: string; code: string};
+      expect(errorEvent.type).toBe('error');
+      expect(errorEvent.code).toBe('invalid_subscription');
+    });
+    
+    it('should remove event listener correctly', async () => {
+      await client.connect();
+      
+      let callCount = 0;
+      const listener = () => callCount++;
+      
+      const unsubscribe = client.addEventListener(listener);
+      client.addEventListener(() => callCount++);
+      
+      client.unsubscribe(client.subscribeToQuote('XLM', 'USDC'));
+      
+      await new Promise((r) => setTimeout(r, 20));
+      
+      const countBefore = callCount;
+      
+      unsubscribe();
+      
+      // Further events should only increment once
+      client.unsubscribe(client.subscribeToQuote('XLM', 'USDC'));
+      
+      expect(callCount).toBeLessThanOrEqual(countBefore + 2);
+    });
+  });
+  
+  describe('reconnection', () => {
+    it('should attempt reconnection on disconnect', async () => {
+      client = createWebSocketClient('ws://localhost:8080', {
+        connectionTimeoutMs: 100,
+        initialBackoffMs: 10,
+        maxReconnectAttempts: 2,
+      });
+      
+      await client.connect();
+      expect(MockWebSocket.instances.length).toBe(1);
+      
+      // Simulate unexpected disconnect
+      const ws = MockWebSocket.instances[0];
+      ws.close(1006, 'Connection lost');
+      
+      // Wait for reconnection attempt
+      await new Promise((r) => setTimeout(r, 100));
+      
+      // Should have attempted reconnection
+      expect(MockWebSocket.instances.length).toBeGreaterThan(1);
+    });
+    
+    it('should resubscribe after reconnection', async () => {
+      client = createWebSocketClient('ws://localhost:8080', {
+        connectionTimeoutMs: 100,
+        initialBackoffMs: 10,
+        maxReconnectAttempts: 2,
+      });
+      
+      await client.connect();
+      client.subscribeToQuote('XLM', 'USDC');
+      
+      expect(client.getSubscriptions().size).toBe(1);
+      
+      // Simulate disconnect and reconnect
+      const ws = MockWebSocket.instances[0];
+      ws.close(1006, 'Connection lost');
+      
+      await new Promise((r) => setTimeout(r, 100));
+      
+      // Subscriptions should be preserved
+      expect(client.getSubscriptions().size).toBe(1);
+    });
+  });
+});
+
+describe('createWebSocketClient', () => {
+  it('should create a client with default options', () => {
+    const client = createWebSocketClient();
+    expect(client).toBeInstanceOf(StellarRouteWebSocket);
+  });
+  
+  it('should create a client with custom options', () => {
+    const client = createWebSocketClient('ws://custom:8080', {
+      maxReconnectAttempts: 10,
+      debug: true,
+    });
+    expect(client).toBeInstanceOf(StellarRouteWebSocket);
+  });
+});

--- a/sdk-js/src/websocket.ts
+++ b/sdk-js/src/websocket.ts
@@ -1,0 +1,482 @@
+/**
+ * WebSocket subscription API for live quote and orderbook updates.
+ * 
+ * Features:
+ * - Subscribe/unsubscribe lifecycle
+ * - Automatic reconnection with exponential backoff
+ * - Typed event payloads
+ * - Connection state management
+ */
+
+import type { PriceQuote, Orderbook } from './types.js';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type WebSocketState = 'connecting' | 'connected' | 'disconnecting' | 'disconnected';
+
+export interface WebSocketOptions {
+  /** Maximum reconnection attempts (default: 5) */
+  maxReconnectAttempts?: number;
+  /** Initial backoff delay in ms (default: 1000) */
+  initialBackoffMs?: number;
+  /** Maximum backoff delay in ms (default: 30000) */
+  maxBackoffMs?: number;
+  /** Backoff multiplier (default: 2) */
+  backoffMultiplier?: number;
+  /** Connection timeout in ms (default: 10000) */
+  connectionTimeoutMs?: number;
+  /** Enable debug logging */
+  debug?: boolean;
+}
+
+export interface SubscriptionOptions {
+  /** Subscription identifier for reference */
+  id?: string;
+}
+
+export type SubscriptionType = 'quote' | 'orderbook';
+
+export interface QuoteSubscription {
+  type: 'quote';
+  base: string;
+  quote: string;
+}
+
+export interface OrderbookSubscription {
+  type: 'orderbook';
+  base: string;
+  quote: string;
+}
+
+export type Subscription = QuoteSubscription | OrderbookSubscription;
+
+export interface QuoteUpdateEvent {
+  type: 'quote_update';
+  subscription: QuoteSubscription;
+  data: PriceQuote;
+  timestamp: number;
+}
+
+export interface OrderbookUpdateEvent {
+  type: 'orderbook_update';
+  subscription: OrderbookSubscription;
+  data: Orderbook;
+  timestamp: number;
+}
+
+export interface SubscriptionConfirmedEvent {
+  type: 'subscription_confirmed';
+  subscription: Subscription;
+  timestamp: number;
+}
+
+export interface SubscriptionRemovedEvent {
+  type: 'subscription_removed';
+  subscription: Subscription;
+  timestamp: number;
+}
+
+export interface ErrorEvent {
+  type: 'error';
+  code: string;
+  message: string;
+  details?: unknown;
+  timestamp: number;
+}
+
+export interface ConnectionStateEvent {
+  type: 'connection_state';
+  state: WebSocketState;
+  timestamp: number;
+}
+
+export type WebSocketEvent = 
+  | QuoteUpdateEvent 
+  | OrderbookUpdateEvent
+  | SubscriptionConfirmedEvent
+  | SubscriptionRemovedEvent
+  | ErrorEvent
+  | ConnectionStateEvent;
+
+export type EventListener = (event: WebSocketEvent) => void;
+
+// ============================================================================
+// WebSocket Client
+// ============================================================================
+
+export class StellarRouteWebSocket {
+  private ws: WebSocket | null = null;
+  private readonly baseUrl: string;
+  private readonly options: Required<WebSocketOptions>;
+  private state: WebSocketState = 'disconnected';
+  private listeners: Set<EventListener> = new Set();
+  private subscriptions: Map<string, Subscription> = new Map();
+  private reconnectAttempts = 0;
+  private reconnectTimeout: ReturnType<typeof setTimeout> | null = null;
+  private connectionTimeout: ReturnType<typeof setTimeout> | null = null;
+  private shouldReconnect = true;
+
+  constructor(baseUrl = 'ws://localhost:8080', options?: WebSocketOptions) {
+    this.baseUrl = baseUrl.replace(/\/$/, '').replace(/^http/, 'ws');
+    this.options = {
+      maxReconnectAttempts: options?.maxReconnectAttempts ?? 5,
+      initialBackoffMs: options?.initialBackoffMs ?? 1000,
+      maxBackoffMs: options?.maxBackoffMs ?? 30000,
+      backoffMultiplier: options?.backoffMultiplier ?? 2,
+      connectionTimeoutMs: options?.connectionTimeoutMs ?? 10000,
+      debug: options?.debug ?? false,
+    };
+  }
+
+  // ============================================================================
+  // Connection Management
+  // ============================================================================
+
+  /**
+   * Connect to the WebSocket server.
+   * Automatically reconnects on disconnection unless disconnect() was called.
+   */
+  async connect(): Promise<void> {
+    if (this.state === 'connected' || this.state === 'connecting') {
+      return;
+    }
+
+    this.shouldReconnect = true;
+    this.setState('connecting');
+
+    return new Promise((resolve, reject) => {
+      try {
+        const wsUrl = `${this.baseUrl}/ws`;
+        this.log('Connecting to', wsUrl);
+        
+        this.ws = new WebSocket(wsUrl);
+        
+        // Connection timeout
+        this.connectionTimeout = setTimeout(() => {
+          if (this.ws?.readyState !== WebSocket.OPEN) {
+            this.log('Connection timeout');
+            this.ws?.close();
+            reject(new Error('Connection timeout'));
+          }
+        }, this.options.connectionTimeoutMs);
+
+        this.ws.onopen = () => {
+          this.clearConnectionTimeout();
+          this.setState('connected');
+          this.reconnectAttempts = 0;
+          this.log('Connected');
+          
+          // Resubscribe to all active subscriptions
+          this.resubscribeAll();
+          resolve();
+        };
+
+        this.ws.onclose = (event) => {
+          this.clearConnectionTimeout();
+          this.log('Disconnected', event.code, event.reason);
+          
+          if (this.state === 'connected') {
+            this.setState('disconnected');
+          }
+
+          // Attempt reconnection if not intentionally disconnected
+          if (this.shouldReconnect && this.reconnectAttempts < this.options.maxReconnectAttempts) {
+            this.scheduleReconnect();
+          } else if (this.reconnectAttempts >= this.options.maxReconnectAttempts) {
+            this.emit({
+              type: 'error',
+              code: 'reconnect_failed',
+              message: 'Maximum reconnection attempts reached',
+              timestamp: Date.now(),
+            });
+          }
+        };
+
+        this.ws.onerror = (error) => {
+          this.clearConnectionTimeout();
+          this.log('WebSocket error', error);
+          this.emit({
+            type: 'error',
+            code: 'websocket_error',
+            message: 'WebSocket connection error',
+            timestamp: Date.now(),
+          });
+        };
+
+        this.ws.onmessage = (event) => {
+          this.handleMessage(event.data);
+        };
+
+      } catch (error) {
+        this.clearConnectionTimeout();
+        reject(error);
+      }
+    });
+  }
+
+  /**
+   * Disconnect from the WebSocket server.
+   * Prevents automatic reconnection.
+   */
+  async disconnect(): Promise<void> {
+    this.shouldReconnect = false;
+    this.clearReconnectTimeout();
+    
+    if (this.ws) {
+      this.setState('disconnecting');
+      this.ws.close(1000, 'Client disconnect');
+      this.ws = null;
+    }
+    
+    this.setState('disconnected');
+    this.subscriptions.clear();
+  }
+
+  /**
+   * Get the current connection state.
+   */
+  getState(): WebSocketState {
+    return this.state;
+  }
+
+  /**
+   * Check if connected to the server.
+   */
+  isConnected(): boolean {
+    return this.state === 'connected' && this.ws?.readyState === WebSocket.OPEN;
+  }
+
+  // ============================================================================
+  // Subscription Management
+  // ============================================================================
+
+  /**
+   * Subscribe to quote updates for a trading pair.
+   */
+  subscribeToQuote(base: string, quote: string, options?: SubscriptionOptions): string {
+    const subscription: QuoteSubscription = { type: 'quote', base, quote };
+    return this.subscribe(subscription, options);
+  }
+
+  /**
+   * Subscribe to orderbook updates for a trading pair.
+   */
+  subscribeToOrderbook(base: string, quote: string, options?: SubscriptionOptions): string {
+    const subscription: OrderbookSubscription = { type: 'orderbook', base, quote };
+    return this.subscribe(subscription, options);
+  }
+
+  /**
+   * Unsubscribe from updates.
+   */
+  unsubscribe(subscriptionId: string): void {
+    const subscription = this.subscriptions.get(subscriptionId);
+    if (!subscription) return;
+
+    if (this.isConnected()) {
+      this.send({
+        action: 'unsubscribe',
+        subscription,
+      });
+    }
+
+    this.subscriptions.delete(subscriptionId);
+    this.emit({
+      type: 'subscription_removed',
+      subscription,
+      timestamp: Date.now(),
+    });
+  }
+
+  /**
+   * Unsubscribe from all subscriptions.
+   */
+  unsubscribeAll(): void {
+    for (const id of this.subscriptions.keys()) {
+      this.unsubscribe(id);
+    }
+  }
+
+  /**
+   * Get all active subscriptions.
+   */
+  getSubscriptions(): Map<string, Subscription> {
+    return new Map(this.subscriptions);
+  }
+
+  // ============================================================================
+  // Event Handling
+  // ============================================================================
+
+  /**
+   * Add an event listener.
+   */
+  addEventListener(listener: EventListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  /**
+   * Remove an event listener.
+   */
+  removeEventListener(listener: EventListener): void {
+    this.listeners.delete(listener);
+  }
+
+  // ============================================================================
+  // Private Methods
+  // ============================================================================
+
+  private subscribe(subscription: Subscription, options?: SubscriptionOptions): string {
+    const id = options?.id ?? this.generateSubscriptionId(subscription);
+    
+    this.subscriptions.set(id, subscription);
+    
+    if (this.isConnected()) {
+      this.send({
+        action: 'subscribe',
+        subscription,
+      });
+    }
+
+    return id;
+  }
+
+  private generateSubscriptionId(subscription: Subscription): string {
+    return `${subscription.type}:${subscription.base}/${subscription.quote}:${Date.now()}`;
+  }
+
+  private send(message: unknown): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(JSON.stringify(message));
+    }
+  }
+
+  private handleMessage(data: string): void {
+    try {
+      const message = JSON.parse(data);
+      this.log('Received message', message);
+
+      switch (message.type) {
+        case 'quote_update':
+          this.emit({
+            type: 'quote_update',
+            subscription: message.subscription,
+            data: message.data,
+            timestamp: message.timestamp ?? Date.now(),
+          });
+          break;
+
+        case 'orderbook_update':
+          this.emit({
+            type: 'orderbook_update',
+            subscription: message.subscription,
+            data: message.data,
+            timestamp: message.timestamp ?? Date.now(),
+          });
+          break;
+
+        case 'subscription_confirmed':
+          this.emit({
+            type: 'subscription_confirmed',
+            subscription: message.subscription,
+            timestamp: message.timestamp ?? Date.now(),
+          });
+          break;
+
+        case 'error':
+          this.emit({
+            type: 'error',
+            code: message.code,
+            message: message.message,
+            details: message.details,
+            timestamp: message.timestamp ?? Date.now(),
+          });
+          break;
+
+        default:
+          this.log('Unknown message type', message.type);
+      }
+    } catch (error) {
+      this.log('Failed to parse message', error);
+    }
+  }
+
+  private emit(event: WebSocketEvent): void {
+    for (const listener of this.listeners) {
+      try {
+        listener(event);
+      } catch (error) {
+        this.log('Listener error', error);
+      }
+    }
+  }
+
+  private setState(state: WebSocketState): void {
+    this.state = state;
+    this.emit({
+      type: 'connection_state',
+      state,
+      timestamp: Date.now(),
+    });
+  }
+
+  private scheduleReconnect(): void {
+    this.reconnectAttempts++;
+    const backoff = Math.min(
+      this.options.initialBackoffMs * Math.pow(this.options.backoffMultiplier, this.reconnectAttempts - 1),
+      this.options.maxBackoffMs
+    );
+    
+    this.log(`Scheduling reconnect attempt ${this.reconnectAttempts} in ${backoff}ms`);
+    
+    this.reconnectTimeout = setTimeout(() => {
+      this.connect().catch((error) => {
+        this.log('Reconnect failed', error);
+      });
+    }, backoff);
+  }
+
+  private resubscribeAll(): void {
+    for (const [id, subscription] of this.subscriptions) {
+      this.log('Resubscribing to', id);
+      this.send({
+        action: 'subscribe',
+        subscription,
+      });
+    }
+  }
+
+  private clearReconnectTimeout(): void {
+    if (this.reconnectTimeout) {
+      clearTimeout(this.reconnectTimeout);
+      this.reconnectTimeout = null;
+    }
+  }
+
+  private clearConnectionTimeout(): void {
+    if (this.connectionTimeout) {
+      clearTimeout(this.connectionTimeout);
+      this.connectionTimeout = null;
+    }
+  }
+
+  private log(...args: unknown[]): void {
+    if (this.options.debug) {
+      console.log('[StellarRouteWebSocket]', ...args);
+    }
+  }
+}
+
+// ============================================================================
+// Utility Functions
+// ============================================================================
+
+/**
+ * Create a WebSocket client with default options.
+ */
+export function createWebSocketClient(baseUrl?: string, options?: WebSocketOptions): StellarRouteWebSocket {
+  return new StellarRouteWebSocket(baseUrl, options);
+}


### PR DESCRIPTION
## Summary

Implements Issue #100 - Add WebSocket subscription API for live quote updates in TS SDK

This PR adds a complete WebSocket client implementation for subscribing to real-time quote and orderbook updates.

## Features

### Subscribe/Unsubscribe Lifecycle
- \subscribeToQuote(base, quote)\ - Subscribe to quote updates
- \subscribeToOrderbook(base, quote)\ - Subscribe to orderbook updates  
- \unsubscribe(id)\ - Unsubscribe from a specific subscription
- \unsubscribeAll()\ - Unsubscribe from all active subscriptions

### Reconnection with Exponential Backoff
- Automatic reconnection on unexpected disconnect
- Configurable max attempts, initial backoff, and backoff multiplier
- Preserves subscriptions across reconnections

### Typed Event Payloads
- \quote_update\ - Quote price updates
- \orderbook_update\ - Orderbook changes
- \subscription_confirmed\ - Subscription acknowledgment
- \subscription_removed\ - Unsubscription event
- \error\ - Error events with code and message
- \connection_state\ - Connection state changes

### Integration Tests
- 17 new tests covering all WebSocket functionality
- Mock WebSocket for reliable testing
- All 20 tests passing (3 client + 17 websocket)

## Usage Example

\\\	ypescript
import { StellarRouteWebSocket } from '@stellarroute/sdk-js';

const ws = new StellarRouteWebSocket('wss://api.stellarroute.io');

// Connect
await ws.connect();

// Subscribe to quote updates
const quoteId = ws.subscribeToQuote('XLM', 'USDC');

// Listen for events
ws.addEventListener((event) => {
  if (event.type === 'quote_update') {
    console.log('Quote:', event.data.price);
  }
});

// Unsubscribe
ws.unsubscribe(quoteId);

// Disconnect
await ws.disconnect();
\\\

## Acceptance Criteria

- [x] SDK includes subscribe/unsubscribe lifecycle
- [x] Reconnect and backoff behavior is handled
- [x] Event payload typing is documented
- [x] Integration tests validate stream behavior

## Test Results

\\\
 ✓ src/client.test.ts (3 tests) 58ms
 ✓ src/websocket.test.ts (17 tests) 640ms

 Test Files  2 passed (2)
      Tests  20 passed (20)
   Duration  2.15s
\\\

Closes #100