### PR TITLE
refactor: centralize swap validation with a shared schema

### DIFF
--- a/frontend/components/DemoSwap.tsx
+++ b/frontend/components/DemoSwap.tsx
@@ -26,10 +26,10 @@ import { TransactionStatus } from "@/types/transaction";
 import {
   formatMaxAmountForInput,
   maxDecimalsForSellAsset,
-  parseSellAmount,
 } from "@/lib/amount-input";
 import { QUOTE_AUTO_REFRESH_INTERVAL_MS } from "@/lib/quote-stale";
 import { TradeRouteDisplay } from "@/components/shared/TradeRouteDisplay";
+import { SwapValidationSchema } from "@/lib/swap-validation";
 
 const MOCK_WALLET = "GBSU...XYZ9";
 
@@ -90,10 +90,30 @@ export function DemoSwap() {
     )
     : maxDecimalsForSellAsset("native");
 
-  const parseResult = parseSellAmount(sellRaw, sellMaxDecimals);
+  const inputValidation = SwapValidationSchema.validate(
+    {
+      amount: sellRaw,
+      maxDecimals: sellMaxDecimals,
+      sellAssetId: selectedPair?.base_asset,
+      buyAssetId: selectedPair?.counter_asset,
+      slippage,
+    },
+    { mode: "input" },
+  );
+  const submitValidation = SwapValidationSchema.validate(
+    {
+      amount: sellRaw,
+      maxDecimals: sellMaxDecimals,
+      sellAssetId: selectedPair?.base_asset,
+      buyAssetId: selectedPair?.counter_asset,
+      slippage,
+    },
+    { mode: "submit" },
+  );
 
-  const numericForQuote =
-    parseResult.status === "ok" ? parseResult.numeric : undefined;
+  const parseResult = inputValidation.amountResult;
+
+  const numericForQuote = inputValidation.parsed.amount?.numeric;
 
   const quoteBase = selectedPair?.base_asset ?? "";
   const quoteCounter = selectedPair?.counter_asset ?? "";
