### PR TITLE
feat(sdk): add output formats and stable cli exit codes

### DIFF
--- a/crates/sdk-rust/Cargo.toml
+++ b/crates/sdk-rust/Cargo.toml
@@ -20,3 +20,6 @@ uuid.workspace = true
 
 # SDK-specific dependencies
 clap = { version = "4.5", features = ["derive", "env"] }
+
+[dev-dependencies]
+insta = "1.41"

--- a/crates/sdk-rust/README.md
+++ b/crates/sdk-rust/README.md
@@ -1,0 +1,26 @@
+# StellarRoute Rust SDK CLI
+
+The CLI binary is available as:
+
+```bash
+cargo run -p stellarroute-sdk --bin stellarroute -- <command>
+```
+
+## Output formats
+
+Use the global `--output` flag:
+
+- `--output human` (default)
+- `--output table`
+- `--output json`
+
+Invalid output values are rejected with an explicit validation error that lists accepted values.
+
+## Exit codes
+
+The CLI uses stable exit codes for scripting:
+
+- `0`: success
+- `2`: CLI usage/validation error (including invalid `--output`)
+- `3`: invalid client configuration (for example, malformed `--api-url`)
+- `4`: runtime/API error (HTTP/API/serialization failure)

--- a/crates/sdk-rust/src/bin/stellarroute.rs
+++ b/crates/sdk-rust/src/bin/stellarroute.rs
@@ -1,13 +1,23 @@
 use clap::{builder::TypedValueParser, CommandFactory, Parser, Subcommand, ValueEnum};
+use serde::Serialize;
 use std::ffi::OsStr;
 use std::num::NonZeroUsize;
-use stellarroute_sdk::{QuoteRequest, QuoteType, StellarRouteClient};
+use stellarroute_sdk::{
+    HealthResponse, OrderbookLevel, OrderbookResponse, PairsResponse, QuoteRequest, QuoteResponse,
+    QuoteType, SdkError, StellarRouteClient,
+};
+
+const EXIT_SUCCESS: i32 = 0;
+const EXIT_USAGE_ERROR: i32 = 2;
+const EXIT_CONFIG_ERROR: i32 = 3;
+const EXIT_RUNTIME_ERROR: i32 = 4;
 
 #[derive(Parser, Debug)]
 #[command(
     name = "stellarroute",
     about = "Query the StellarRoute API from the terminal",
-    long_about = "Query the StellarRoute API from terminal workflows with concise, human-readable output.",
+    long_about = "Query the StellarRoute API from terminal workflows with machine-friendly or human-friendly output.",
+    after_help = "Output formats:\n  json | table | human\n\nExit codes:\n  0 success\n  2 CLI usage/validation error\n  3 invalid client configuration\n  4 runtime/API error",
     version
 )]
 struct Cli {
@@ -20,8 +30,25 @@ struct Cli {
     )]
     api_url: String,
 
+    #[arg(
+        long,
+        global = true,
+        value_enum,
+        default_value_t = OutputFormat::Human,
+        help = "Output format: json, table, or human"
+    )]
+    output: OutputFormat,
+
     #[command(subcommand)]
     command: Commands,
+}
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq, ValueEnum)]
+#[value(rename_all = "lower")]
+enum OutputFormat {
+    Json,
+    Table,
+    Human,
 }
 
 #[derive(Subcommand, Debug)]
