### PR TITLE
[frontend] Export quote summary as JSON or CSV for power users

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,6 +47,24 @@ jobs:
       - name: Run tests
         run: cd frontend && NODE_OPTIONS=--max-old-space-size=8192 npm test -- --maxWorkers=1 --exclude hooks/useQuoteRefresh.test.ts
 
+  frontend-visual-regression:
+    name: Frontend Visual Regression
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "npm"
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: cd frontend && npm ci --legacy-peer-deps
+      - name: Install Playwright browsers
+        run: cd frontend && npx playwright install --with-deps chromium
+      - name: Run visual regression
+        run: cd frontend && npm run test:visual
+
   sdk-checks:
     name: JS SDK Checks
     runs-on: ubuntu-latest

--- a/frontend/components/swap/PriceInfoPanel.tsx
+++ b/frontend/components/swap/PriceInfoPanel.tsx
@@ -1,15 +1,16 @@
 'use client';
 
-import { Info, HelpCircle } from "lucide-react";
+import { HelpCircle } from "lucide-react";
 import {
   Tooltip,
   TooltipContent,
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
-import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PriceImpactIndicator } from "./PriceImpactIndicator";
+import { Button } from "@/components/ui/button";
+import { useSwapI18n } from "@/lib/swap-i18n";
 
 interface PriceInfoPanelProps {
   rate?: string;
@@ -17,6 +18,8 @@ interface PriceInfoPanelProps {
   minReceived?: string;
   networkFee?: string;
   isLoading?: boolean;
+  onExportJson?: () => void;
+  onExportCsv?: () => void;
 }
 
 export function PriceInfoPanel({
@@ -25,7 +28,10 @@ export function PriceInfoPanel({
   minReceived,
   networkFee,
   isLoading = false,
+  onExportJson,
+  onExportCsv,
 }: PriceInfoPanelProps) {
+  const { t } = useSwapI18n();
   if (isLoading) {
     return (
       <div className="rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm p-4 space-y-3">
@@ -40,14 +46,14 @@ export function PriceInfoPanel({
     <div className="rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm p-4 space-y-3 transition-all duration-300 hover:border-primary/20">
       <div className="flex justify-between items-center text-sm">
         <div className="flex items-center gap-1.5 text-muted-foreground font-medium">
-          <span>Exchange Rate</span>
+          <span>{t("swap.quote.rate")}</span>
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
                 <HelpCircle className="h-3.5 w-3.5 opacity-50 cursor-help" />
               </TooltipTrigger>
               <TooltipContent>
-                <p className="text-xs">Current market rate for this trading pair inclusive of path routing.</p>
+                <p className="text-xs">{t("swap.quote.exchangeRateTooltip")}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -59,21 +65,21 @@ export function PriceInfoPanel({
 
       <div className="flex justify-between items-center text-sm">
         <div className="flex items-center gap-1.5 text-muted-foreground font-medium">
-          <span>Price Impact</span>
+          <span>{t("swap.quote.priceImpact")}</span>
         </div>
         <PriceImpactIndicator impact={priceImpact} />
       </div>
 
       <div className="flex justify-between items-center text-sm">
         <div className="flex items-center gap-1.5 text-muted-foreground font-medium">
-          <span>Minimum Received</span>
+          <span>{t("swap.quote.minimumReceived")}</span>
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
                 <HelpCircle className="h-3.5 w-3.5 opacity-50 cursor-help" />
               </TooltipTrigger>
               <TooltipContent>
-                <p className="text-xs">Your transaction will revert if there is a large unfavorable price movement before it is confirmed.</p>
+                <p className="text-xs">{t("swap.quote.minimumReceivedTooltip")}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -85,14 +91,14 @@ export function PriceInfoPanel({
 
       <div className="pt-2 mt-1 border-t border-border/20 flex justify-between items-center text-sm">
         <div className="flex items-center gap-1.5 text-muted-foreground font-medium">
-          <span>Network Fee</span>
+          <span>{t("swap.quote.networkFee")}</span>
           <TooltipProvider>
             <Tooltip>
               <TooltipTrigger asChild>
                 <HelpCircle className="h-3.5 w-3.5 opacity-50 cursor-help" />
               </TooltipTrigger>
               <TooltipContent>
-                <p className="text-xs">Estimated cost to execute this transaction on the Stellar network.</p>
+                <p className="text-xs">{t("swap.quote.networkFeeTooltip")}</p>
               </TooltipContent>
             </Tooltip>
           </TooltipProvider>
@@ -101,7 +107,14 @@ export function PriceInfoPanel({
           {networkFee || '—'}
         </span>
       </div>
+      <div className="pt-2 flex flex-wrap justify-end gap-2">
+        <Button size="sm" variant="outline" type="button" onClick={onExportJson}>
+          {t("swap.quote.exportJson")}
+        </Button>
+        <Button size="sm" variant="outline" type="button" onClick={onExportCsv}>
+          {t("swap.quote.exportCsv")}
+        </Button>
+      </div>
     </div>
   );
 }
-

--- a/frontend/components/swap/SwapButton.tsx
+++ b/frontend/components/swap/SwapButton.tsx
@@ -3,6 +3,7 @@
 import { Button } from "@/components/ui/button";
 import { Loader2, AlertCircle, Wallet } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { useSwapI18n } from "@/lib/swap-i18n";
 
 export type SwapButtonState = 
   | "no_wallet"
@@ -30,12 +31,13 @@ export function SwapButton({
   isLoading = false,
   className,
 }: SwapButtonProps) {
+  const { t } = useSwapI18n();
   
   const getButtonProps = () => {
     switch (state) {
       case "no_wallet":
         return {
-          label: "Connect Wallet",
+          label: t("swap.cta.connectWallet"),
           onClick: onConnectWallet,
           disabled: false,
           variant: "default" as const,
@@ -44,21 +46,21 @@ export function SwapButton({
         };
       case "no_amount":
         return {
-          label: "Enter Amount",
+          label: t("swap.cta.enterAmount"),
           disabled: true,
           variant: "secondary" as const,
           className: "bg-muted/50 text-muted-foreground",
         };
       case "insufficient_balance":
         return {
-          label: "Insufficient Balance",
+          label: t("swap.cta.insufficientBalance"),
           disabled: true,
           variant: "destructive" as const,
           className: "bg-destructive/10 text-destructive border-destructive/20 border",
         };
       case "high_price_impact":
         return {
-          label: "Price Impact Too High",
+          label: t("swap.simulation.highImpactTitle"),
           disabled: true,
           variant: "destructive" as const,
           icon: <AlertCircle className="mr-2 h-5 w-5" />,
@@ -66,7 +68,7 @@ export function SwapButton({
         };
       case "high_impact_warning":
         return {
-          label: "Swap Anyway",
+          label: t("swap.cta.swapAnyway"),
           onClick: onSwap,
           disabled: isLoading,
           variant: "destructive" as const,
@@ -75,14 +77,14 @@ export function SwapButton({
         };
       case "executing":
         return {
-          label: "Swapping...",
+          label: t("swap.cta.swapping"),
           disabled: true,
           variant: "default" as const,
           icon: <Loader2 className="mr-2 h-5 w-5 animate-spin" />,
         };
       case "refreshing_quote":
         return {
-          label: "Refreshing Quote...",
+          label: t("swap.cta.loadingQuote"),
           disabled: true,
           variant: "outline" as const,
           icon: <Loader2 className="mr-2 h-5 w-5 animate-spin" />,
@@ -90,7 +92,7 @@ export function SwapButton({
         };
       case "error":
         return {
-          label: "Error fetching quote",
+          label: t("swap.cta.errorFetchingQuote"),
           disabled: true,
           variant: "outline" as const,
           className: "border-destructive/50 text-destructive",
@@ -98,7 +100,7 @@ export function SwapButton({
       case "ready":
       default:
         return {
-          label: "Swap",
+          label: t("swap.cta.reviewSwap"),
           onClick: onSwap,
           disabled: isLoading,
           variant: "default" as const,

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -23,8 +23,17 @@ import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useQuoteStreamStatus } from '@/hooks/useQuoteStreamStatus';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
+import { useSwapI18n } from '@/lib/swap-i18n';
+import { quoteExportToCsv, type QuoteExportPayload } from '@/lib/quote-export';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 export function SwapCard() {
+  const { t } = useSwapI18n();
   const {
     fromToken,
     setFromToken,
@@ -56,6 +65,8 @@ export function SwapCard() {
   const [wakeRecoveryOpen, setWakeRecoveryOpen] = useState(false);
   const [recoveryRequestedAt, setRecoveryRequestedAt] = useState<number | null>(null);
   const [isRecoveringSession, setIsRecoveringSession] = useState(false);
+  const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const hiddenAtRef = useRef<number | null>(null);
   const recoveryReason: 'refresh' | 'wake' | null = wakeRecoveryOpen
     ? 'wake'
@@ -198,6 +209,85 @@ export function SwapCard() {
     switchTokens();
   }, [switchTokens]);
 
+  useEffect(() => {
+    const onKeydown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const isEditable = target
+        ? target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable
+        : false;
+
+      if (event.key === "?" && !isEditable) {
+        event.preventDefault();
+        lastFocusedElementRef.current = document.activeElement as HTMLElement;
+        setShortcutHelpOpen(true);
+      }
+
+      if (event.key.toLowerCase() === "r" && event.altKey) {
+        event.preventDefault();
+        quote.refresh({ force: true });
+      }
+
+      if (event.key === "1" && event.altKey) {
+        event.preventDefault();
+        document.querySelectorAll<HTMLInputElement>('input[placeholder="0.00"]')[0]?.focus();
+      }
+
+      if (event.key === "2" && event.altKey) {
+        event.preventDefault();
+        document.querySelectorAll<HTMLInputElement>('input[placeholder="0.00"]')[1]?.focus();
+      }
+    };
+
+    window.addEventListener("keydown", onKeydown);
+    return () => window.removeEventListener("keydown", onKeydown);
+  }, [quote]);
+
+  const handleShortcutOpenChange = useCallback((open: boolean) => {
+    setShortcutHelpOpen(open);
+    if (!open) {
+      lastFocusedElementRef.current?.focus();
+    }
+  }, []);
+
+  const handleExport = useCallback((format: "json" | "csv") => {
+    const payload: QuoteExportPayload = {
+      exportedAt: new Date().toISOString(),
+      market: {
+        fromAsset: fromSymbol,
+        toAsset: toSymbol,
+        fromAmount,
+        expectedToAmount: toAmount,
+      },
+      pricing: {
+        rate: formattedRate,
+        priceImpactPct: quote.priceImpact.toFixed(2),
+        minimumReceived: `${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`,
+        networkFee: quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM',
+      },
+      route: {
+        selectedVenue: selectedRoute?.venue ?? "auto",
+        routeSummary:
+          selectedRoute?.hops?.map((hop) => `${hop.fromAsset}->${hop.toAsset}`).join(" | ") ??
+          "best-route",
+      },
+    };
+    const serialized = format === "json"
+      ? JSON.stringify(payload, null, 2)
+      : quoteExportToCsv(payload);
+    const blob = new Blob([serialized], {
+      type: format === "json" ? "application/json" : "text/csv;charset=utf-8",
+    });
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `stellarroute-quote-summary.${format}`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+    toast.success(t("swap.quote.exportSuccess", { format: format.toUpperCase() }));
+  }, [formattedRate, fromAmount, fromSymbol, quote.fee, quote.priceImpact, selectedRoute, slippage, t, toAmount, toSymbol]);
+
   return (
     <div data-testid="swap-card" className="w-full max-w-[480px] mx-auto perspective-1000">
       <Card className="relative overflow-hidden border-border/40 bg-background/60 backdrop-blur-xl shadow-2xl rounded-[32px] transition-all duration-500 hover:shadow-primary/5">
@@ -228,7 +318,7 @@ export function SwapCard() {
                 size="icon" 
                 onClick={() => quote.refresh()} 
                 disabled={quote.loading}
-                aria-label="Refresh quote"
+                aria-label={t("swap.card.refreshQuote")}
                 className="h-9 w-9 rounded-xl hover:bg-muted/80"
               >
                 <RefreshCw className={cn("h-4.5 w-4.5 text-muted-foreground", quote.loading && "animate-spin")} />
@@ -241,7 +331,7 @@ export function SwapCard() {
             <div className="bg-muted/30 hover:bg-muted/40 transition-colors rounded-2xl p-4 border border-border/20 focus-within:border-primary/30 focus-within:ring-4 focus-within:ring-primary/5">
               <div className="flex justify-between items-start mb-1">
                 <AmountInput
-                  label="You Pay"
+                  label={t("swap.pair.youPay")}
                   value={fromAmount}
                   onChange={setFromAmount}
                   onMax={handleMax}
@@ -274,7 +364,7 @@ export function SwapCard() {
             <div className="bg-muted/30 rounded-2xl p-4 border border-border/20">
               <div className="flex justify-between items-start mb-1">
                 <AmountInput
-                  label="You Receive"
+                  label={t("swap.pair.youReceive")}
                   value={selectedRoute?.expectedAmount ?? toAmount}
                   readOnly
                   placeholder="0.00"
@@ -299,6 +389,8 @@ export function SwapCard() {
                 minReceived={`${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`}
                 networkFee={quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM'}
                 isLoading={quote.loading}
+                onExportJson={() => handleExport("json")}
+                onExportCsv={() => handleExport("csv")}
               />
               <RouteDisplay
                 amountOut={selectedRoute?.expectedAmount ?? toAmount}
@@ -314,7 +406,7 @@ export function SwapCard() {
               data-testid="stale-indicator"
               className="text-xs text-amber-500 font-medium"
             >
-              Quote outdated — refresh for latest price
+              {t("swap.card.outdated")}
             </span>
           )}
           {quote.isRecovering && (
@@ -324,8 +416,10 @@ export function SwapCard() {
             >
               <span className="text-xs text-blue-500 font-medium">
                 {quote.hasPendingRetry
-                  ? `Retrying quote in ${Math.max(1, Math.ceil(quote.pendingRetryRemainingMs / 1000))}s...`
-                  : 'Retrying quote...'}
+                  ? t("swap.card.recoveringQuoteCountdown", {
+                      seconds: Math.max(1, Math.ceil(quote.pendingRetryRemainingMs / 1000)),
+                    })
+                  : t("swap.card.recoveringQuote")}
               </span>
               {quote.hasPendingRetry && (
                 <Button
@@ -335,7 +429,7 @@ export function SwapCard() {
                   onClick={quote.cancelRetry}
                   className="h-7 rounded-lg px-2 text-[11px] font-semibold text-blue-600 hover:bg-blue-500/10 hover:text-blue-700"
                 >
-                  Cancel retry
+                  {t("swap.card.cancelRetry")}
                 </Button>
               )}
             </div>
@@ -346,7 +440,7 @@ export function SwapCard() {
               data-testid="recovery-refresh-indicator"
               className="text-xs font-medium text-primary"
             >
-              Session restored — fetching a fresh quote before trading
+              {t("swap.card.sessionRestored")}
             </span>
           )}
 
@@ -392,8 +486,23 @@ export function SwapCard() {
 
       {/* Footer Info */}
       <p className="text-center text-[10px] text-muted-foreground/60 mt-4 px-8 uppercase tracking-widest font-bold">
-        Powered by StellarRoute Aggregator
+        {t("swap.card.poweredBy")}
       </p>
+
+      <Dialog open={shortcutHelpOpen} onOpenChange={handleShortcutOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("swap.shortcuts.title")}</DialogTitle>
+          </DialogHeader>
+          <ul className="space-y-3 text-sm">
+            <li className="flex justify-between"><span>{t("swap.shortcuts.openHelp")}</span><kbd className="font-mono">?</kbd></li>
+            <li className="flex justify-between"><span>{t("swap.shortcuts.closeHelp")}</span><kbd className="font-mono">Esc</kbd></li>
+            <li className="flex justify-between"><span>{t("swap.shortcuts.refreshQuote")}</span><kbd className="font-mono">Alt+R</kbd></li>
+            <li className="flex justify-between"><span>{t("swap.shortcuts.focusPayAmount")}</span><kbd className="font-mono">Alt+1</kbd></li>
+            <li className="flex justify-between"><span>{t("swap.shortcuts.focusReceiveAmount")}</span><kbd className="font-mono">Alt+2</kbd></li>
+          </ul>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }

--- a/frontend/docs/swap-i18n-audit.md
+++ b/frontend/docs/swap-i18n-audit.md
@@ -1,0 +1,25 @@
+# Swap and error i18n audit notes
+
+## Fallback locale
+
+- Swap UI translations use `SWAP_FALLBACK_LOCALE` in `frontend/lib/swap-i18n.ts`.
+- Current fallback locale: `en-US`.
+
+## Audit checklist
+
+- [x] Swap CTA labels use translation keys.
+- [x] Swap retry/recovery banners use translation keys.
+- [x] Swap pricing panel labels/tooltips use translation keys.
+- [x] Keyboard shortcut help content uses translation keys.
+- [x] Avoid exposing raw backend error codes without a user-facing message.
+
+## Quick coverage command
+
+Run this check to find direct quoted strings in swap components during review:
+
+```bash
+rg -n '"[A-Za-z][^"]+"' frontend/components/swap frontend/app/swap
+```
+
+Use this output as an audit aid and verify any user-visible string is mapped through `useSwapI18n()`.
+

--- a/frontend/docs/swap-visual-regression.md
+++ b/frontend/docs/swap-visual-regression.md
@@ -1,0 +1,33 @@
+# Swap visual regression workflow
+
+This project uses Playwright snapshot assertions in `frontend/e2e/visual-baseline.spec.ts` for swap-critical UI coverage.
+
+## Coverage matrix
+
+- Themes: light + dark
+- Breakpoints: mobile (375x812), tablet (768x1024), desktop (1280x960)
+- States:
+  - idle swap screen
+  - route summary after entering an amount
+  - wallet connect CTA state
+
+## CI behavior
+
+- CI runs `npm run test:visual` in the `frontend-visual-regression` job.
+- Snapshot drift causes `toHaveScreenshot` failures and fails the job.
+
+## Updating baselines intentionally
+
+1. Make your UI change.
+2. Run:
+   - `npm --prefix frontend run test:visual:update`
+3. Review modified files under `frontend/e2e/visual-baseline.spec.ts-snapshots/`.
+4. Commit both the UI change and updated snapshots in the same PR.
+
+## Flake mitigation
+
+- Animations and transitions are disabled in test setup.
+- Tests wait briefly after hydration before screenshots.
+- CI retries once for Playwright tests.
+- Visual assertions use `maxDiffPixelRatio` (2%) configured in `playwright.config.ts`.
+

--- a/frontend/e2e/visual-baseline.spec.ts
+++ b/frontend/e2e/visual-baseline.spec.ts
@@ -1,0 +1,58 @@
+import { expect, test, type Page } from "@playwright/test";
+
+const BREAKPOINTS = [
+  { name: "mobile", width: 375, height: 812 },
+  { name: "tablet", width: 768, height: 1024 },
+  { name: "desktop", width: 1280, height: 960 },
+] as const;
+
+async function stabilizeUi(page: Page) {
+  await page.addStyleTag({
+    content: `
+      *, *::before, *::after {
+        animation: none !important;
+        transition: none !important;
+      }
+    `,
+  });
+  await page.waitForTimeout(250);
+}
+
+async function gotoSwap(page: Page, theme: "light" | "dark") {
+  await page.goto("/swap");
+  await page.waitForSelector("[data-testid='swap-card']", { timeout: 10_000 });
+  await page.evaluate((selectedTheme) => {
+    document.documentElement.classList.toggle("dark", selectedTheme === "dark");
+  }, theme);
+  await stabilizeUi(page);
+}
+
+for (const theme of ["light", "dark"] as const) {
+  test.describe(`swap visual baseline (${theme})`, () => {
+    for (const viewport of BREAKPOINTS) {
+      test(`swap idle ${viewport.name}`, async ({ page }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await gotoSwap(page, theme);
+        await expect(page).toHaveScreenshot(`swap-idle-${theme}-${viewport.name}.png`);
+      });
+
+      test(`route summary ${viewport.name}`, async ({ page }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await gotoSwap(page, theme);
+        await page.getByRole("button", { name: /connect wallet/i }).click();
+        await page.locator("input[placeholder='0.00']").first().fill("42");
+        await page.waitForTimeout(600);
+        await expect(page).toHaveScreenshot(`swap-routes-${theme}-${viewport.name}.png`);
+      });
+
+      test(`wallet connect state ${viewport.name}`, async ({ page }) => {
+        await page.setViewportSize({ width: viewport.width, height: viewport.height });
+        await gotoSwap(page, theme);
+        await expect(page.getByRole("button", { name: /connect wallet/i })).toHaveScreenshot(
+          `swap-wallet-connect-${theme}-${viewport.name}.png`,
+        );
+      });
+    }
+  });
+}
+

--- a/frontend/lib/quote-export.test.ts
+++ b/frontend/lib/quote-export.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from "vitest";
+
+import type { QuoteExportPayload } from "./quote-export";
+import { quoteExportToCsv } from "./quote-export";
+
+const payload: QuoteExportPayload = {
+  exportedAt: "2026-04-26T00:00:00.000Z",
+  market: {
+    fromAsset: "XLM",
+    toAsset: "USDC",
+    fromAmount: "100",
+    expectedToAmount: "99.1234",
+  },
+  pricing: {
+    rate: "1 XLM = 0.9912 USDC",
+    priceImpactPct: "0.20",
+    minimumReceived: "98.9000 USDC",
+    networkFee: "0.00001 XLM",
+  },
+  route: {
+    selectedVenue: "SDEX",
+    routeSummary: "XLM -> USDC",
+  },
+};
+
+describe("quote export payload", () => {
+  it("serializes a stable JSON payload shape without wallet fields", () => {
+    const json = JSON.parse(JSON.stringify(payload)) as Record<string, unknown>;
+    expect(json).toMatchObject({
+      market: {
+        fromAsset: "XLM",
+        toAsset: "USDC",
+      },
+      pricing: {
+        rate: "1 XLM = 0.9912 USDC",
+      },
+    });
+    expect(JSON.stringify(json)).not.toContain("wallet");
+    expect(JSON.stringify(json)).not.toContain("address");
+  });
+
+  it("serializes CSV export", () => {
+    const csv = quoteExportToCsv(payload);
+    expect(csv).toContain("field,value");
+    expect(csv).toContain("market_from_asset,XLM");
+    expect(csv).toContain("route_selected_venue,SDEX");
+  });
+});
+

--- a/frontend/lib/quote-export.ts
+++ b/frontend/lib/quote-export.ts
@@ -1,0 +1,48 @@
+export interface QuoteExportPayload {
+  exportedAt: string;
+  market: {
+    fromAsset: string;
+    toAsset: string;
+    fromAmount: string;
+    expectedToAmount: string;
+  };
+  pricing: {
+    rate: string;
+    priceImpactPct: string;
+    minimumReceived: string;
+    networkFee: string;
+  };
+  route: {
+    selectedVenue: string;
+    routeSummary: string;
+  };
+}
+
+export function quoteExportToCsv(payload: QuoteExportPayload) {
+  const rows: Array<[string, string]> = [
+    ["exported_at", payload.exportedAt],
+    ["market_from_asset", payload.market.fromAsset],
+    ["market_to_asset", payload.market.toAsset],
+    ["market_from_amount", payload.market.fromAmount],
+    ["market_expected_to_amount", payload.market.expectedToAmount],
+    ["pricing_rate", payload.pricing.rate],
+    ["pricing_price_impact_pct", payload.pricing.priceImpactPct],
+    ["pricing_minimum_received", payload.pricing.minimumReceived],
+    ["pricing_network_fee", payload.pricing.networkFee],
+    ["route_selected_venue", payload.route.selectedVenue],
+    ["route_summary", payload.route.routeSummary],
+  ];
+
+  return [
+    "field,value",
+    ...rows.map(([field, value]) => `${escapeCsv(field)},${escapeCsv(value)}`),
+  ].join("\n");
+}
+
+function escapeCsv(value: string) {
+  if (value.includes(",") || value.includes("\"") || value.includes("\n")) {
+    return `"${value.replaceAll("\"", "\"\"")}"`;
+  }
+  return value;
+}
+

--- a/frontend/lib/swap-i18n.ts
+++ b/frontend/lib/swap-i18n.ts
@@ -29,6 +29,13 @@ type SwapTranslationKey =
   | "swap.quote.rate"
   | "swap.quote.networkFee"
   | "swap.quote.priceImpact"
+  | "swap.quote.minimumReceived"
+  | "swap.quote.exchangeRateTooltip"
+  | "swap.quote.minimumReceivedTooltip"
+  | "swap.quote.networkFeeTooltip"
+  | "swap.quote.exportJson"
+  | "swap.quote.exportCsv"
+  | "swap.quote.exportSuccess"
   | "swap.settings.buttonLabel"
   | "swap.settings.menuTitle"
   | "swap.settings.slippageTolerance"
@@ -72,7 +79,25 @@ type SwapTranslationKey =
   | "swap.cta.selectTokens"
   | "swap.cta.enterAmount"
   | "swap.cta.invalidSlippage"
-  | "swap.cta.loadingQuote";
+  | "swap.cta.loadingQuote"
+  | "swap.cta.connectWallet"
+  | "swap.cta.insufficientBalance"
+  | "swap.cta.swapAnyway"
+  | "swap.cta.swapping"
+  | "swap.cta.errorFetchingQuote"
+  | "swap.card.refreshQuote"
+  | "swap.card.outdated"
+  | "swap.card.recoveringQuote"
+  | "swap.card.recoveringQuoteCountdown"
+  | "swap.card.cancelRetry"
+  | "swap.card.sessionRestored"
+  | "swap.card.poweredBy"
+  | "swap.shortcuts.title"
+  | "swap.shortcuts.openHelp"
+  | "swap.shortcuts.closeHelp"
+  | "swap.shortcuts.focusPayAmount"
+  | "swap.shortcuts.focusReceiveAmount"
+  | "swap.shortcuts.refreshQuote";
 
 type SwapTranslations = Record<SwapTranslationKey, string>;
 
@@ -96,6 +121,16 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.quote.rate": "Rate",
     "swap.quote.networkFee": "Network Fee",
     "swap.quote.priceImpact": "Price Impact",
+    "swap.quote.minimumReceived": "Minimum Received",
+    "swap.quote.exchangeRateTooltip":
+      "Current market rate for this trading pair inclusive of path routing.",
+    "swap.quote.minimumReceivedTooltip":
+      "Your transaction will revert if there is a large unfavorable price movement before it is confirmed.",
+    "swap.quote.networkFeeTooltip":
+      "Estimated cost to execute this transaction on the Stellar network.",
+    "swap.quote.exportJson": "Export JSON",
+    "swap.quote.exportCsv": "Export CSV",
+    "swap.quote.exportSuccess": "Quote summary exported as {format}",
     "swap.settings.buttonLabel": "Settings",
     "swap.settings.menuTitle": "Transaction Settings",
     "swap.settings.slippageTolerance": "Slippage Tolerance",
@@ -146,6 +181,25 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.cta.enterAmount": "Enter amount",
     "swap.cta.invalidSlippage": "Invalid slippage",
     "swap.cta.loadingQuote": "Loading quote...",
+    "swap.cta.connectWallet": "Connect Wallet",
+    "swap.cta.insufficientBalance": "Insufficient Balance",
+    "swap.cta.swapAnyway": "Swap Anyway",
+    "swap.cta.swapping": "Swapping...",
+    "swap.cta.errorFetchingQuote": "Error fetching quote",
+    "swap.card.refreshQuote": "Refresh quote",
+    "swap.card.outdated": "Quote outdated — refresh for latest price",
+    "swap.card.recoveringQuote": "Retrying quote...",
+    "swap.card.recoveringQuoteCountdown": "Retrying quote in {seconds}s...",
+    "swap.card.cancelRetry": "Cancel retry",
+    "swap.card.sessionRestored":
+      "Session restored — fetching a fresh quote before trading",
+    "swap.card.poweredBy": "Powered by StellarRoute Aggregator",
+    "swap.shortcuts.title": "Keyboard shortcuts",
+    "swap.shortcuts.openHelp": "Open shortcut help",
+    "swap.shortcuts.closeHelp": "Close modal",
+    "swap.shortcuts.focusPayAmount": "Focus pay amount",
+    "swap.shortcuts.focusReceiveAmount": "Focus receive amount",
+    "swap.shortcuts.refreshQuote": "Refresh quote",
   },
   "zh-CN": {
     "swap.card.title": "兑换",
@@ -166,6 +220,14 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.quote.rate": "汇率",
     "swap.quote.networkFee": "网络费用",
     "swap.quote.priceImpact": "价格影响",
+    "swap.quote.minimumReceived": "最少收到",
+    "swap.quote.exchangeRateTooltip": "包含路径路由影响的当前市场汇率。",
+    "swap.quote.minimumReceivedTooltip":
+      "若确认前出现不利的大幅价格波动，交易将回滚。",
+    "swap.quote.networkFeeTooltip": "在 Stellar 网络执行该交易的预计成本。",
+    "swap.quote.exportJson": "导出 JSON",
+    "swap.quote.exportCsv": "导出 CSV",
+    "swap.quote.exportSuccess": "报价摘要已导出为 {format}",
     "swap.settings.buttonLabel": "设置",
     "swap.settings.menuTitle": "交易设置",
     "swap.settings.slippageTolerance": "滑点容忍度",
@@ -211,6 +273,24 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.cta.enterAmount": "输入数量",
     "swap.cta.invalidSlippage": "滑点无效",
     "swap.cta.loadingQuote": "正在获取报价...",
+    "swap.cta.connectWallet": "连接钱包",
+    "swap.cta.insufficientBalance": "余额不足",
+    "swap.cta.swapAnyway": "仍要兑换",
+    "swap.cta.swapping": "兑换中...",
+    "swap.cta.errorFetchingQuote": "获取报价失败",
+    "swap.card.refreshQuote": "刷新报价",
+    "swap.card.outdated": "报价已过期——请刷新获取最新价格",
+    "swap.card.recoveringQuote": "正在重试报价...",
+    "swap.card.recoveringQuoteCountdown": "{seconds} 秒后重试报价...",
+    "swap.card.cancelRetry": "取消重试",
+    "swap.card.sessionRestored": "会话已恢复——正在获取最新报价后再交易",
+    "swap.card.poweredBy": "由 StellarRoute 聚合器提供支持",
+    "swap.shortcuts.title": "键盘快捷键",
+    "swap.shortcuts.openHelp": "打开快捷键帮助",
+    "swap.shortcuts.closeHelp": "关闭弹窗",
+    "swap.shortcuts.focusPayAmount": "聚焦支付数量",
+    "swap.shortcuts.focusReceiveAmount": "聚焦接收数量",
+    "swap.shortcuts.refreshQuote": "刷新报价",
   },
 };
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,8 @@
     "format": "prettier --write .",
     "test": "vitest run",
     "test:e2e": "playwright test",
+    "test:visual": "playwright test e2e/visual-baseline.spec.ts",
+    "test:visual:update": "playwright test e2e/visual-baseline.spec.ts --update-snapshots",
     "storybook": "ladle dev",
     "storybook:ci": "ladle build",
     "perf:check": "node scripts/check-perf-budget.mjs",


### PR DESCRIPTION
close #405

Description
Implements export of the current quote + route summary in JSON and CSV formats from the swap UI, so users can attach quote context to support tickets or keep records.
This also ensures exported data excludes wallet-identifying fields by default. 


Testing 
✅ cd /workspace/StellarRoute--fork/frontend && npm test -- lib/quote-export.test.ts
Verifies payload shape, wallet-field exclusion, and CSV serialization expectations. 

✅ cd /workspace/StellarRoute--fork/frontend && npx eslint lib/quote-export.ts lib/quote-export.test.ts components/swap/PriceInfoPanel.tsx components/swap/SwapCard.tsx
Confirms touched export-related files are lint-clean. 