@@ -127,13 +147,8 @@ export function DemoSwap() {
 
 
   const handleSwapClick = () => {
-    if (parseResult.status !== "ok" || !selectedPair) {
-      toast.error("Enter a valid sell amount and select a pair.");
-      return;
-    }
-
-    if (slippage === null || slippage < 0 || slippage > 50) {
-      toast.error("Enter a valid slippage tolerance between 0% and 50%.");
+    if (!submitValidation.isValid) {
+      toast.error(submitValidation.issues[0]?.message ?? "Invalid swap inputs.");
       return;
     }
 
@@ -227,10 +242,8 @@ export function DemoSwap() {
   const priceImpactDisplay =
     quote?.priceImpact != null ? `${quote.priceImpact}%` : "—";
 
-  const slippageTooLow = slippage !== null && slippage < 0.1;
-  const slippageTooHigh = slippage !== null && slippage > 1;
-  const slippageOutOfBounds =
-    slippage !== null && (slippage < 0 || slippage > 50);
+  const slippageWarning = inputValidation.warnings.slippage;
+  const slippageError = inputValidation.fieldErrors.slippage;
 
   return (
     <Card className="mx-auto mt-8 max-w-lg border-primary/20 bg-background/50 p-6 shadow-lg backdrop-blur-sm">
@@ -414,22 +427,14 @@ export function DemoSwap() {
               <span className="text-sm">%</span>
             </div>
 
-            {slippageOutOfBounds && (
+            {slippageError && (
               <p className="text-xs text-destructive">
-                Enter a slippage value between 0% and 50%.
+                {slippageError}
               </p>
             )}
 
-            {!slippageOutOfBounds && slippageTooLow && (
-              <p className="text-xs text-yellow-500">
-                Very low slippage may cause the swap to fail.
-              </p>
-            )}
-
-            {!slippageOutOfBounds && slippageTooHigh && (
-              <p className="text-xs text-yellow-500">
-                High slippage increases the risk of receiving a worse price.
-              </p>
+            {!slippageError && slippageWarning && (
+              <p className="text-xs text-yellow-500">{slippageWarning}</p>
             )}
           </div>
 
@@ -474,10 +479,7 @@ export function DemoSwap() {
           className="h-12 w-full text-lg"
           onClick={handleSwapClick}
           disabled={
-            !selectedPair ||
-            parseResult.status !== "ok" ||
-            slippage === null ||
-            slippageOutOfBounds
+            !submitValidation.isValid
           }
         >
           Review Swap

--- a/frontend/components/shared/TransactionConfirmationModal.tsx
+++ b/frontend/components/shared/TransactionConfirmationModal.tsx
@@ -27,6 +27,7 @@ import {
 import { Badge } from "@/components/ui/badge";
 import { getAssetCode, parseSource } from "@/lib/route-helpers";
 import { cn } from "@/lib/utils";
+import { getSlippageWarningLevel } from "@/lib/slippage";
 
 interface TransactionConfirmationModalProps {
   isOpen: boolean;
@@ -83,8 +84,11 @@ export function TransactionConfirmationModal({
   const isHighPriceImpact = priceImpactValue >= 2;
   const isSeverePriceImpact = priceImpactValue >= 5;
 
-  const isHighSlippage = (slippageTolerancePct || 0) > 1;
-  const isLowSlippage = slippageTolerancePct !== undefined && slippageTolerancePct < 0.1;
+  const slippageWarningLevel = getSlippageWarningLevel(
+    slippageTolerancePct ?? null,
+  );
+  const isHighSlippage = slippageWarningLevel === "high";
+  const isLowSlippage = slippageWarningLevel === "low";
 
   const computedMinReceived = useMemo(() => {
     const toAmountN = parseMaybeNumber(toAmount);

--- a/frontend/components/swap/SwapCTA.tsx
+++ b/frontend/components/swap/SwapCTA.tsx
@@ -2,25 +2,34 @@
 
 import { Button } from "@/components/ui/button";
 import { Loader2 } from "lucide-react";
+import type { SwapValidationResult } from "@/lib/swap-validation";
 
 interface SwapCTAProps {
-  amount: string;
+  validation: SwapValidationResult;
   isLoading: boolean;
-  hasPair: boolean;
   onSwap: () => void;
 }
 
-export function SwapCTA({ amount, isLoading, hasPair, onSwap }: SwapCTAProps) {
-  const numAmount = parseFloat(amount || "0");
-
+export function SwapCTA({ validation, isLoading, onSwap }: SwapCTAProps) {
   let label = "Review Swap";
   let disabled = false;
 
-  if (!hasPair) {
+  const hasPairIssue = validation.issues.some((issue) => issue.field === "pair");
+  const hasAmountIssue = validation.issues.some(
+    (issue) => issue.field === "amount",
+  );
+  const hasSlippageIssue = validation.issues.some(
+    (issue) => issue.field === "slippage",
+  );
+
+  if (hasPairIssue) {
     label = "Select tokens";
     disabled = true;
-  } else if (!amount || isNaN(numAmount) || numAmount <= 0) {
+  } else if (hasAmountIssue) {
     label = "Enter amount";
+    disabled = true;
+  } else if (hasSlippageIssue) {
+    label = "Invalid slippage";
     disabled = true;
   } else if (isLoading) {
     label = "Loading quote...";

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -12,6 +12,8 @@ import { SimulationPanel } from './SimulationPanel';
 import { FeeBreakdownPanel } from './FeeBreakdownPanel';
 import { useTradeFormStorage } from '@/hooks/useTradeFormStorage';
 import { useState } from 'react';
+import { STELLAR_NATIVE_MAX_DECIMALS } from '@/lib/amount-input';
+import { SwapValidationSchema } from '@/lib/swap-validation';
 
 export function SwapCard() {
   const {
@@ -28,8 +30,15 @@ export function SwapCard() {
   const [confidenceScore, setConfidenceScore] = useState<number>(85);
   const [volatility, setVolatility] = useState<'high' | 'medium' | 'low'>('low');
 
-  // Derived state for the button
-  const isValidAmount = parseFloat(payAmount) > 0;
+  const validation = SwapValidationSchema.validate(
+    {
+      amount: payAmount,
+      maxDecimals: STELLAR_NATIVE_MAX_DECIMALS,
+      slippage,
+    },
+    { mode: 'submit', requirePair: false },
+  );
+  const isValidAmount = validation.amountResult.status === 'ok';
 
   // Simulate quote fetching with confidence and volatility
   const handlePayAmountChange = (amount: string) => {
@@ -133,9 +142,8 @@ export function SwapCard() {
           </>
         )}
         <SwapCTA
-          amount={payAmount}
+          validation={validation}
           isLoading={isLoading}
-          hasPair={true}
           onSwap={() => console.log('Swapping...')}
         />
       </CardContent>

--- a/frontend/components/swap/SwapWithPairSelector.tsx
+++ b/frontend/components/swap/SwapWithPairSelector.tsx
@@ -8,6 +8,8 @@ import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
+import { maxDecimalsForSellAsset } from "@/lib/amount-input";
+import { SwapValidationSchema } from "@/lib/swap-validation";
 
 /**
  * Example component showing TokenPairSelector integrated with a swap form.
@@ -40,6 +42,40 @@ export function SwapWithPairSelector() {
   const selectedPair = pairs.find(
     (p) => p.base_asset === base && p.counter_asset === quote
   );
+  const maxDecimals = selectedPair
+    ? maxDecimalsForSellAsset(selectedPair.base_asset, selectedPair.base_decimals)
+    : undefined;
+  const inputValidation = selectedPair
+    ? SwapValidationSchema.validate(
+      {
+        amount,
+        maxDecimals,
+        sellAssetId: selectedPair.base_asset,
+        buyAssetId: selectedPair.counter_asset,
+        slippage: 0.5,
+      },
+      { mode: "input" },
+    )
+    : null;
+  const submitValidation = selectedPair
+    ? SwapValidationSchema.validate(
+      {
+        amount,
+        maxDecimals,
+        sellAssetId: selectedPair.base_asset,
+        buyAssetId: selectedPair.counter_asset,
+        slippage: 0.5,
+      },
+      { mode: "submit" },
+    )
+    : null;
+  const amountError =
+    amount.trim() !== "" &&
+    inputValidation &&
+    inputValidation.amountResult.status !== "ok" &&
+    inputValidation.amountResult.status !== "empty"
+      ? inputValidation.amountResult.message
+      : null;
 
   return (
     <div className="space-y-4 max-w-lg mx-auto">
@@ -72,7 +108,11 @@ export function SwapWithPairSelector() {
                 value={amount}
                 onChange={(e) => setAmount(e.target.value)}
                 className="text-lg"
+                aria-invalid={!!amountError}
               />
+              {amountError && (
+                <p className="mt-2 text-xs text-destructive">{amountError}</p>
+              )}
             </div>
 
             <div className="rounded-lg bg-muted/50 p-4">
@@ -87,7 +127,11 @@ export function SwapWithPairSelector() {
               </p>
             </div>
 
-            <Button className="w-full" size="lg" disabled={!amount || isNaN(Number(amount))}>
+            <Button
+              className="w-full"
+              size="lg"
+              disabled={!submitValidation?.isValid}
+            >
               Review Swap
             </Button>
           </div>

--- a/frontend/lib/slippage.test.ts
+++ b/frontend/lib/slippage.test.ts
@@ -3,6 +3,7 @@ import {
   parseSlippageInput,
   isValidSlippage,
   getSlippageWarning,
+  getSlippageWarningLevel,
 } from "./slippage";
 
 describe("Slippage Utils", () => {
@@ -34,5 +35,11 @@ describe("Slippage Utils", () => {
 
   it("detects normal slippage", () => {
     expect(getSlippageWarning(0.5)).toBeNull();
+  });
+
+  it("reports warning levels", () => {
+    expect(getSlippageWarningLevel(0.05)).toBe("low");
+    expect(getSlippageWarningLevel(5)).toBe("high");
+    expect(getSlippageWarningLevel(0.5)).toBeNull();
   });
 });

--- a/frontend/lib/slippage.ts
+++ b/frontend/lib/slippage.ts
@@ -3,6 +3,9 @@ export const SLIPPAGE_PRESETS = [0.1, 0.5, 1];
 export const MIN_SLIPPAGE = 0;
 export const MAX_SLIPPAGE = 50;
 
+export const LOW_SLIPPAGE_WARNING_THRESHOLD = 0.1;
+export const HIGH_SLIPPAGE_WARNING_THRESHOLD = 1;
+
 export function parseSlippageInput(value: string): number | null {
   if (value.trim() === "") return null;
 
@@ -20,12 +23,28 @@ export function isValidSlippage(value: number): boolean {
 export function getSlippageWarning(value: number | null): string | null {
   if (value === null) return null;
 
-  if (value < 0.1) {
+  if (value < LOW_SLIPPAGE_WARNING_THRESHOLD) {
     return "Very low slippage may cause the swap to fail.";
   }
 
-  if (value > 1) {
+  if (value > HIGH_SLIPPAGE_WARNING_THRESHOLD) {
     return "High slippage increases the risk of receiving a worse price.";
+  }
+
+  return null;
+}
+
+export function getSlippageWarningLevel(
+  value: number | null,
+): "low" | "high" | null {
+  if (value === null) return null;
+
+  if (value < LOW_SLIPPAGE_WARNING_THRESHOLD) {
+    return "low";
+  }
+
+  if (value > HIGH_SLIPPAGE_WARNING_THRESHOLD) {
+    return "high";
   }
 
   return null;

--- a/frontend/lib/swap-validation.test.ts
+++ b/frontend/lib/swap-validation.test.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect } from "vitest";
+import { SwapValidationSchema, SWAP_VALIDATION_MESSAGES } from "./swap-validation";
+
+const BASE = "native";
+const COUNTER = "USDC:GA5Z...";
+
+describe("SwapValidationSchema", () => {
+  it("accepts valid inputs", () => {
+    const result = SwapValidationSchema.validate({
+      amount: "12.5",
+      maxDecimals: 7,
+      sellAssetId: BASE,
+      buyAssetId: COUNTER,
+      slippage: 0.5,
+    });
+
+    expect(result.isValid).toBe(true);
+    expect(result.parsed.amount?.numeric).toBe(12.5);
+    expect(result.fieldErrors.amount).toBeUndefined();
+    expect(result.fieldErrors.pair).toBeUndefined();
+    expect(result.fieldErrors.slippage).toBeUndefined();
+  });
+
+  it("requires amount on submit", () => {
+    const result = SwapValidationSchema.validate(
+      {
+        amount: "",
+        maxDecimals: 7,
+        sellAssetId: BASE,
+        buyAssetId: COUNTER,
+        slippage: 0.5,
+      },
+      { mode: "submit" },
+    );
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.amount).toBe(SWAP_VALIDATION_MESSAGES.amountRequired);
+  });
+
+  it("allows empty amount during input", () => {
+    const result = SwapValidationSchema.validate(
+      {
+        amount: "",
+        maxDecimals: 7,
+        sellAssetId: BASE,
+        buyAssetId: COUNTER,
+        slippage: 0.5,
+      },
+      { mode: "input" },
+    );
+
+    expect(result.fieldErrors.amount).toBeUndefined();
+  });
+
+  it("flags invalid amounts", () => {
+    const cases = ["abc", "1.2.3", "1e7", "-1", "0"];
+    
+    cases.forEach(amount => {
+      const result = SwapValidationSchema.validate({
+        amount,
+        maxDecimals: 7,
+        sellAssetId: BASE,
+        buyAssetId: COUNTER,
+        slippage: 0.5,
+      });
+
+      expect(result.isValid).toBe(false);
+      expect(result.fieldErrors.amount).toBeDefined();
+    });
+  });
+
+  it("flags precision-exceeded amounts", () => {
+    const result = SwapValidationSchema.validate({
+      amount: "1.123456789",
+      maxDecimals: 7,
+      sellAssetId: BASE,
+      buyAssetId: COUNTER,
+      slippage: 0.5,
+    });
+
+    expect(result.isValid).toBe(false);
+    expect(result.fieldErrors.amount).toBe(SWAP_VALIDATION_MESSAGES.amountPrecision(7));
+  });
+
+  it("validates the asset pair", () => {
+    const missing = SwapValidationSchema.validate({
+      amount: "1",
+      maxDecimals: 7,
+      sellAssetId: "",
+      buyAssetId: "",
+      slippage: 0.5,
+    });
+
+    expect(missing.fieldErrors.pair).toBe(SWAP_VALIDATION_MESSAGES.pairRequired);
+
+    const same = SwapValidationSchema.validate({
+      amount: "1",
+      maxDecimals: 7,
+      sellAssetId: BASE,
+      buyAssetId: BASE,
+      slippage: 0.5,
+    });
+
+    expect(same.fieldErrors.pair).toBe(SWAP_VALIDATION_MESSAGES.pairSame);
+  });
+
+  it("validates slippage bounds and warnings", () => {
+    const missing = SwapValidationSchema.validate(
+      {
+        amount: "1",
+        maxDecimals: 7,
+        sellAssetId: BASE,
+        buyAssetId: COUNTER,
+        slippage: null,
+      },
+      { mode: "submit" },
+    );
+
+    expect(missing.fieldErrors.slippage).toBe(
+      SWAP_VALIDATION_MESSAGES.slippageRequired,
+    );
+
+    const outOfRange = SwapValidationSchema.validate({
+      amount: "1",
+      maxDecimals: 7,
+      sellAssetId: BASE,
+      buyAssetId: COUNTER,
+      slippage: 51,
+    });
+
+    expect(outOfRange.fieldErrors.slippage).toBe(
+      SWAP_VALIDATION_MESSAGES.slippageInvalid,
+    );
+
+    const negative = SwapValidationSchema.validate({
+      amount: "1",
+      maxDecimals: 7,
+      sellAssetId: BASE,
+      buyAssetId: COUNTER,
+      slippage: -1,
+    });
+
+    expect(negative.fieldErrors.slippage).toBe(
+      SWAP_VALIDATION_MESSAGES.slippageInvalid,
+    );
+  });
+
+  it("handles edge cases for slippage", () => {
+    // 0 is valid
+    const zero = SwapValidationSchema.validate({
+      amount: "1",
+      maxDecimals: 7,
+      sellAssetId: BASE,
+      buyAssetId: COUNTER,
+      slippage: 0,
+    });
+    expect(zero.isValid).toBe(true);
+
+    // 50 is valid
+    const fifty = SwapValidationSchema.validate({
+      amount: "1",
+      maxDecimals: 7,
+      sellAssetId: BASE,
+      buyAssetId: COUNTER,
+      slippage: 50,
+    });
+    expect(fifty.isValid).toBe(true);
+    
+    // NaN should be handled
+    const nan = SwapValidationSchema.validate({
+      amount: "1",
+      maxDecimals: 7,
+      sellAssetId: BASE,
+      buyAssetId: COUNTER,
+      slippage: NaN,
+    }, { mode: "submit" });
+    expect(nan.fieldErrors.slippage).toBe(SWAP_VALIDATION_MESSAGES.slippageRequired);
+  });
+
+  it("can skip pair validation when configured", () => {
+    const result = SwapValidationSchema.validate(
+      {
+        amount: "1",
+        maxDecimals: 7,
+        sellAssetId: "",
+        buyAssetId: "",
+        slippage: 0.5,
+      },
+      { requirePair: false },
+    );
+
+    expect(result.fieldErrors.pair).toBeUndefined();
+  });
+
+  it("supports future extension via additional input fields", () => {
+    const result = SwapValidationSchema.validate({
+      amount: "1",
+      sellAssetId: BASE,
+      buyAssetId: COUNTER,
+      slippage: 0.5,
+      newField: "some value"
+    } as any);
+
+    expect(result.isValid).toBe(true);
+  });
+});

--- a/frontend/lib/swap-validation.ts
+++ b/frontend/lib/swap-validation.ts
@@ -1,0 +1,197 @@
+import type { ParseSellAmountResult } from "./amount-input";
+import {
+  DEFAULT_ISSUED_MAX_DECIMALS,
+  parseSellAmount,
+} from "./amount-input";
+import {
+  getSlippageWarning,
+  isValidSlippage,
+  MAX_SLIPPAGE,
+  MIN_SLIPPAGE,
+} from "./slippage";
+
+export type SwapValidationField = "amount" | "pair" | "slippage" | string;
+
+export interface SwapValidationIssue {
+  field: SwapValidationField;
+  code: string;
+  message: string;
+}
+
+export interface SwapValidationInput {
+  amount: string;
+  maxDecimals?: number;
+  sellAssetId?: string | null;
+  buyAssetId?: string | null;
+  slippage: number | null;
+  [key: string]: any; // Allow for future extension
+}
+
+export interface SwapValidationOptions {
+  /**
+   * In `input` mode, empty values are allowed without errors.
+   * In `submit` mode, required fields must be present.
+   */
+  mode?: "input" | "submit";
+  /**
+   * When false, asset pair validation is skipped (useful for demo-only UIs).
+   */
+  requirePair?: boolean;
+}
+
+export interface SwapValidationResult {
+  isValid: boolean;
+  /**
+   * Issues are additive so new fields can be introduced without
+   * breaking existing consumers that only check known keys.
+   */
+  issues: SwapValidationIssue[];
+  fieldErrors: Partial<Record<SwapValidationField, string>>;
+  warnings: Partial<Record<SwapValidationField, string>>;
+  amountResult: ParseSellAmountResult;
+  parsed: {
+    amount?: { normalized: string; numeric: number };
+    slippage?: number;
+    [key: string]: any;
+  };
+}
+
+export const SWAP_VALIDATION_MESSAGES = {
+  amountRequired: "Enter an amount.",
+  amountInvalid: "Enter a valid amount.",
+  amountPrecision: (max: number) => `Maximum ${max} decimal places for this asset.`,
+  pairRequired: "Select tokens.",
+  pairSame: "Select two different assets.",
+  slippageRequired: "Enter a slippage value.",
+  slippageInvalid: `Enter a slippage value between ${MIN_SLIPPAGE}% and ${MAX_SLIPPAGE}%.`,
+} as const;
+
+function resolveMaxDecimals(maxDecimals?: number): number {
+  if (
+    typeof maxDecimals === "number" &&
+    Number.isInteger(maxDecimals) &&
+    maxDecimals >= 0
+  ) {
+    return maxDecimals;
+  }
+  return DEFAULT_ISSUED_MAX_DECIMALS;
+}
+
+/**
+ * Shared validation schema for swap inputs.
+ * Centralizes validation logic for amount, asset pair, and slippage.
+ */
+export const SwapValidationSchema = {
+  validate: (
+    input: SwapValidationInput,
+    options: SwapValidationOptions = {},
+  ): SwapValidationResult => {
+    const mode = options.mode ?? "submit";
+    const requirePair = options.requirePair ?? true;
+
+    const issues: SwapValidationIssue[] = [];
+    const fieldErrors: Partial<Record<SwapValidationField, string>> = {};
+    const warnings: Partial<Record<SwapValidationField, string>> = {};
+    const parsed: SwapValidationResult["parsed"] = {};
+
+    const addIssue = (issue: SwapValidationIssue) => {
+      issues.push(issue);
+      if (!fieldErrors[issue.field]) {
+        fieldErrors[issue.field] = issue.message;
+      }
+    };
+
+    // 1. Pair Validation
+    if (requirePair) {
+      const sellAssetId = input.sellAssetId ?? "";
+      const buyAssetId = input.buyAssetId ?? "";
+      if (!sellAssetId || !buyAssetId) {
+        addIssue({
+          field: "pair",
+          code: "pair_missing",
+          message: SWAP_VALIDATION_MESSAGES.pairRequired,
+        });
+      } else if (sellAssetId === buyAssetId) {
+        addIssue({
+          field: "pair",
+          code: "pair_same",
+          message: SWAP_VALIDATION_MESSAGES.pairSame,
+        });
+      }
+    }
+
+    // 2. Amount Validation
+    const maxDecimals = resolveMaxDecimals(input.maxDecimals);
+    const amountResult = parseSellAmount(input.amount ?? "", maxDecimals);
+
+    if (amountResult.status === "empty") {
+      if (mode === "submit") {
+        addIssue({
+          field: "amount",
+          code: "amount_empty",
+          message: SWAP_VALIDATION_MESSAGES.amountRequired,
+        });
+      }
+    } else if (amountResult.status === "invalid") {
+      addIssue({
+        field: "amount",
+        code: "amount_invalid",
+        message: amountResult.message || SWAP_VALIDATION_MESSAGES.amountInvalid,
+      });
+    } else if (amountResult.status === "precision_exceeded") {
+      addIssue({
+        field: "amount",
+        code: "amount_precision",
+        message: amountResult.message || SWAP_VALIDATION_MESSAGES.amountPrecision(maxDecimals),
+      });
+    } else if (amountResult.status === "ok") {
+      parsed.amount = {
+        normalized: amountResult.normalized,
+        numeric: amountResult.numeric,
+      };
+    }
+
+    // 3. Slippage Validation
+    if (input.slippage === null || typeof input.slippage === "undefined" || Number.isNaN(input.slippage)) {
+      if (mode === "submit") {
+        addIssue({
+          field: "slippage",
+          code: "slippage_missing",
+          message: SWAP_VALIDATION_MESSAGES.slippageRequired,
+        });
+      }
+    } else if (!isValidSlippage(input.slippage)) {
+      addIssue({
+        field: "slippage",
+        code: "slippage_out_of_range",
+        message: SWAP_VALIDATION_MESSAGES.slippageInvalid,
+      });
+    } else {
+      parsed.slippage = input.slippage;
+      const warning = getSlippageWarning(input.slippage);
+      if (warning) {
+        warnings.slippage = warning;
+      }
+    }
+
+    return {
+      isValid: issues.length === 0,
+      issues,
+      fieldErrors,
+      warnings,
+      amountResult,
+      parsed,
+    };
+  },
+};
+
+/**
+ * Legacy wrapper for the schema-based validation.
+ * @deprecated Use SwapValidationSchema.validate instead.
+ */
+export function validateSwapInputs(
+  input: SwapValidationInput,
+  options: SwapValidationOptions = {},
+): SwapValidationResult {
+  return SwapValidationSchema.validate(input, options);
+}

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -2556,23 +2556,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@playwright/test": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
-      "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "playwright": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/number/-/number-1.1.1.tgz",
@@ -11143,55 +11126,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.20.0"
-      }
-    },
-    "node_modules/playwright": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
-      "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "playwright-core": "1.58.2"
-      },
-      "bin": {
-        "playwright": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "fsevents": "2.3.2"
-      }
-    },
-    "node_modules/playwright-core": {
-      "version": "1.58.2",
-      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
-      "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
-      "license": "Apache-2.0",
-      "optional": true,
-      "peer": true,
-      "bin": {
-        "playwright-core": "cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/playwright/node_modules/fsevents": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
-      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
-      "hasInstallScript": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "peer": true,
-      "engines": {
-        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/frontend/vitest.setup.ts
+++ b/frontend/vitest.setup.ts
@@ -16,3 +16,34 @@ Object.defineProperty(window, "matchMedia", {
     dispatchEvent: vi.fn(() => false),
   }),
 });
+
+// Ensure localStorage is available in the test environment.
+if (
+  typeof window.localStorage === "undefined" ||
+  typeof window.localStorage.getItem !== "function"
+) {
+  const localStorageMock = (() => {
+    let store: Record<string, string> = {};
+    return {
+      getItem: (key: string) => (key in store ? store[key] : null),
+      setItem: (key: string, value: string) => {
+        store[key] = String(value);
+      },
+      removeItem: (key: string) => {
+        delete store[key];
+      },
+      clear: () => {
+        store = {};
+      },
+    };
+  })();
+
+  Object.defineProperty(window, "localStorage", {
+    value: localStorageMock,
+    configurable: true,
+  });
+  Object.defineProperty(globalThis, "localStorage", {
+    value: localStorageMock,
+    configurable: true,
+  });
+}


### PR DESCRIPTION
closes #211 

---

- Implement SwapValidationSchema in lib/swap-validation.ts to unify amount, pair, and slippage logic.
- Standardize error messages in SWAP_VALIDATION_MESSAGES for consistency across components.
- Refactor SwapCard, SwapWithPairSelector, and DemoSwap to use the new schema.
- Update slippage utilities to support warning levels (low/high).
- Expand test suite to cover NaN, out-of-bounds, and future extensibility.
-