@@ -135,110 +162,97 @@ impl TypedValueParser for PositiveAmountParser {
 async fn main() {
     Cli::command().debug_assert();
 
-    let cli = Cli::parse();
-    let client = match StellarRouteClient::new(&cli.api_url) {
-        Ok(client) => client,
-        Err(error) => exit_with_error(&error.to_string()),
+    let cli = match Cli::try_parse() {
+        Ok(cli) => cli,
+        Err(error) => {
+            let kind = error.kind();
+            let _ = error.print();
+            let code = match kind {
+                clap::error::ErrorKind::DisplayHelp | clap::error::ErrorKind::DisplayVersion => {
+                    EXIT_SUCCESS
+                }
+                _ => EXIT_USAGE_ERROR,
+            };
+            std::process::exit(code);
+        }
     };
 
-    let result = match cli.command {
-        Commands::Health => render_health(&client).await,
-        Commands::Pairs { limit } => render_pairs(&client, limit).await,
+    match run(cli).await {
+        Ok(output) => {
+            println!("{output}");
+        }
+        Err((code, message)) => {
+            eprintln!("Error: {message}");
+            std::process::exit(code);
+        }
+    }
+}
+
+async fn run(cli: Cli) -> Result<String, (i32, String)> {
+    let client = StellarRouteClient::new(&cli.api_url)
+        .map_err(|error| (exit_code_for_sdk_error(&error), error.to_string()))?;
+
+    match cli.command {
+        Commands::Health => render_health(&client, cli.output)
+            .await
+            .map_err(|error| (exit_code_for_sdk_error(&error), error.to_string())),
+        Commands::Pairs { limit } => render_pairs(&client, limit, cli.output)
+            .await
+            .map_err(|error| (exit_code_for_sdk_error(&error), error.to_string())),
         Commands::Quote {
             base,
             quote,
             amount,
             quote_type,
-        } => {
-            render_quote(
-                &client,
-                QuoteRequest {
-                    base: &base,
-                    quote: &quote,
-                    amount: amount.as_deref(),
-                    quote_type: quote_type.into(),
-                },
-            )
-            .await
-        }
+        } => render_quote(
+            &client,
+            QuoteRequest {
+                base: &base,
+                quote: &quote,
+                amount: amount.as_deref(),
+                quote_type: quote_type.into(),
+            },
+            cli.output,
+        )
+        .await
+        .map_err(|error| (exit_code_for_sdk_error(&error), error.to_string())),
         Commands::Orderbook {
             base,
             quote,
             levels,
-        } => render_orderbook(&client, &base, &quote, levels.get()).await,
-    };
-
-    if let Err(error) = result {
-        exit_with_error(&error.to_string());
+        } => render_orderbook(&client, &base, &quote, levels.get(), cli.output)
+            .await
+            .map_err(|error| (exit_code_for_sdk_error(&error), error.to_string())),
     }
 }
 
-async fn render_health(client: &StellarRouteClient) -> Result<(), stellarroute_sdk::SdkError> {
+async fn render_health(
+    client: &StellarRouteClient,
+    output: OutputFormat,
+) -> Result<String, SdkError> {
     let response = client.health().await?;
 
-    println!("status: {}", response.status);
-    println!("version: {}", response.version);
-    println!("timestamp: {}", response.timestamp);
-
-    if !response.components.is_empty() {
-        println!("components:");
-        let mut components = response.components.into_iter().collect::<Vec<_>>();
-        components.sort_by(|a, b| a.0.cmp(&b.0));
-        for (name, status) in components {
-            println!("  {name}: {status}");
-        }
-    }
-
-    Ok(())
+    format_health(&response, output)
 }
 
 async fn render_pairs(
     client: &StellarRouteClient,
     limit: usize,
-) -> Result<(), stellarroute_sdk::SdkError> {
+    output: OutputFormat,
+) -> Result<String, SdkError> {
     let response = client.pairs().await?;
-    let shown = response.pairs.iter().take(limit);
 
-    println!("total pairs: {}", response.total);
-    for pair in shown {
-        println!(
-            "{} / {} | offers: {} | canonical: {} / {}",
-            pair.base, pair.counter, pair.offer_count, pair.base_asset, pair.counter_asset
-        );
-    }
-
-    Ok(())
+    format_pairs(&response, limit, output)
 }
 
 async fn render_quote(
     client: &StellarRouteClient,
     request: QuoteRequest<'_>,
-) -> Result<(), stellarroute_sdk::SdkError> {
+    output: OutputFormat,
+) -> Result<String, SdkError> {
     let response = client.quote(request).await?;
 
-    println!(
-        "pair: {} / {}",
-        response.base_asset.display_name(),
-        response.quote_asset.display_name()
-    );
-    println!("amount: {}", response.amount);
-    println!("quote type: {}", response.quote_type);
-    println!("price: {}", response.price);
-    println!("total: {}", response.total);
-    println!("route steps: {}", response.path.len());
-
-    for (index, step) in response.path.iter().enumerate() {
-        println!(
-            "{}. {} -> {} @ {} via {}",
-            index + 1,
-            step.from_asset.display_name(),
-            step.to_asset.display_name(),
-            step.price,
-            step.source
-        );
-    }
-
-    Ok(())
+    format_quote(&response, output)
 }
 
 async fn render_orderbook(
@@ -246,37 +260,352 @@ async fn render_orderbook(
     base: &str,
     quote: &str,
     levels: usize,
-) -> Result<(), stellarroute_sdk::SdkError> {
-    let response = client.orderbook(base, quote).await?;
+    output: OutputFormat,
+) -> Result<String, SdkError> {
+    let mut response = client.orderbook(base, quote).await?;
+    response.asks.truncate(levels);
+    response.bids.truncate(levels);
 
-    println!(
-        "pair: {} / {}",
-        response.base_asset.display_name(),
-        response.quote_asset.display_name()
-    );
-    println!("timestamp: {}", response.timestamp);
-    println!("asks:");
-    for level in response.asks.iter().take(levels) {
-        println!(
-            "  price={} amount={} total={}",
-            level.price, level.amount, level.total
-        );
-    }
-
-    println!("bids:");
-    for level in response.bids.iter().take(levels) {
-        println!(
-            "  price={} amount={} total={}",
-            level.price, level.amount, level.total
-        );
-    }
-
-    Ok(())
+    format_orderbook(&response, output)
 }
 
-fn exit_with_error(message: &str) -> ! {
-    eprintln!("Error: {message}");
-    std::process::exit(1);
+fn format_health(response: &HealthResponse, output: OutputFormat) -> Result<String, SdkError> {
+    match output {
+        OutputFormat::Human => {
+            let mut lines = vec![
+                format!("status: {}", response.status),
+                format!("version: {}", response.version),
+                format!("timestamp: {}", response.timestamp),
+            ];
+
+            if !response.components.is_empty() {
+                lines.push("components:".to_string());
+                let mut components = response.components.iter().collect::<Vec<_>>();
+                components.sort_by(|a, b| a.0.cmp(b.0));
+                for (name, status) in components {
+                    lines.push(format!("  {name}: {status}"));
+                }
+            }
+
+            Ok(lines.join("\n"))
+        }
+        OutputFormat::Table => {
+            let summary = format_table(
+                &["field", "value"],
+                vec![
+                    vec!["status".to_string(), response.status.clone()],
+                    vec!["version".to_string(), response.version.clone()],
+                    vec!["timestamp".to_string(), response.timestamp.clone()],
+                ],
+            );
+
+            if response.components.is_empty() {
+                return Ok(summary);
+            }
+
+            let mut components = response.components.iter().collect::<Vec<_>>();
+            components.sort_by(|a, b| a.0.cmp(b.0));
+            let component_rows = components
+                .into_iter()
+                .map(|(name, status)| vec![name.clone(), status.clone()])
+                .collect::<Vec<_>>();
+
+            Ok(format!(
+                "{}\n\ncomponents\n{}",
+                summary,
+                format_table(&["name", "status"], component_rows)
+            ))
+        }
+        OutputFormat::Json => {
+            #[derive(Serialize)]
+            struct ComponentRow {
+                name: String,
+                status: String,
+            }
+
+            #[derive(Serialize)]
+            struct HealthJson {
+                status: String,
+                version: String,
+                timestamp: String,
+                components: Vec<ComponentRow>,
+            }
+
+            let mut components = response.components.iter().collect::<Vec<_>>();
+            components.sort_by(|a, b| a.0.cmp(b.0));
+            let components = components
+                .into_iter()
+                .map(|(name, status)| ComponentRow {
+                    name: name.clone(),
+                    status: status.clone(),
+                })
+                .collect::<Vec<_>>();
+
+            serde_json::to_string_pretty(&HealthJson {
+                status: response.status.clone(),
+                version: response.version.clone(),
+                timestamp: response.timestamp.clone(),
+                components,
+            })
+            .map_err(Into::into)
+        }
+    }
+}
+
+fn format_pairs(
+    response: &PairsResponse,
+    limit: usize,
+    output: OutputFormat,
+) -> Result<String, SdkError> {
+    let shown_pairs = response
+        .pairs
+        .iter()
+        .take(limit)
+        .cloned()
+        .collect::<Vec<_>>();
+
+    match output {
+        OutputFormat::Human => {
+            let mut lines = vec![format!("total pairs: {}", response.total)];
+            for pair in &shown_pairs {
+                lines.push(format!(
+                    "{} / {} | offers: {} | canonical: {} / {}",
+                    pair.base, pair.counter, pair.offer_count, pair.base_asset, pair.counter_asset
+                ));
+            }
+            Ok(lines.join("\n"))
+        }
+        OutputFormat::Table => {
+            let rows = shown_pairs
+                .iter()
+                .map(|pair| {
+                    vec![
+                        pair.base.clone(),
+                        pair.counter.clone(),
+                        pair.offer_count.to_string(),
+                        pair.base_asset.clone(),
+                        pair.counter_asset.clone(),
+                    ]
+                })
+                .collect::<Vec<_>>();
+
+            let table = format_table(
+                &["base", "counter", "offers", "base_asset", "counter_asset"],
+                rows,
+            );
+            Ok(format!(
+                "total pairs: {}\nshowing: {}\n\n{}",
+                response.total,
+                shown_pairs.len(),
+                table
+            ))
+        }
+        OutputFormat::Json => {
+            #[derive(Serialize)]
+            struct PairsJson {
+                total: usize,
+                showing: usize,
+                pairs: Vec<stellarroute_sdk::TradingPair>,
+            }
+
+            serde_json::to_string_pretty(&PairsJson {
+                total: response.total,
+                showing: shown_pairs.len(),
+                pairs: shown_pairs,
+            })
+            .map_err(Into::into)
+        }
+    }
+}
+
+fn format_quote(response: &QuoteResponse, output: OutputFormat) -> Result<String, SdkError> {
+    match output {
+        OutputFormat::Human => {
+            let mut lines = vec![
+                format!(
+                    "pair: {} / {}",
+                    response.base_asset.display_name(),
+                    response.quote_asset.display_name()
+                ),
+                format!("amount: {}", response.amount),
+                format!("quote type: {}", response.quote_type),
+                format!("price: {}", response.price),
+                format!("total: {}", response.total),
+                format!("route steps: {}", response.path.len()),
+            ];
+
+            for (index, step) in response.path.iter().enumerate() {
+                lines.push(format!(
+                    "{}. {} -> {} @ {} via {}",
+                    index + 1,
+                    step.from_asset.display_name(),
+                    step.to_asset.display_name(),
+                    step.price,
+                    step.source
+                ));
+            }
+
+            Ok(lines.join("\n"))
+        }
+        OutputFormat::Table => {
+            let summary = format_table(
+                &["field", "value"],
+                vec![
+                    vec![
+                        "pair".to_string(),
+                        format!(
+                            "{} / {}",
+                            response.base_asset.display_name(),
+                            response.quote_asset.display_name()
+                        ),
+                    ],
+                    vec!["amount".to_string(), response.amount.clone()],
+                    vec!["quote_type".to_string(), response.quote_type.clone()],
+                    vec!["price".to_string(), response.price.clone()],
+                    vec!["total".to_string(), response.total.clone()],
+                ],
+            );
+
+            let rows = response
+                .path
+                .iter()
+                .enumerate()
+                .map(|(idx, step)| {
+                    vec![
+                        (idx + 1).to_string(),
+                        step.from_asset.display_name(),
+                        step.to_asset.display_name(),
+                        step.price.clone(),
+                        step.source.clone(),
+                    ]
+                })
+                .collect::<Vec<_>>();
+
+            let steps = format_table(&["step", "from", "to", "price", "source"], rows);
+            Ok(format!("{}\n\nroute\n{}", summary, steps))
+        }
+        OutputFormat::Json => serde_json::to_string_pretty(response).map_err(Into::into),
+    }
+}
+
+fn format_orderbook(
+    response: &OrderbookResponse,
+    output: OutputFormat,
+) -> Result<String, SdkError> {
+    match output {
+        OutputFormat::Human => {
+            let mut lines = vec![
+                format!(
+                    "pair: {} / {}",
+                    response.base_asset.display_name(),
+                    response.quote_asset.display_name()
+                ),
+                format!("timestamp: {}", response.timestamp),
+                "asks:".to_string(),
+            ];
+
+            for level in &response.asks {
+                lines.push(format!(
+                    "  price={} amount={} total={}",
+                    level.price, level.amount, level.total
+                ));
+            }
+
+            lines.push("bids:".to_string());
+            for level in &response.bids {
+                lines.push(format!(
+                    "  price={} amount={} total={}",
+                    level.price, level.amount, level.total
+                ));
+            }
+
+            Ok(lines.join("\n"))
+        }
+        OutputFormat::Table => {
+            let asks_rows = response.asks.iter().map(level_to_row).collect::<Vec<_>>();
+            let bids_rows = response.bids.iter().map(level_to_row).collect::<Vec<_>>();
+
+            Ok(format!(
+                "pair: {} / {}\ntimestamp: {}\n\nasks\n{}\n\nbids\n{}",
+                response.base_asset.display_name(),
+                response.quote_asset.display_name(),
+                response.timestamp,
+                format_table(&["price", "amount", "total"], asks_rows),
+                format_table(&["price", "amount", "total"], bids_rows)
+            ))
+        }
+        OutputFormat::Json => serde_json::to_string_pretty(response).map_err(Into::into),
+    }
+}
+
+fn level_to_row(level: &OrderbookLevel) -> Vec<String> {
+    vec![
+        level.price.clone(),
+        level.amount.clone(),
+        level.total.clone(),
+    ]
+}
+
+fn format_table(headers: &[&str], rows: Vec<Vec<String>>) -> String {
+    let mut widths = headers
+        .iter()
+        .map(|header| header.len())
+        .collect::<Vec<_>>();
+
+    for row in &rows {
+        for (idx, cell) in row.iter().enumerate() {
+            if idx >= widths.len() {
+                widths.push(cell.len());
+            } else {
+                widths[idx] = widths[idx].max(cell.len());
+            }
+        }
+    }
+
+    let header_line = headers
+        .iter()
+        .enumerate()
+        .map(|(idx, header)| format!("{header:<width$}", width = widths[idx]))
+        .collect::<Vec<_>>()
+        .join(" | ")
+        .trim_end()
+        .to_string();
+
+    let separator = widths
+        .iter()
+        .map(|width| "-".repeat(*width))
+        .collect::<Vec<_>>()
+        .join("-+-");
+
+    let row_lines = rows
+        .iter()
+        .map(|row| {
+            widths
+                .iter()
+                .enumerate()
+                .map(|(idx, width)| {
+                    let cell = row.get(idx).cloned().unwrap_or_default();
+                    format!("{cell:<width$}", width = *width)
+                })
+                .collect::<Vec<_>>()
+                .join(" | ")
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>();
+
+    if row_lines.is_empty() {
+        format!("{}\n{}", header_line, separator)
+    } else {
+        format!("{}\n{}\n{}", header_line, separator, row_lines.join("\n"))
+    }
+}
+
+fn exit_code_for_sdk_error(error: &SdkError) -> i32 {
+    match error {
+        SdkError::InvalidConfig(_) => EXIT_CONFIG_ERROR,
+        SdkError::Http(_) | SdkError::Api(_) | SdkError::Serialization(_) => EXIT_RUNTIME_ERROR,
+    }
 }
 
 fn parse_asset(value: &str) -> Result<String, String> {
@@ -312,6 +641,7 @@ fn parse_asset(value: &str) -> Result<String, String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use stellarroute_sdk::{AssetInfo, PathStep, TradingPair};
 
     #[test]
     fn clap_help_is_well_formed() {
@@ -367,5 +697,176 @@ mod tests {
                 .expect_err("asset should fail");
 
         assert_eq!(error.kind(), clap::error::ErrorKind::ValueValidation);
+    }
+
+    #[test]
+    fn rejects_invalid_output_format_explicitly() {
+        let error = Cli::try_parse_from(["stellarroute", "--output", "xml", "health"])
+            .expect_err("output format should fail");
+
+        assert_eq!(error.kind(), clap::error::ErrorKind::InvalidValue);
+        let message = error.to_string();
+        assert!(message.contains("json"));
+        assert!(message.contains("table"));
+        assert!(message.contains("human"));
+    }
+
+    #[test]
+    fn snapshot_pairs_output_human() {
+        let rendered = format_pairs(&sample_pairs_response(), 2, OutputFormat::Human)
+            .expect("formatting should succeed");
+        insta::assert_snapshot!(rendered, @r###"
+total pairs: 2
+XLM / USDC | offers: 12 | canonical: native / USDC:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
+XLM / EURC | offers: 4 | canonical: native / EURC:GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBW7
+"###);
+    }
+
+    #[test]
+    fn snapshot_pairs_output_table() {
+        let rendered = normalize_for_snapshot(
+            &format_pairs(&sample_pairs_response(), 2, OutputFormat::Table)
+                .expect("formatting should succeed"),
+        );
+        insta::assert_snapshot!(rendered, @r###"
+total pairs: 2
+showing: 2
+
+base | counter | offers | base_asset | counter_asset
+<sep>
+XLM  | USDC    | 12     | native     | USDC:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF
+XLM  | EURC    | 4      | native     | EURC:GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBW7
+"###);
+    }
+
+    #[test]
+    fn snapshot_pairs_output_json() {
+        let rendered = format_pairs(&sample_pairs_response(), 1, OutputFormat::Json)
+            .expect("formatting should succeed");
+        insta::assert_snapshot!(rendered, @r###"
+{
+  "total": 2,
+  "showing": 1,
+  "pairs": [
+    {
+      "base": "XLM",
+      "counter": "USDC",
+      "base_asset": "native",
+      "counter_asset": "USDC:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF",
+      "offer_count": 12,
+      "last_updated": null
+    }
+  ]
+}
+"###);
+    }
+
+    #[test]
+    fn snapshot_quote_output_table() {
+        let rendered = normalize_for_snapshot(
+            &format_quote(&sample_quote_response(), OutputFormat::Table)
+                .expect("formatting should succeed"),
+        );
+        insta::assert_snapshot!(rendered, @r###"
+field      | value
+<sep>
+pair       | native / USDC
+amount     | 10.0000000
+quote_type | sell
+price      | 0.1050000
+total      | 1.0500000
+
+route
+step | from   | to   | price     | source
+<sep>
+1    | native | USDC | 0.1050000 | sdex
+"###);
+    }
+
+    #[test]
+    fn exit_code_mapping_is_stable() {
+        assert_eq!(
+            exit_code_for_sdk_error(&SdkError::InvalidConfig("bad url".to_string())),
+            EXIT_CONFIG_ERROR
+        );
+        assert_eq!(
+            exit_code_for_sdk_error(&SdkError::Api("api error".to_string())),
+            EXIT_RUNTIME_ERROR
+        );
+    }
+
+    fn sample_pairs_response() -> PairsResponse {
+        PairsResponse {
+            total: 2,
+            pairs: vec![
+                TradingPair {
+                    base: "XLM".to_string(),
+                    counter: "USDC".to_string(),
+                    base_asset: "native".to_string(),
+                    counter_asset: "USDC:GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF"
+                        .to_string(),
+                    offer_count: 12,
+                    last_updated: None,
+                },
+                TradingPair {
+                    base: "XLM".to_string(),
+                    counter: "EURC".to_string(),
+                    base_asset: "native".to_string(),
+                    counter_asset: "EURC:GBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBW7"
+                        .to_string(),
+                    offer_count: 4,
+                    last_updated: None,
+                },
+            ],
+        }
+    }
+
+    fn sample_quote_response() -> QuoteResponse {
+        QuoteResponse {
+            base_asset: AssetInfo {
+                asset_type: "native".to_string(),
+                asset_code: None,
+                asset_issuer: None,
+            },
+            quote_asset: AssetInfo {
+                asset_type: "credit_alphanum4".to_string(),
+                asset_code: Some("USDC".to_string()),
+                asset_issuer: None,
+            },
+            amount: "10.0000000".to_string(),
+            price: "0.1050000".to_string(),
+            total: "1.0500000".to_string(),
+            quote_type: "sell".to_string(),
+            path: vec![PathStep {
+                from_asset: AssetInfo {
+                    asset_type: "native".to_string(),
+                    asset_code: None,
+                    asset_issuer: None,
+                },
+                to_asset: AssetInfo {
+                    asset_type: "credit_alphanum4".to_string(),
+                    asset_code: Some("USDC".to_string()),
+                    asset_issuer: None,
+                },
+                price: "0.1050000".to_string(),
+                source: "sdex".to_string(),
+            }],
+            timestamp: 1_742_908_400,
+        }
+    }
+
+    fn normalize_for_snapshot(value: &str) -> String {
+        value
+            .lines()
+            .map(|line| {
+                let line = line.trim_end();
+                if !line.is_empty() && line.chars().all(|ch| ch == '-' || ch == '+') {
+                    "<sep>".to_string()
+                } else {
+                    line.to_string()
+                }
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
     }
 }


### PR DESCRIPTION
Closes #104

## Summary

This PR updates the `stellarroute` Rust CLI to support script-friendly output modes and deterministic process exit behavior.

### Changes

- Added global `--output` flag with supported values:
  - `json`
  - `table`
  - `human` (default)
- Made invalid format handling explicit via `clap` value validation.
- Added stable, documented exit code mapping:
  - `0` = success
  - `2` = CLI usage/validation error
  - `3` = invalid client configuration
  - `4` = runtime/API/serialization error
- Added snapshot tests for output rendering paths.
- Added SDK CLI README documenting output formats and exit codes.

## Acceptance Criteria Mapping

- [x] `--output` supports `json/table/human`
- [x] Exit codes are documented and consistent
- [x] Invalid format handling is explicit
- [x] Snapshot tests verify output rendering

## Testing

Commands run:

```bash
cargo fmt -p stellarroute-sdk -- --check
cargo test -p stellarroute-sdk
```

Result:

- Formatting check passes for `stellarroute-sdk`.
- All `stellarroute-sdk` tests pass, including output snapshot tests.

## Scope

Changes are limited to:

- `crates/sdk-rust/src/bin/stellarroute.rs`
- `crates/sdk-rust/Cargo.toml`
- `crates/sdk-rust/README.md`
