### PR TITLE
[#353] [frontend] Progressive skeleton-to-content transitions for swap modules

### DIFF
--- a/frontend/components/Header.tsx
+++ b/frontend/components/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { ThemeToggle } from "./ThemeToggle";
-import { WalletButton } from "@/components/shared/WalletButton";
+import { WalletButton } from "@/components/shared/wallet-button";
 
 export function Header() {
   return (

--- a/frontend/components/TransactionHistory.test.tsx
+++ b/frontend/components/TransactionHistory.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { TransactionRecord } from "@/types/transaction";
@@ -39,7 +39,10 @@ describe("TransactionHistory", () => {
     historyState.clearHistory = vi.fn();
   });
 
-  afterEach(() => cleanup());
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
 
   it("should show skeleton loader initially", async () => {
     const { container } = render(<TransactionHistory />);
@@ -95,9 +98,20 @@ describe("TransactionHistory", () => {
 
     expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
 
-    await new Promise((resolve) => setTimeout(resolve, 350));
+    await waitFor(() => {
+      expect(screen.getByText("No Transactions Found")).toBeInTheDocument();
+    }, { timeout: 700 });
+  });
 
-    expect(container.querySelectorAll(".animate-pulse").length).toBe(0);
+  it("progressively transitions from skeleton to history content", async () => {
+    const { container } = render(<TransactionHistory />);
+
+    expect(container.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    expect(screen.queryByText("No Transactions Found")).not.toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(screen.getByText("No Transactions Found")).toBeInTheDocument();
+    }, { timeout: 700 });
   });
 
   it("virtualizes long activity lists and swaps the rendered window on scroll", async () => {

--- a/frontend/components/TransactionHistory.tsx
+++ b/frontend/components/TransactionHistory.tsx
@@ -9,6 +9,7 @@ import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
 import { ActivityTableSkeleton } from "@/components/shared/ActivityTableSkeleton"
 import { CopyButton } from "@/components/shared/CopyButton"
+import { useProgressiveLoadingTransition } from "@/hooks/useProgressiveLoadingTransition"
 import { useTransactionHistory } from "@/hooks/useTransactionHistory"
 import { useVirtualWindow } from "@/hooks/useVirtualWindow"
 import { TransactionRecord } from "@/types/transaction"
@@ -31,6 +32,7 @@ export function TransactionHistory() {
   const [filterAsset, setFilterAsset] = useState<string>("ALL")
   const [sortKey, setSortKey] = useState<"date" | "amount">("date")
   const [isLoading, setIsLoading] = useState(true)
+  const { showSkeleton, contentClassName } = useProgressiveLoadingTransition(isLoading)
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
   useEffect(() => {
@@ -119,10 +121,10 @@ export function TransactionHistory() {
       </div>
 
       <div ref={scrollRef} data-testid="tx-history-scroll" className="flex-1 overflow-auto">
-        {isLoading ? (
+        {showSkeleton ? (
           <ActivityTableSkeleton />
         ) : sortedTxs.length === 0 ? (
-          <div className="flex flex-col items-center justify-center p-12 text-center h-full">
+          <div className={`flex flex-col items-center justify-center p-12 text-center h-full ${contentClassName}`.trim()}>
             <div className="text-muted-foreground w-16 h-16 mb-4 opacity-50 bg-muted rounded-full flex items-center justify-center">
               <span className="text-2xl">📋</span>
             </div>
@@ -132,7 +134,7 @@ export function TransactionHistory() {
             </p>
           </div>
         ) : (
-          <div className="min-w-[720px]">
+          <div className={`min-w-[720px] ${contentClassName}`.trim()}>
             <Table>
               <TableHeader className="bg-muted/50 sticky top-0 z-10">
                 <TableRow>

--- a/frontend/components/swap/PriceInfoPanel.tsx
+++ b/frontend/components/swap/PriceInfoPanel.tsx
@@ -10,6 +10,7 @@ import {
 import { cn } from "@/lib/utils";
 import { Skeleton } from "@/components/ui/skeleton";
 import { PriceImpactIndicator } from "./PriceImpactIndicator";
+import { useProgressiveLoadingTransition } from "@/hooks/useProgressiveLoadingTransition";
 
 interface PriceInfoPanelProps {
   rate?: string;
@@ -26,7 +27,9 @@ export function PriceInfoPanel({
   networkFee,
   isLoading = false,
 }: PriceInfoPanelProps) {
-  if (isLoading) {
+  const { showSkeleton, contentClassName } = useProgressiveLoadingTransition(isLoading);
+
+  if (showSkeleton) {
     return (
       <div className="rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm p-4 space-y-3">
         <Skeleton className="h-4 w-full opacity-50" />
@@ -37,7 +40,7 @@ export function PriceInfoPanel({
   }
 
   return (
-    <div className="rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm p-4 space-y-3 transition-all duration-300 hover:border-primary/20">
+    <div className={`rounded-2xl border border-border/40 bg-background/40 backdrop-blur-sm p-4 space-y-3 transition-all duration-300 hover:border-primary/20 ${contentClassName}`.trim()}>
       <div className="flex justify-between items-center text-sm">
         <div className="flex items-center gap-1.5 text-muted-foreground font-medium">
           <span>Exchange Rate</span>

--- a/frontend/components/swap/QuoteSummary.test.tsx
+++ b/frontend/components/swap/QuoteSummary.test.tsx
@@ -1,6 +1,7 @@
 import { render, screen } from "@testing-library/react";
 import { cleanup } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 import { QuoteSummary } from "./QuoteSummary";
 
 describe("QuoteSummary", () => {
@@ -80,5 +81,39 @@ describe("QuoteSummary", () => {
     );
 
     expect(screen.getByText("1 XLM ≈ 0.98 USDC")).toBeInTheDocument();
+  });
+
+  it("progressively transitions from skeleton to content", () => {
+    vi.useFakeTimers();
+
+    const { rerender } = render(
+      <QuoteSummary
+        rate="1 XLM ≈ 0.98 USDC"
+        fee="0.01 XLM"
+        priceImpact="< 0.1%"
+        isLoading={true}
+      />
+    );
+
+    expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+
+    rerender(
+      <QuoteSummary
+        rate="1 XLM ≈ 0.98 USDC"
+        fee="0.01 XLM"
+        priceImpact="< 0.1%"
+        isLoading={false}
+      />
+    );
+
+    expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    expect(screen.queryByText("1 XLM ≈ 0.98 USDC")).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByText("1 XLM ≈ 0.98 USDC")).toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/frontend/components/swap/QuoteSummary.tsx
+++ b/frontend/components/swap/QuoteSummary.tsx
@@ -1,6 +1,7 @@
 import { Skeleton } from "@/components/ui/skeleton";
 
 import { useSwapI18n } from "@/lib/swap-i18n";
+import { useProgressiveLoadingTransition } from "@/hooks/useProgressiveLoadingTransition";
 import { QuoteSummarySkeleton } from "./QuoteSummarySkeleton";
 
 interface QuoteSummaryProps {
@@ -17,8 +18,9 @@ export function QuoteSummary({
   isLoading = false,
 }: QuoteSummaryProps) {
   const { t } = useSwapI18n();
+  const { showSkeleton, contentClassName } = useProgressiveLoadingTransition(isLoading);
 
-  if (isLoading) {
+  if (showSkeleton) {
     return <QuoteSummarySkeleton />;
   }
 
@@ -27,7 +29,7 @@ export function QuoteSummary({
   const displayPriceImpact = priceImpact?.trim() || null;
 
   return (
-    <div className="rounded-xl border border-border/50 p-4 space-y-3 bg-muted/30">
+    <div className={`rounded-xl border border-border/50 p-4 space-y-3 bg-muted/30 ${contentClassName}`.trim()}>
       {rate && (
         <div className="flex justify-between items-center text-sm">
           <span className="text-muted-foreground">{t("swap.quote.rate")}</span>

--- a/frontend/components/swap/RouteDisplay.test.tsx
+++ b/frontend/components/swap/RouteDisplay.test.tsx
@@ -1,5 +1,6 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { act } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { RouteDisplay } from "./RouteDisplay";
 
@@ -76,5 +77,25 @@ describe("RouteDisplay", () => {
     });
 
     expect(screen.queryByTestId("alternative-route-route-0")).not.toBeInTheDocument();
+  });
+
+  it("progressively transitions from skeleton to content", () => {
+    vi.useFakeTimers();
+
+    const { rerender } = render(<RouteDisplay amountOut="50.0" isLoading={true} />);
+
+    expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+
+    rerender(<RouteDisplay amountOut="50.0" isLoading={false} />);
+
+    expect(document.querySelectorAll(".animate-pulse").length).toBeGreaterThan(0);
+    expect(screen.queryByText("Best Route")).not.toBeInTheDocument();
+
+    act(() => {
+      vi.advanceTimersByTime(400);
+    });
+
+    expect(screen.getByText("Best Route")).toBeInTheDocument();
+    vi.useRealTimers();
   });
 });

--- a/frontend/components/swap/RouteDisplay.tsx
+++ b/frontend/components/swap/RouteDisplay.tsx
@@ -3,6 +3,7 @@ import { useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { useVirtualWindow } from "@/hooks/useVirtualWindow";
+import { useProgressiveLoadingTransition } from "@/hooks/useProgressiveLoadingTransition";
 
 import { ConfidenceIndicator } from "./ConfidenceIndicator";
 import { RouteDisplaySkeleton } from "./RouteDisplaySkeleton";
@@ -90,6 +91,7 @@ export function RouteDisplay({
 }: RouteDisplayProps) {
   const [showDetails, setShowDetails] = useState(false);
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
+  const { showSkeleton, contentClassName } = useProgressiveLoadingTransition(isLoading);
   const routes = alternativeRoutes ?? buildAlternativeRoutes(amountOut);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -111,12 +113,15 @@ export function RouteDisplay({
     ? routes.slice(virtualWindow.startIndex, virtualWindow.endIndex)
     : routes;
 
-  if (isLoading) {
+  if (showSkeleton) {
     return <RouteDisplaySkeleton />;
   }
 
   return (
-    <div data-testid="route-display" className="rounded-xl border border-border/50 p-4 space-y-4 transition-all duration-200 hover:border-border hover:shadow-sm focus-within:ring-2 focus-within:ring-primary/20">
+    <div
+      data-testid="route-display"
+      className={`rounded-xl border border-border/50 p-4 space-y-4 transition-all duration-200 hover:border-border hover:shadow-sm focus-within:ring-2 focus-within:ring-primary/20 ${contentClassName}`.trim()}
+    >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h4 className="text-sm font-medium">Best Route</h4>

--- a/frontend/components/swap/SimulationPanel.tsx
+++ b/frontend/components/swap/SimulationPanel.tsx
@@ -4,6 +4,7 @@ import { Badge } from "@/components/ui/badge";
 import { Skeleton } from "@/components/ui/skeleton";
 import { AlertTriangle, TrendingDown, TrendingUp } from "lucide-react";
 import { useSwapI18n } from "@/lib/swap-i18n";
+import { useProgressiveLoadingTransition } from "@/hooks/useProgressiveLoadingTransition";
 
 export interface SimulationPanelProps {
   /** Amount being paid/sold */
@@ -34,6 +35,7 @@ export function SimulationPanel({
   error,
 }: SimulationPanelProps) {
   const { t } = useSwapI18n();
+  const { showSkeleton, contentClassName } = useProgressiveLoadingTransition(isLoading);
 
   const calculateSimulation = (): SimulationData | null => {
     const payAmountNum = parseFloat(payAmount);
@@ -79,7 +81,7 @@ export function SimulationPanel({
     );
   }
 
-  if (isLoading) {
+  if (showSkeleton) {
     return (
       <div className="rounded-xl border border-border/50 p-4 space-y-4 shadow-sm animate-in fade-in duration-500">
         <div className="flex items-center gap-2">
@@ -111,7 +113,7 @@ export function SimulationPanel({
   const isHighImpact = parseFloat(simulation.priceImpact) > 0.2;
 
   return (
-    <div className="rounded-xl border border-border/50 p-4 space-y-4 bg-muted/30">
+    <div className={`rounded-xl border border-border/50 p-4 space-y-4 bg-muted/30 ${contentClassName}`.trim()}>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h4 className="text-sm font-medium">{t("swap.simulation.title")}</h4>

--- a/frontend/hooks/useProgressiveLoadingTransition.ts
+++ b/frontend/hooks/useProgressiveLoadingTransition.ts
@@ -1,0 +1,85 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+interface ProgressiveLoadingOptions {
+  minimumSkeletonMs?: number;
+  enterDurationMs?: number;
+}
+
+interface ProgressiveLoadingState {
+  showSkeleton: boolean;
+  contentClassName: string;
+}
+
+const DEFAULT_MINIMUM_SKELETON_MS = 260;
+const DEFAULT_ENTER_DURATION_MS = 320;
+
+export function useProgressiveLoadingTransition(
+  isLoading: boolean,
+  {
+    minimumSkeletonMs = DEFAULT_MINIMUM_SKELETON_MS,
+    enterDurationMs = DEFAULT_ENTER_DURATION_MS,
+  }: ProgressiveLoadingOptions = {},
+): ProgressiveLoadingState {
+  const [showSkeleton, setShowSkeleton] = useState(isLoading);
+  const [isEntering, setIsEntering] = useState(!isLoading);
+
+  const loadingStartedAtRef = useRef<number | null>(isLoading ? Date.now() : null);
+  const revealTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const enterTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  useEffect(() => {
+    if (revealTimerRef.current) {
+      clearTimeout(revealTimerRef.current);
+      revealTimerRef.current = null;
+    }
+    if (enterTimerRef.current) {
+      clearTimeout(enterTimerRef.current);
+      enterTimerRef.current = null;
+    }
+
+    if (isLoading) {
+      loadingStartedAtRef.current = Date.now();
+      setShowSkeleton(true);
+      setIsEntering(false);
+      return;
+    }
+
+    if (!showSkeleton) {
+      setIsEntering(true);
+      enterTimerRef.current = setTimeout(() => {
+        setIsEntering(false);
+      }, enterDurationMs);
+      return;
+    }
+
+    const loadingStartedAt = loadingStartedAtRef.current ?? Date.now();
+    const elapsed = Date.now() - loadingStartedAt;
+    const waitMs = Math.max(minimumSkeletonMs - elapsed, 0);
+
+    revealTimerRef.current = setTimeout(() => {
+      setShowSkeleton(false);
+      setIsEntering(true);
+      enterTimerRef.current = setTimeout(() => {
+        setIsEntering(false);
+      }, enterDurationMs);
+    }, waitMs);
+
+    return () => {
+      if (revealTimerRef.current) {
+        clearTimeout(revealTimerRef.current);
+        revealTimerRef.current = null;
+      }
+      if (enterTimerRef.current) {
+        clearTimeout(enterTimerRef.current);
+        enterTimerRef.current = null;
+      }
+    };
+  }, [isLoading, showSkeleton, minimumSkeletonMs, enterDurationMs]);
+
+  return {
+    showSkeleton,
+    contentClassName: isEntering ? 'animate-in fade-in slide-in-from-bottom-1 duration-300' : '',
+  };
+}


### PR DESCRIPTION
Closes #353

## Summary
- add progressive skeleton-to-content transitions across swap modules
- apply consistent hold-and-reveal behavior including history block
- include visual/behavioral tests for transition states

## Validation
- CI checks attached to this PR must pass