### PR TITLE
feat(api): cache quote routes with ttl, invalidation, and metrics

### DIFF
--- a/crates/api/src/bin/stellarroute-api.rs
+++ b/crates/api/src/bin/stellarroute-api.rs
@@ -74,6 +74,10 @@ async fn main() {
         enable_cors: true,
         enable_compression: true,
         redis_url: std::env::var("REDIS_URL").ok(),
+        quote_cache_ttl_seconds: std::env::var("QUOTE_CACHE_TTL_SECONDS")
+            .ok()
+            .and_then(|v| v.parse().ok())
+            .unwrap_or(2),
     };
 
     // Create and start server

--- a/crates/api/src/cache/mod.rs
+++ b/crates/api/src/cache/mod.rs
@@ -71,6 +71,21 @@ impl CacheManager {
         Ok(())
     }
 
+    /// Delete all cached values that match a Redis glob pattern
+    pub async fn delete_by_pattern(&mut self, pattern: &str) -> Result<u64, RedisError> {
+        let keys: Vec<String> = self.client.keys(pattern).await?;
+        if keys.is_empty() {
+            return Ok(0);
+        }
+
+        let deleted: u64 = self.client.del(keys).await?;
+        debug!(
+            "Deleted {} cache keys matching pattern: {}",
+            deleted, pattern
+        );
+        Ok(deleted)
+    }
+
     /// Check if cache is healthy
     pub async fn is_healthy(&mut self) -> bool {
         self.client
@@ -93,8 +108,21 @@ pub mod keys {
     }
 
     /// Cache key for quote
-    pub fn quote(base: &str, quote: &str, amount: &str) -> String {
-        format!("quote:{}:{}:{}", base, quote, amount)
+    pub fn quote(base: &str, quote: &str, amount: &str, slippage_bps: u32, quote_type: &str) -> String {
+        format!(
+            "quote:{}:{}:{}:{}:{}",
+            base, quote, amount, slippage_bps, quote_type
+        )
+    }
+
+    /// Key used to track the latest liquidity revision observed for a pair
+    pub fn liquidity_revision(base: &str, quote: &str) -> String {
+        format!("liquidity:revision:{}:{}", base, quote)
+    }
+
+    /// Pattern that matches all cached quotes for a pair
+    pub fn quote_pair_pattern(base: &str, quote: &str) -> String {
+        format!("quote:{}:{}:*", base, quote)
     }
 }
 
@@ -106,6 +134,17 @@ mod tests {
     fn test_cache_keys() {
         assert_eq!(keys::pairs_list(), "pairs:list");
         assert_eq!(keys::orderbook("XLM", "USDC"), "orderbook:XLM:USDC");
-        assert_eq!(keys::quote("XLM", "USDC", "100"), "quote:XLM:USDC:100");
+        assert_eq!(
+            keys::quote("XLM", "USDC", "100", 50, "sell"),
+            "quote:XLM:USDC:100:50:sell"
+        );
+        assert_eq!(
+            keys::liquidity_revision("XLM", "USDC"),
+            "liquidity:revision:XLM:USDC"
+        );
+        assert_eq!(
+            keys::quote_pair_pattern("XLM", "USDC"),
+            "quote:XLM:USDC:*"
+        );
     }
 }

--- a/crates/api/src/docs.rs
+++ b/crates/api/src/docs.rs
@@ -3,8 +3,8 @@
 use utoipa::OpenApi;
 
 use crate::models::{
-    AssetInfo, ErrorResponse, HealthResponse, OrderbookLevel, OrderbookResponse, PairsResponse,
-    PathStep, QuoteResponse, TradingPair,
+    AssetInfo, CacheMetricsResponse, ErrorResponse, HealthResponse, OrderbookLevel,
+    OrderbookResponse, PairsResponse, PathStep, QuoteResponse, TradingPair,
 };
 
 /// OpenAPI documentation
@@ -12,12 +12,14 @@ use crate::models::{
 #[openapi(
     paths(
         crate::routes::health::health_check,
+        crate::routes::metrics::cache_metrics,
         crate::routes::pairs::list_pairs,
         crate::routes::orderbook::get_orderbook,
         crate::routes::quote::get_quote,
     ),
     components(schemas(
         HealthResponse,
+        CacheMetricsResponse,
         PairsResponse,
         TradingPair,
         AssetInfo,

--- a/crates/api/src/handlers.rs
+++ b/crates/api/src/handlers.rs
@@ -3,5 +3,6 @@
 //! This module re-exports all route handlers for convenience.
 
 pub use crate::routes::{
-    health::health_check, orderbook::get_orderbook, pairs::list_pairs, quote::get_quote,
+    health::health_check, metrics::cache_metrics, orderbook::get_orderbook, pairs::list_pairs,
+    quote::get_quote,
 };

--- a/crates/api/src/models/request.rs
+++ b/crates/api/src/models/request.rs
@@ -7,6 +7,8 @@ use serde::Deserialize;
 pub struct QuoteParams {
     /// Amount to trade
     pub amount: Option<String>,
+    /// Slippage tolerance in basis points (e.g. 50 = 0.50%)
+    pub slippage_bps: Option<u32>,
     /// Type of quote (buy or sell)
     #[serde(default = "default_quote_type")]
     pub quote_type: QuoteType,

--- a/crates/api/src/models/response.rs
+++ b/crates/api/src/models/response.rs
@@ -19,6 +19,13 @@ pub struct HealthResponse {
     pub components: std::collections::HashMap<String, ComponentStatus>,
 }
 
+/// Cache metrics response
+#[derive(Debug, Serialize, Deserialize, ToSchema)]
+pub struct CacheMetricsResponse {
+    pub quote_hits: u64,
+    pub quote_misses: u64,
+}
+
 /// Trading pair information — matches GET /api/v1/pairs spec
 ///
 /// `base` / `counter` are human-readable codes (e.g. "XLM", "USDC").

--- a/crates/api/src/routes/metrics.rs
+++ b/crates/api/src/routes/metrics.rs
@@ -1,0 +1,24 @@
+//! Metrics endpoint
+
+use axum::{extract::State, Json};
+use std::sync::Arc;
+
+use crate::{models::CacheMetricsResponse, state::AppState};
+
+/// Cache metrics endpoint
+#[utoipa::path(
+    get,
+    path = "/metrics/cache",
+    tag = "health",
+    responses(
+        (status = 200, description = "Cache hit/miss metrics", body = CacheMetricsResponse),
+    )
+)]
+pub async fn cache_metrics(State(state): State<Arc<AppState>>) -> Json<CacheMetricsResponse> {
+    let (quote_hits, quote_misses) = state.cache_metrics.snapshot();
+
+    Json(CacheMetricsResponse {
+        quote_hits,
+        quote_misses,
+    })
+}

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -1,6 +1,7 @@
 //! API routes
 
 pub mod health;
+pub mod metrics;
 pub mod orderbook;
 pub mod pairs;
 pub mod quote;
@@ -15,6 +16,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
     Router::new()
         // Health check
         .route("/health", get(health::health_check))
+        .route("/metrics/cache", get(metrics::cache_metrics))
         // API v1 routes
         .route("/api/v1/pairs", get(pairs::list_pairs))
         .route(

--- a/crates/api/src/routes/quote.rs
+++ b/crates/api/src/routes/quote.rs
@@ -5,7 +5,7 @@ use axum::{
     Json,
 };
 use sqlx::Row;
-use std::{sync::Arc, time::Duration};
+use std::sync::Arc;
 use tracing::debug;
 
 use crate::{
@@ -29,6 +29,7 @@ use crate::{
         ("base" = String, Path, description = "Base asset (e.g., 'native', 'USDC', or 'USDC:ISSUER')"),
         ("quote" = String, Path, description = "Quote asset (e.g., 'native', 'USDC', or 'USDC:ISSUER')"),
         ("amount" = Option<String>, Query, description = "Amount to trade (default: 1)"),
+        ("slippage_bps" = Option<u32>, Query, description = "Slippage tolerance in basis points (default: 50)"),
         ("quote_type" = Option<String>, Query, description = "Type of quote: 'sell' or 'buy' (default: sell)"),
     ),
     responses(
@@ -68,31 +69,44 @@ pub async fn get_quote(
         ));
     }
 
-    // Try to get from cache first
-    let amount_str = format!("{:.7}", amount);
-    if let Some(cache) = &state.cache {
-        if let Ok(mut cache) = cache.try_lock() {
-            if let Some(cached) = cache
-                .get::<QuoteResponse>(&cache::keys::quote(&base, &quote, &amount_str))
-                .await
-            {
-                debug!("Returning cached quote for {}/{}", base, quote);
-                return Ok(Json(cached));
-            }
-        }
+    let slippage_bps = params.slippage_bps.unwrap_or(50);
+    if slippage_bps > 10_000 {
+        return Err(ApiError::Validation(
+            "slippage_bps must be between 0 and 10000".to_string(),
+        ));
     }
-
-    // For now, implement simple direct path (SDEX only)
-    // TODO: Implement multi-hop routing in Phase 2
-    let (price, path) = find_best_price(&state, &base_asset, &quote_asset, amount).await?;
-
-    let total = amount * price;
-    let timestamp = chrono::Utc::now().timestamp();
 
     let quote_type = match params.quote_type {
         crate::models::request::QuoteType::Sell => "sell",
         crate::models::request::QuoteType::Buy => "buy",
     };
+
+    let base_id = find_asset_id(&state, &base_asset).await?;
+    let quote_id = find_asset_id(&state, &quote_asset).await?;
+
+    maybe_invalidate_quote_cache(&state, &base, &quote, base_id, quote_id).await?;
+
+    // Try to get from cache first
+    let amount_str = format!("{:.7}", amount);
+    let quote_cache_key = cache::keys::quote(&base, &quote, &amount_str, slippage_bps, quote_type);
+    if let Some(cache) = &state.cache {
+        if let Ok(mut cache) = cache.try_lock() {
+            if let Some(cached) = cache.get::<QuoteResponse>(&quote_cache_key).await {
+                state.cache_metrics.inc_quote_hit();
+                debug!("Returning cached quote for {}/{}", base, quote);
+                return Ok(Json(cached));
+            }
+
+            state.cache_metrics.inc_quote_miss();
+        }
+    }
+
+    // For now, implement simple direct path (SDEX only)
+    // TODO: Implement multi-hop routing in Phase 2
+    let (price, path) = find_best_price(&state, &base_asset, &quote_asset, base_id, quote_id, amount).await?;
+
+    let total = amount * price;
+    let timestamp = chrono::Utc::now().timestamp();
 
     let response = QuoteResponse {
         base_asset: asset_path_to_info(&base_asset),
@@ -110,9 +124,9 @@ pub async fn get_quote(
         if let Ok(mut cache) = cache.try_lock() {
             let _ = cache
                 .set(
-                    &cache::keys::quote(&base, &quote, &amount_str),
+                    &quote_cache_key,
                     &response,
-                    Duration::from_secs(2),
+                    state.cache_policy.quote_ttl,
                 )
                 .await;
         }
@@ -126,12 +140,10 @@ async fn find_best_price(
     state: &AppState,
     base: &AssetPath,
     quote: &AssetPath,
+    base_id: uuid::Uuid,
+    quote_id: uuid::Uuid,
     _amount: f64,
 ) -> Result<(f64, Vec<PathStep>)> {
-    // Get asset IDs
-    let base_id = find_asset_id(state, base).await?;
-    let quote_id = find_asset_id(state, quote).await?;
-
     // Find best offer
     let row = sqlx::query(
         r#"
@@ -175,6 +187,66 @@ async fn find_best_price(
         }
         None => Err(ApiError::NoRouteFound),
     }
+}
+
+async fn maybe_invalidate_quote_cache(
+    state: &AppState,
+    base: &str,
+    quote: &str,
+    base_id: uuid::Uuid,
+    quote_id: uuid::Uuid,
+) -> Result<()> {
+    let liquidity_revision = get_liquidity_revision(state, base_id, quote_id).await?;
+
+    if let Some(cache) = &state.cache {
+        if let Ok(mut cache) = cache.try_lock() {
+            let revision_key = cache::keys::liquidity_revision(base, quote);
+            let cached_revision = cache.get::<String>(&revision_key).await;
+
+            if cached_revision.as_deref() != Some(liquidity_revision.as_str()) {
+                if cached_revision.is_some() {
+                    let pattern = cache::keys::quote_pair_pattern(base, quote);
+                    let deleted = cache.delete_by_pattern(&pattern).await.unwrap_or(0);
+                    debug!(
+                        "Liquidity revision changed for {}/{}; invalidated {} quote cache keys",
+                        base, quote, deleted
+                    );
+                }
+
+                let _ = cache
+                    .set(
+                        &revision_key,
+                        &liquidity_revision,
+                        std::time::Duration::from_secs(3600),
+                    )
+                    .await;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+async fn get_liquidity_revision(
+    state: &AppState,
+    base_id: uuid::Uuid,
+    quote_id: uuid::Uuid,
+) -> Result<String> {
+    let row = sqlx::query(
+        r#"
+        select coalesce(max(source_ledger), 0)::bigint as revision
+        from normalized_liquidity
+        where (selling_asset_id = $1 and buying_asset_id = $2)
+           or (selling_asset_id = $2 and buying_asset_id = $1)
+        "#,
+    )
+    .bind(base_id)
+    .bind(quote_id)
+    .fetch_one(&state.db)
+    .await?;
+
+    let revision: i64 = row.get("revision");
+    Ok(revision.to_string())
 }
 
 /// Find asset ID in database

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -18,7 +18,7 @@ use crate::{
     error::Result,
     middleware::{EndpointConfig, RateLimitLayer},
     routes,
-    state::AppState,
+    state::{AppState, CachePolicy},
 };
 
 /// API server configuration
@@ -34,6 +34,8 @@ pub struct ServerConfig {
     pub enable_compression: bool,
     /// Redis URL (optional)
     pub redis_url: Option<String>,
+    /// Quote cache TTL in seconds
+    pub quote_cache_ttl_seconds: u64,
 }
 
 impl Default for ServerConfig {
@@ -44,6 +46,7 @@ impl Default for ServerConfig {
             enable_cors: true,
             enable_compression: true,
             redis_url: None,
+            quote_cache_ttl_seconds: 2,
         }
     }
 }
@@ -57,6 +60,10 @@ pub struct Server {
 impl Server {
     /// Create a new API server
     pub async fn new(config: ServerConfig, db: PgPool) -> Self {
+        let cache_policy = CachePolicy {
+            quote_ttl: std::time::Duration::from_secs(config.quote_cache_ttl_seconds),
+        };
+
         // Try to connect to Redis if URL is provided
         let (state, rate_limit_layer) = if let Some(redis_url) = &config.redis_url {
             match CacheManager::new(redis_url).await {
@@ -81,12 +88,15 @@ impl Server {
                         }
                     };
 
-                    (Arc::new(AppState::with_cache(db, cache)), rate_limit)
+                    (
+                        Arc::new(AppState::with_cache_and_policy(db, cache, cache_policy.clone())),
+                        rate_limit,
+                    )
                 }
                 Err(e) => {
                     warn!("⚠️  Redis connection failed, running without cache: {}", e);
                     (
-                        Arc::new(AppState::new(db)),
+                        Arc::new(AppState::new_with_policy(db, cache_policy.clone())),
                         RateLimitLayer::in_memory(EndpointConfig::default()),
                     )
                 }
@@ -94,7 +104,7 @@ impl Server {
         } else {
             info!("ℹ️  Running without Redis cache");
             (
-                Arc::new(AppState::new(db)),
+                Arc::new(AppState::new_with_policy(db, cache_policy)),
                 RateLimitLayer::in_memory(EndpointConfig::default()),
             )
         };

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -1,10 +1,49 @@
 //! Shared application state
 
 use sqlx::PgPool;
-use std::sync::Arc;
+use std::{sync::Arc, time::Duration};
 use tokio::sync::Mutex;
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use crate::cache::CacheManager;
+
+/// Cache policy configuration
+#[derive(Debug, Clone)]
+pub struct CachePolicy {
+    pub quote_ttl: Duration,
+}
+
+impl Default for CachePolicy {
+    fn default() -> Self {
+        Self {
+            quote_ttl: Duration::from_secs(2),
+        }
+    }
+}
+
+/// In-process cache metrics
+#[derive(Default)]
+pub struct CacheMetrics {
+    quote_hits: AtomicU64,
+    quote_misses: AtomicU64,
+}
+
+impl CacheMetrics {
+    pub fn inc_quote_hit(&self) {
+        self.quote_hits.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn inc_quote_miss(&self) {
+        self.quote_misses.fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn snapshot(&self) -> (u64, u64) {
+        (
+            self.quote_hits.load(Ordering::Relaxed),
+            self.quote_misses.load(Ordering::Relaxed),
+        )
+    }
+}
 
 /// Shared API state
 #[derive(Clone)]
@@ -15,24 +54,42 @@ pub struct AppState {
     pub cache: Option<Arc<Mutex<CacheManager>>>,
     /// API version
     pub version: String,
+    /// Cache policy settings
+    pub cache_policy: CachePolicy,
+    /// Cache hit/miss counters
+    pub cache_metrics: Arc<CacheMetrics>,
 }
 
 impl AppState {
     /// Create new application state
     pub fn new(db: PgPool) -> Self {
+        Self::new_with_policy(db, CachePolicy::default())
+    }
+
+    /// Create new application state with an explicit cache policy
+    pub fn new_with_policy(db: PgPool, cache_policy: CachePolicy) -> Self {
         Self {
             db,
             cache: None,
             version: env!("CARGO_PKG_VERSION").to_string(),
+            cache_policy,
+            cache_metrics: Arc::new(CacheMetrics::default()),
         }
     }
 
     /// Create new application state with cache
     pub fn with_cache(db: PgPool, cache: CacheManager) -> Self {
+        Self::with_cache_and_policy(db, cache, CachePolicy::default())
+    }
+
+    /// Create new application state with cache and explicit cache policy
+    pub fn with_cache_and_policy(db: PgPool, cache: CacheManager, cache_policy: CachePolicy) -> Self {
         Self {
             db,
             cache: Some(Arc::new(Mutex::new(cache))),
             version: env!("CARGO_PKG_VERSION").to_string(),
+            cache_policy,
+            cache_metrics: Arc::new(CacheMetrics::default()),
         }
     }
 

--- a/crates/api/tests/pairs_integration.rs
+++ b/crates/api/tests/pairs_integration.rs
@@ -109,6 +109,7 @@ async fn get_pairs_returns_200_and_valid_json() {
         enable_cors: false,
         enable_compression: false,
         redis_url: None,
+        quote_cache_ttl_seconds: 2,
     };
 
     let router = Server::new(config, pool).await.into_router();


### PR DESCRIPTION
Closes #82 

## Summary

This PR implements route computation caching for quote requests in the API layer and wires cache invalidation to market-state changes.

### What changed

- Added quote cache key inputs for:
  - pair (`base`, `quote`)
  - `amount`
  - `slippage_bps`
  - `quote_type`
- Added configurable quote cache TTL policy:
  - new server config field: `quote_cache_ttl_seconds`
  - new env var: `QUOTE_CACHE_TTL_SECONDS`
- Added liquidity-change invalidation hook:
  - checks latest liquidity revision from `normalized_liquidity`
  - invalidates cached quote entries for affected pair when revision changes
- Added cache hit/miss metrics exposure:
  - endpoint: `GET /metrics/cache`
  - response fields: `quote_hits`, `quote_misses`
- Updated OpenAPI docs to include new metrics endpoint and schema.

## Motivation

Quote requests are frequent and often repeated with identical inputs. Caching reduces repeated DB work and improves latency, while invalidation ensures stale prices are not served after liquidity changes.

## Acceptance Criteria Mapping

- [x] **Cache keys include pair/amount/slippage inputs**
  - Implemented in quote cache key builder and quote route usage.
- [x] **TTL policy is configurable**
  - TTL moved from hardcoded value to config/env-driven policy.
- [x] **Invalidation hooks for liquidity updates are wired**
  - Quote route now compares liquidity revision and invalidates pair quote cache on revision change.
- [x] **Cache hit/miss metrics are exposed**
  - Added `GET /metrics/cache` endpoint.

## Testing

Run:

```bash
cargo test -p stellarroute-api
```

Result:

- All non-ignored tests pass.
- DB-dependent integration tests remain `#[ignore]` unless `DATABASE_URL` is provided.

## Notes

- Scope is intentionally limited to backend API changes required for this issue.
- No unrelated feature additions were introduced.
