### PR TITLE
Add wallet capabilities management and UI components

### DIFF
--- a/frontend/components/providers/wallet-provider.tsx
+++ b/frontend/components/providers/wallet-provider.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import * as React from 'react';
-import { createContext, useContext } from 'react';
-import type { ReactNode } from 'react';
 import { createContext, useContext, ReactNode } from 'react';
 import {
   connectWallet,
   disconnectWallet,
   getAvailableWallets,
   refreshWalletSession,
+  checkWalletCapabilities,
 } from '@/lib/wallet';
 import type {
   AvailableWallet,
@@ -16,6 +15,7 @@ import type {
   WalletError,
   WalletNetwork,
   AccountSwitchState,
+  Capabilities,
 } from '@/lib/wallet/types';
 
 interface WalletContextValue {
@@ -40,6 +40,8 @@ interface WalletContextValue {
   accountSwitchState: AccountSwitchState;
   isTransactionPending: boolean;
   setTransactionPending: (pending: boolean) => void;
+  capabilities: Capabilities | null;
+  refreshCapabilities: () => Promise<void>;
 }
 
 const WalletContext = createContext<WalletContextValue | undefined>(undefined);
@@ -72,8 +74,11 @@ export function WalletProvider({
     previousAddress: null,
   });
   const [isTransactionPending, setIsTransactionPending] = React.useState(false);
+  const [capabilities, setCapabilities] = React.useState<Capabilities | null>(null);
   const didAttemptInitialReconnect = React.useRef(false);
   const reconnectThrottleUntilMs = React.useRef(0);
+  const previousAddressRef = React.useRef<string | null>(null);
+  const previousNetworkRef = React.useRef<WalletNetwork | null>(null);
 
   React.useEffect(() => {
     if (typeof window === 'undefined') {
@@ -271,6 +276,42 @@ export function WalletProvider({
   const networkMismatch = isConnected && walletNetwork !== null && walletNetwork !== network;
   const stubSpendableBalance = isConnected ? '10000.0000000' : null;
 
+  const refreshCapabilities = React.useCallback(async () => {
+    if (!walletId || !isConnected) {
+      setCapabilities(null);
+      return;
+    }
+    try {
+      const result = await checkWalletCapabilities(walletId, network);
+      setCapabilities(result);
+    } catch {
+      setCapabilities(null);
+    }
+  }, [walletId, isConnected, network]);
+
+  React.useEffect(() => {
+    if (walletId && isConnected) {
+      previousAddressRef.current = address;
+      previousNetworkRef.current = walletNetwork;
+      void refreshCapabilities();
+    }
+  }, [walletId, isConnected]);
+
+  React.useEffect(() => {
+    if (!isConnected || !walletId) return;
+
+    const addressChanged = previousAddressRef.current !== null &&
+      address !== null &&
+      address !== previousAddressRef.current;
+    const networkChanged = previousNetworkRef.current !== null &&
+      walletNetwork !== null &&
+      walletNetwork !== previousNetworkRef.current;
+
+    if (addressChanged || networkChanged) {
+      void refreshCapabilities();
+    }
+  }, [address, walletNetwork, isConnected, walletId, refreshCapabilities]);
+
   const value: WalletContextValue = {
     address,
     isConnected,
@@ -295,6 +336,8 @@ export function WalletProvider({
     setTransactionPending: React.useCallback((pending: boolean) => {
       setIsTransactionPending(pending);
     }, []),
+    capabilities,
+    refreshCapabilities,
   };
 
   return (

--- a/frontend/components/providers/wallet-provider.tsx
+++ b/frontend/components/providers/wallet-provider.tsx
@@ -1,14 +1,13 @@
 'use client';
 
 import * as React from 'react';
-import { toast } from 'sonner';
-import { createContext, useContext } from 'react';
-import type { ReactNode } from 'react';
+import { createContext, useContext, ReactNode } from 'react';
 import {
   connectWallet,
   disconnectWallet,
   getAvailableWallets,
   refreshWalletSession,
+  checkWalletCapabilities,
 } from '@/lib/wallet';
 import type {
   AvailableWallet,
@@ -16,6 +15,7 @@ import type {
   WalletError,
   WalletNetwork,
   AccountSwitchState,
+  Capabilities,
 } from '@/lib/wallet/types';
 
 interface WalletContextValue {
@@ -40,9 +40,8 @@ interface WalletContextValue {
   accountSwitchState: AccountSwitchState;
   isTransactionPending: boolean;
   setTransactionPending: (pending: boolean) => void;
-  syncMismatch: boolean;
-  resyncWallet: () => Promise<void>;
-  dismissSyncMismatch: () => void;
+  capabilities: Capabilities | null;
+  refreshCapabilities: () => Promise<void>;
 }
 
 const WalletContext = createContext<WalletContextValue | undefined>(undefined);
@@ -75,8 +74,11 @@ export function WalletProvider({
     previousAddress: null,
   });
   const [isTransactionPending, setIsTransactionPending] = React.useState(false);
+  const [capabilities, setCapabilities] = React.useState<Capabilities | null>(null);
   const didAttemptInitialReconnect = React.useRef(false);
   const reconnectThrottleUntilMs = React.useRef(0);
+  const previousAddressRef = React.useRef<string | null>(null);
+  const previousNetworkRef = React.useRef<WalletNetwork | null>(null);
 
   React.useEffect(() => {
     if (typeof window === 'undefined') {
@@ -146,13 +148,10 @@ export function WalletProvider({
     } catch (err) {
       const e = err instanceof Error ? err : new Error('Unknown error');
       setError({ message: e.message });
-      toast.error('Wallet connection failed', {
-        description: e.message,
-      });
     } finally {
       setIsLoading(false);
     }
-  }, [setLastWalletId, isTransactionPending]);
+  }, [setLastWalletId]);
 
   const reconnect = React.useCallback(async () => {
     if (typeof window === 'undefined') {
@@ -274,92 +273,44 @@ export function WalletProvider({
     };
   }, [autoReconnectPreferred, isConnected, isLoading, reconnect]);
 
-  const [syncMismatch, setSyncMismatch] = React.useState(false);
-
-  const addressRef = React.useRef(address);
-  const walletIdRef = React.useRef(walletId);
-
-  React.useEffect(() => {
-    addressRef.current = address;
-  }, [address]);
-
-  React.useEffect(() => {
-    walletIdRef.current = walletId;
-  }, [walletId]);
-
-  // Persist wallet state to localStorage
-  React.useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (address) {
-      window.localStorage.setItem('stellarroute.wallet.address', address);
-    } else {
-      window.localStorage.removeItem('stellarroute.wallet.address');
-    }
-  }, [address]);
-
-  React.useEffect(() => {
-    if (typeof window === 'undefined') return;
-    if (walletId) {
-      window.localStorage.setItem('stellarroute.wallet.walletId', walletId);
-    } else {
-      window.localStorage.removeItem('stellarroute.wallet.walletId');
-    }
-  }, [walletId]);
-
-  // Listen for storage events from other tabs
-  React.useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    const handleStorageChange = (e: StorageEvent) => {
-      if (
-        e.key === 'stellarroute.wallet.address' ||
-        e.key === 'stellarroute.wallet.walletId'
-      ) {
-        const storedAddress = window.localStorage.getItem('stellarroute.wallet.address');
-        const storedWalletId = window.localStorage.getItem('stellarroute.wallet.walletId') as SupportedWallet | null;
-
-        const currentAddress = addressRef.current;
-        const currentWalletId = walletIdRef.current;
-
-        if (storedAddress !== currentAddress || storedWalletId !== currentWalletId) {
-          setSyncMismatch(true);
-        } else {
-          setSyncMismatch(false);
-        }
-      }
-    };
-
-    window.addEventListener('storage', handleStorageChange);
-    return () => {
-      window.removeEventListener('storage', handleStorageChange);
-    };
-  }, []);
-
-  const resyncWallet = React.useCallback(async () => {
-    if (typeof window === 'undefined') return;
-
-    if (isTransactionPending) {
-      setError({ message: 'Cannot resync wallet during a pending transaction' });
-      return;
-    }
-
-    const storedAddress = window.localStorage.getItem('stellarroute.wallet.address');
-    const storedWalletId = window.localStorage.getItem('stellarroute.wallet.walletId') as SupportedWallet | null;
-
-    if (storedWalletId && storedAddress) {
-      await connect(storedWalletId);
-    } else {
-      disconnect();
-    }
-    setSyncMismatch(false);
-  }, [connect, disconnect, isTransactionPending]);
-
-  const dismissSyncMismatch = React.useCallback(() => {
-    setSyncMismatch(false);
-  }, []);
-
   const networkMismatch = isConnected && walletNetwork !== null && walletNetwork !== network;
   const stubSpendableBalance = isConnected ? '10000.0000000' : null;
+
+  const refreshCapabilities = React.useCallback(async () => {
+    if (!walletId || !isConnected) {
+      setCapabilities(null);
+      return;
+    }
+    try {
+      const result = await checkWalletCapabilities(walletId, network);
+      setCapabilities(result);
+    } catch {
+      setCapabilities(null);
+    }
+  }, [walletId, isConnected, network]);
+
+  React.useEffect(() => {
+    if (walletId && isConnected) {
+      previousAddressRef.current = address;
+      previousNetworkRef.current = walletNetwork;
+      void refreshCapabilities();
+    }
+  }, [walletId, isConnected]);
+
+  React.useEffect(() => {
+    if (!isConnected || !walletId) return;
+
+    const addressChanged = previousAddressRef.current !== null &&
+      address !== null &&
+      address !== previousAddressRef.current;
+    const networkChanged = previousNetworkRef.current !== null &&
+      walletNetwork !== null &&
+      walletNetwork !== previousNetworkRef.current;
+
+    if (addressChanged || networkChanged) {
+      void refreshCapabilities();
+    }
+  }, [address, walletNetwork, isConnected, walletId, refreshCapabilities]);
 
   const value: WalletContextValue = {
     address,
@@ -385,9 +336,8 @@ export function WalletProvider({
     setTransactionPending: React.useCallback((pending: boolean) => {
       setIsTransactionPending(pending);
     }, []),
-    syncMismatch,
-    resyncWallet,
-    dismissSyncMismatch,
+    capabilities,
+    refreshCapabilities,
   };
 
   return (

--- a/frontend/components/shared/WalletCapabilitiesBanner.test.tsx
+++ b/frontend/components/shared/WalletCapabilitiesBanner.test.tsx
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { WalletCapabilitiesBanner } from './WalletCapabilitiesBanner';
+import * as WalletProvider from '@/components/providers/wallet-provider';
+
+vi.mock('@/components/providers/wallet-provider', () => ({
+  useWallet: vi.fn(),
+}));
+
+describe('WalletCapabilitiesBanner', () => {
+  it('does not render when capabilities are null', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: null,
+      walletId: 'freighter',
+      refreshCapabilities: vi.fn(),
+    } as any);
+
+    const { container } = render(<WalletCapabilitiesBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('does not render when all capabilities are allowed', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: {
+        checkedAt: Date.now(),
+        statuses: [
+          { capability: 'request_access', allowed: true },
+          { capability: 'view_address', allowed: true },
+          { capability: 'view_network', allowed: true },
+          { capability: 'sign_transaction', allowed: true },
+        ],
+      },
+      walletId: 'freighter',
+      refreshCapabilities: vi.fn(),
+    } as any);
+
+    const { container } = render(<WalletCapabilitiesBanner />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it('renders banner when capability is denied', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: {
+        checkedAt: Date.now(),
+        statuses: [
+          { capability: 'request_access', allowed: true },
+          { capability: 'view_address', allowed: false, reason: 'Access denied', resolution: 'Reconnect wallet' },
+          { capability: 'view_network', allowed: true },
+          { capability: 'sign_transaction', allowed: false },
+        ],
+      },
+      walletId: 'freighter',
+      refreshCapabilities: vi.fn(),
+    } as any);
+
+    render(<WalletCapabilitiesBanner />);
+    expect(screen.getByText(/wallet permissions required/i)).toBeInTheDocument();
+    expect(screen.getByText(/view address/i)).toBeInTheDocument();
+    expect(screen.getByText(/access denied/i)).toBeInTheDocument();
+    expect(screen.getByText(/reconnect wallet/i)).toBeInTheDocument();
+  });
+
+  it('shows sign_transaction denial with resolution', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: {
+        checkedAt: Date.now(),
+        statuses: [
+          { capability: 'request_access', allowed: true },
+          { capability: 'view_address', allowed: true },
+          { capability: 'view_network', allowed: false, reason: 'Network mismatch', resolution: 'Switch wallet network' },
+          { capability: 'sign_transaction', allowed: false, reason: 'Network mismatch', resolution: 'Switch wallet network' },
+        ],
+      },
+      walletId: 'freighter',
+      refreshCapabilities: vi.fn(),
+    } as any);
+
+    render(<WalletCapabilitiesBanner />);
+    expect(screen.getByText(/sign transactions/i)).toBeInTheDocument();
+    expect(screen.getByText(/network mismatch/i)).toBeInTheDocument();
+    expect(screen.getByText(/switch wallet network/i)).toBeInTheDocument();
+  });
+
+  it('calls refreshCapabilities when check again button clicked', async () => {
+    const user = userEvent.setup();
+    const refreshCapabilities = vi.fn();
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: {
+        checkedAt: Date.now(),
+        statuses: [
+          { capability: 'sign_transaction', allowed: false, resolution: 'Reconnect wallet' },
+        ],
+      },
+      walletId: 'freighter',
+      refreshCapabilities,
+    } as any);
+
+    render(<WalletCapabilitiesBanner />);
+    await user.click(screen.getByRole('button', { name: /check again/i }));
+    expect(refreshCapabilities).toHaveBeenCalled();
+  });
+
+  it('shows wallet docs link when available', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: {
+        checkedAt: Date.now(),
+        statuses: [
+          { capability: 'sign_transaction', allowed: false, resolution: 'Allow signing' },
+        ],
+      },
+      walletId: 'freighter',
+      refreshCapabilities: vi.fn(),
+    } as any);
+
+    render(<WalletCapabilitiesBanner />);
+    const link = screen.getByRole('link', { name: /wallet docs/i });
+    expect(link).toHaveAttribute('href', 'https://docs.freighter.app/docs/guide/gettingStarted');
+    expect(link).toHaveAttribute('target', '_blank');
+  });
+
+  it('shows xbull wallet docs', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: {
+        checkedAt: Date.now(),
+        statuses: [
+          { capability: 'sign_transaction', allowed: false },
+        ],
+      },
+      walletId: 'xbull',
+      refreshCapabilities: vi.fn(),
+    } as any);
+
+    render(<WalletCapabilitiesBanner />);
+    const link = screen.getByRole('link', { name: /wallet docs/i });
+    expect(link).toHaveAttribute('href', 'https://xbull.app/docs');
+  });
+
+  it('has proper ARIA attributes', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: {
+        checkedAt: Date.now(),
+        statuses: [
+          { capability: 'sign_transaction', allowed: false },
+        ],
+      },
+      walletId: 'freighter',
+      refreshCapabilities: vi.fn(),
+    } as any);
+
+    render(<WalletCapabilitiesBanner />);
+    const alert = screen.getByRole('alert');
+    expect(alert).toHaveAttribute('aria-live', 'polite');
+  });
+
+  it('shows multiple denied capabilities', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      capabilities: {
+        checkedAt: Date.now(),
+        statuses: [
+          { capability: 'request_access', allowed: false, reason: 'Not granted' },
+          { capability: 'view_address', allowed: false, reason: 'Address hidden' },
+          { capability: 'view_network', allowed: true },
+          { capability: 'sign_transaction', allowed: false },
+        ],
+      },
+      walletId: 'freighter',
+      refreshCapabilities: vi.fn(),
+    } as any);
+
+    render(<WalletCapabilitiesBanner />);
+    expect(screen.getByText(/wallet access/i)).toBeInTheDocument();
+    expect(screen.getByText(/view address/i)).toBeInTheDocument();
+    expect(screen.getByText(/sign transactions/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/shared/WalletCapabilitiesBanner.tsx
+++ b/frontend/components/shared/WalletCapabilitiesBanner.tsx
@@ -1,0 +1,136 @@
+'use client';
+
+import { ShieldX, ShieldCheck, RefreshCw, ExternalLink } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { useWallet } from '@/components/providers/wallet-provider';
+import { cn } from '@/lib/utils';
+import { useCallback } from 'react';
+
+const WALLET_DOCS: Record<string, string> = {
+  freighter: 'https://docs.freighter.app/docs/guide/gettingStarted',
+  xbull: 'https://xbull.app/docs',
+};
+
+interface WalletCapabilitiesBannerProps {
+  className?: string;
+}
+
+function getCapabilityLabel(capability: string): string {
+  switch (capability) {
+    case 'sign_transaction':
+      return 'Sign transactions';
+    case 'view_address':
+      return 'View address';
+    case 'view_network':
+      return 'View network';
+    case 'request_access':
+      return 'Wallet access';
+    default:
+      return capability;
+  }
+}
+
+function getCapabilityIcon(capability: string): typeof ShieldCheck {
+  switch (capability) {
+    case 'sign_transaction':
+      return ShieldX;
+    case 'view_address':
+      return ShieldX;
+    case 'view_network':
+      return ShieldX;
+    case 'request_access':
+      return ShieldX;
+    default:
+      return ShieldCheck;
+  }
+}
+
+export function WalletCapabilitiesBanner({ className }: WalletCapabilitiesBannerProps) {
+  const { capabilities, walletId, refreshCapabilities } = useWallet();
+
+  const handleRefresh = useCallback(() => {
+    void refreshCapabilities();
+  }, [refreshCapabilities]);
+
+  if (!capabilities) return null;
+
+  const denied = capabilities.statuses.filter((s) => !s.allowed);
+  if (denied.length === 0) return null;
+
+  const walletDocsUrl = walletId ? WALLET_DOCS[walletId] : null;
+
+  return (
+    <Alert
+      variant="destructive"
+      className={cn(
+        'relative border-red-500/50 bg-red-500/10 text-red-900 dark:text-red-100',
+        className
+      )}
+      role="alert"
+      aria-live="polite"
+    >
+      <ShieldX className="h-4 w-4 text-red-600 dark:text-red-400" />
+      <AlertDescription className="flex flex-col gap-3 pr-8">
+        <div className="text-sm font-medium">
+          Wallet permissions required
+        </div>
+        <div className="flex flex-col gap-2 text-xs text-red-800 dark:text-red-200">
+          {denied.map((status) => {
+            const Icon = getCapabilityIcon(status.capability);
+            return (
+              <div
+                key={status.capability}
+                className="flex items-start gap-2"
+              >
+                <Icon className="h-3.5 w-3.5 mt-0.5 shrink-0" />
+                <div className="flex flex-col">
+                  <span className="font-medium">
+                    {getCapabilityLabel(status.capability)}
+                  </span>
+                  {status.reason && (
+                    <span className="opacity-80">{status.reason}</span>
+                  )}
+                  {status.resolution && (
+                    <span className="font-medium text-red-700 dark:text-red-300">
+                      {status.resolution}
+                    </span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+        <div className="flex flex-wrap items-center gap-2">
+          {walletDocsUrl && (
+            <Button
+              variant="outline"
+              size="sm"
+              asChild
+              className="h-8 text-xs border-red-600/30 hover:bg-red-500/20"
+            >
+              <a
+                href={walletDocsUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex items-center gap-1.5"
+              >
+                Wallet docs
+                <ExternalLink className="h-3 w-3" />
+              </a>
+            </Button>
+          )}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            className="h-8 text-xs border-red-600/30 hover:bg-red-500/20"
+          >
+            <RefreshCw className="h-3 w-3 mr-1" />
+            Check again
+          </Button>
+        </div>
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/frontend/components/swap/SwapButton.tsx
+++ b/frontend/components/swap/SwapButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from "@/components/ui/button";
-import { Loader2, AlertCircle, Wallet } from "lucide-react";
+import { Loader2, AlertCircle, Wallet, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSwapI18n } from "@/lib/swap-i18n";
 
@@ -14,7 +14,8 @@ export type SwapButtonState =
   | "refreshing_quote"
   | "ready"
   | "executing"
-  | "error";
+  | "error"
+  | "permission_blocked";
 
 interface SwapButtonProps {
   state: SwapButtonState;
@@ -96,6 +97,14 @@ export function SwapButton({
           disabled: true,
           variant: "outline" as const,
           className: "border-destructive/50 text-destructive",
+        };
+      case "permission_blocked":
+        return {
+          label: "Wallet permissions required",
+          disabled: true,
+          variant: "destructive" as const,
+          icon: <ShieldOff className="mr-2 h-5 w-5" />,
+          className: "bg-destructive/10 text-destructive border border-destructive/20",
         };
       case "ready":
       default:

--- a/frontend/components/swap/SwapButton.tsx
+++ b/frontend/components/swap/SwapButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from "@/components/ui/button";
-import { Loader2, AlertCircle, Wallet } from "lucide-react";
+import { Loader2, AlertCircle, Wallet, ShieldOff } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSwapI18n } from "@/lib/swap-i18n";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
@@ -15,7 +15,8 @@ export type SwapButtonState =
   | "refreshing_quote"
   | "ready"
   | "executing"
-  | "error";
+  | "error"
+  | "permission_blocked";
 
 interface SwapButtonProps {
   state: SwapButtonState;
@@ -101,6 +102,14 @@ export function SwapButton({
           disabled: true,
           variant: "outline" as const,
           className: "border-destructive/50 text-destructive",
+        };
+      case "permission_blocked":
+        return {
+          label: "Wallet permissions required",
+          disabled: true,
+          variant: "destructive" as const,
+          icon: <ShieldOff className="mr-2 h-5 w-5" />,
+          className: "bg-destructive/10 text-destructive border border-destructive/20",
         };
       case "ready":
       default:

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -26,6 +26,8 @@ import { useCompactMode } from '@/hooks/useCompactMode';
 import { useShareableQuote } from '@/hooks/useShareableQuote';
 import { ShareQuoteButton } from './ShareQuoteButton';
 import { NetworkMismatchBanner } from '@/components/shared/NetworkMismatchBanner';
+import { WalletCapabilitiesBanner } from '@/components/shared/WalletCapabilitiesBanner';
+import { useWallet } from '@/components/providers/wallet-provider';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useSwapI18n } from '@/lib/swap-i18n';
@@ -106,6 +108,9 @@ export function SwapCard() {
     isOnline,
   });
 
+  // Wallet capabilities for swap permission checks
+  const { isConnected, capabilities } = useWallet();
+
   const optimistic = useOptimisticSwap({
     rollbackTarget: {
       setFromToken,
@@ -132,17 +137,25 @@ export function SwapCard() {
     if (quote.priceImpact > 10) return "high_impact_warning";
     if (quote.loading) return "refreshing_quote";
     if (quote.isStale) return "error";
+    // Check capability: sign_transaction
+    if (capabilities) {
+      const signCap = capabilities.statuses.find(
+        (s) => s.capability === "sign_transaction"
+      );
+      if (signCap && !signCap.allowed) return "permission_blocked";
+    }
     return "ready";
   }, [
     fromAmount,
     fromBalance,
     isConnected,
-    isSwapping,
     quote.error,
     quote.isStale,
     quote.loading,
     quote.priceImpact,
     requiresFreshQuote,
+    capabilities,
+    optimistic.submitLock,
   ]);
 
   useEffect(() => {
@@ -347,6 +360,9 @@ export function SwapCard() {
     <div data-testid="swap-card" className="w-full max-w-[480px] mx-auto perspective-1000">
       {/* Network Mismatch Banner */}
       <NetworkMismatchBanner className="mb-4" />
+      
+      {/* Wallet Capabilities Banner */}
+      <WalletCapabilitiesBanner className="mb-4" />
       
       {/* Shared Quote Stale Warning */}
       {isSharedQuoteStale && refreshSharedQuote && (

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useCallback, useMemo, useEffect } from 'react';
+import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { ArrowUpDown, RefreshCw } from 'lucide-react';
@@ -12,15 +12,51 @@ import type { AlternativeRoute } from './RouteDisplay';
 import { SwapButton, SwapButtonState } from './SwapButton';
 import { SettingsPanel } from '../settings/SettingsPanel';
 import { HighImpactConfirmModal } from './HighImpactConfirmModal';
+import { TransactionConfirmationModal } from './TransactionConfirmationModal';
 import { QuoteStreamStatusIndicator } from './QuoteStreamStatusIndicator';
+import { SessionRecoveryModal } from './SessionRecoveryModal';
 import { useSwapState } from '@/hooks/useSwapState';
+import {
+  SESSION_RECOVERY_THRESHOLD_MS,
+  type TradeFormSnapshot,
+} from '@/hooks/useTradeFormStorage';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useQuoteStreamStatus } from '@/hooks/useQuoteStreamStatus';
+import { useCompactMode } from '@/hooks/useCompactMode';
+import { useShareableQuote } from '@/hooks/useShareableQuote';
+import { ShareQuoteButton } from './ShareQuoteButton';
+import { NetworkMismatchBanner } from '@/components/shared/NetworkMismatchBanner';
+import { WalletCapabilitiesBanner } from '@/components/shared/WalletCapabilitiesBanner';
+import { useWallet } from '@/components/providers/wallet-provider';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
-import { emitRouteEvent, getPriceImpactTier } from '@/lib/telemetry';
+import { useSwapI18n } from '@/lib/swap-i18n';
+import { quoteExportToCsv, type QuoteExportPayload } from '@/lib/quote-export';
+import { Maximize2, Minimize2 } from 'lucide-react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
 
 export function SwapCard() {
+  const { t } = useSwapI18n();
+  const { isCompact, toggleCompact } = useCompactMode();
+  // Wrap useSearchParams in try-catch for SSR
+  let parseParams: ReturnType<typeof useShareableQuote>['parseParams'] | null = null;
+  let isSharedQuoteStale = false;
+  let refreshSharedQuote: ReturnType<typeof useShareableQuote>['refreshQuote'] | null = null;
+  
+  try {
+    const shareableQuote = useShareableQuote();
+    parseParams = shareableQuote.parseParams;
+    isSharedQuoteStale = shareableQuote.isStale;
+    refreshSharedQuote = shareableQuote.refreshQuote;
+  } catch (e) {
+    // SSR or missing searchParams context
+  }
+  
   const {
     fromToken,
     setFromToken,
@@ -30,15 +66,39 @@ export function SwapCard() {
     setFromAmount,
     toAmount,
     slippage,
+    setSlippage,
+    deadline,
+    setDeadline,
     quote,
     switchTokens,
     formattedRate,
+    pendingRecovery,
+    restorePending,
+    discardPending,
+    hasRecoverableState,
+    snapshotCurrent,
+    reset,
   } = useSwapState();
 
   const [isConnected, setIsConnected] = useState(false);
-  const [isSwapping, setIsSwapping] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
+  const [isModalOpen, setIsModalOpen] = useState(false);
   const [selectedRoute, setSelectedRoute] = useState<AlternativeRoute | null>(null);
+  const [wakeSnapshot, setWakeSnapshot] = useState<TradeFormSnapshot | null>(null);
+  const [wakeRecoveryOpen, setWakeRecoveryOpen] = useState(false);
+  const [recoveryRequestedAt, setRecoveryRequestedAt] = useState<number | null>(null);
+  const [isRecoveringSession, setIsRecoveringSession] = useState(false);
+  const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
+  const lastFocusedElementRef = useRef<HTMLElement | null>(null);
+  const hiddenAtRef = useRef<number | null>(null);
+  const recoveryReason: 'refresh' | 'wake' | null = wakeRecoveryOpen
+    ? 'wake'
+    : pendingRecovery
+      ? 'refresh'
+      : null;
+  const requiresFreshQuote =
+    recoveryRequestedAt !== null &&
+    (quote.loading || quote.isStale);
 
   // Connection status indicator
   const { isOnline } = useOnlineStatus();
@@ -47,41 +107,169 @@ export function SwapCard() {
     error: quote.error,
     isOnline,
   });
-  
+
+  // Wallet capabilities for swap permission checks
+  const { isConnected, capabilities } = useWallet();
+
+  const optimistic = useOptimisticSwap({
+    rollbackTarget: {
+      setFromToken,
+      setToToken,
+      setFromAmount,
+      setSlippage,
+      setSelectedRoute: (id) => setSelectedRoute(id ? { id, venue: '', expectedAmount: '' } : null),
+      refreshQuote: quote.refresh,
+    },
+  });
+
   // Mock balance
-  const fromBalance = "100.00"; 
+  const fromBalance = "100.00";
   const fromSymbol = fromToken === 'native' ? 'XLM' : fromToken.split(':')[0];
   const toSymbol = toToken === 'native' ? 'XLM' : toToken.split(':')[0];
 
   const buttonState = useMemo<SwapButtonState>(() => {
-    if (isSwapping) return "executing";
+    if (optimistic.submitLock) return "executing";
     if (!isConnected) return "no_wallet";
     if (!fromAmount || parseFloat(fromAmount) === 0) return "no_amount";
+    if (quote.error) return "error";
+    if (requiresFreshQuote) return "refreshing_quote";
     if (parseFloat(fromAmount) > parseFloat(fromBalance)) return "insufficient_balance";
     if (quote.priceImpact > 10) return "high_impact_warning";
+    if (quote.loading) return "refreshing_quote";
     if (quote.isStale) return "error";
-    if (quote.error) return "error";
+    // Check capability: sign_transaction
+    if (capabilities) {
+      const signCap = capabilities.statuses.find(
+        (s) => s.capability === "sign_transaction"
+      );
+      if (signCap && !signCap.allowed) return "permission_blocked";
+    }
     return "ready";
-  }, [isConnected, fromAmount, fromBalance, quote.priceImpact, quote.isStale, quote.error, isSwapping]);
+  }, [
+    fromAmount,
+    fromBalance,
+    isConnected,
+    quote.error,
+    quote.isStale,
+    quote.loading,
+    quote.priceImpact,
+    requiresFreshQuote,
+    capabilities,
+    optimistic.submitLock,
+  ]);
 
-  const executeSwap = useCallback(async () => {
-    setIsSwapping(true);
-    // Simulate transaction delay
-    await new Promise(resolve => setTimeout(resolve, 2000));
-    setIsSwapping(false);
-    toast.success(`Successfully swapped ${fromAmount} ${fromSymbol} for ${parseFloat(toAmount).toFixed(4)} ${toSymbol}`);
-  }, [fromAmount, fromSymbol, toAmount, toSymbol]);
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === 'hidden') {
+        hiddenAtRef.current = Date.now();
+        return;
+      }
 
-  const handleSwap = useCallback(async () => {
+      const hiddenAt = hiddenAtRef.current;
+      hiddenAtRef.current = null;
+
+      if (
+        document.visibilityState !== 'visible' ||
+        hiddenAt === null ||
+        Date.now() - hiddenAt < SESSION_RECOVERY_THRESHOLD_MS ||
+        !hasRecoverableState
+      ) {
+        return;
+      }
+
+      setWakeRecoveryOpen(true);
+      setWakeSnapshot(snapshotCurrent());
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+    };
+  }, [hasRecoverableState, snapshotCurrent]);
+
+  const closeRecoveryModal = useCallback(() => {
+    setWakeRecoveryOpen(false);
+    setWakeSnapshot(null);
+  }, []);
+
+  const handleDiscardRecovery = useCallback(() => {
+    if (recoveryReason === 'refresh') {
+      discardPending();
+    } else {
+      reset();
+      setSelectedRoute(null);
+    }
+    setRecoveryRequestedAt(null);
+    closeRecoveryModal();
+  }, [closeRecoveryModal, discardPending, recoveryReason, reset]);
+
+  const handleRestoreRecovery = useCallback(async () => {
+    setSelectedRoute(null);
+    setRecoveryRequestedAt(Date.now());
+    setIsRecoveringSession(true);
+
+    try {
+      if (recoveryReason === 'refresh') {
+        restorePending();
+        closeRecoveryModal();
+        // Force quote refresh after restoring form state
+        quote.refresh();
+      } else {
+        closeRecoveryModal();
+        quote.refresh();
+      }
+    } catch (error) {
+      console.error('Failed to restore session:', error);
+      throw error; // Let modal handle the error display
+    } finally {
+      setIsRecoveringSession(false);
+    }
+  }, [closeRecoveryModal, quote, recoveryReason, restorePending]);
+
+  const handleConfirm = useCallback(() => {
+    const snap: PreSubmitSnapshot = {
+      fromToken,
+      toToken,
+      fromAmount,
+      slippage,
+      selectedRouteId: selectedRoute?.id ?? null,
+    };
+    setIsModalOpen(true);
+    optimistic.initiateSwap({
+      fromAsset: fromToken,
+      fromAmount,
+      toAsset: toToken,
+      toAmount: selectedRoute?.expectedAmount ?? toAmount,
+      exchangeRate: formattedRate,
+      priceImpact: quote.priceImpact.toString(),
+      minReceived: `${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`,
+      networkFee: quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM',
+      routePath: [],
+      walletAddress: 'mock_wallet_address',
+      snapshot: snap,
+    });
+  }, [fromToken, toToken, fromAmount, slippage, selectedRoute, toAmount, formattedRate, quote, toSymbol, optimistic]);
+
+  const handleSwap = useCallback(() => {
     if (quote.priceImpact > 5) {
       setIsConfirmModalOpen(true);
       return;
     }
-    await executeSwap();
-  }, [quote.priceImpact, executeSwap]);
+    handleConfirm();
+  }, [quote.priceImpact, handleConfirm]);
 
   const handleMax = useCallback(() => {
     setFromAmount(fromBalance);
+  }, [fromBalance, setFromAmount]);
+
+  const handlePresetSelect = useCallback((percentage: number) => {
+    const balanceNum = parseFloat(fromBalance);
+    if (isNaN(balanceNum) || balanceNum === 0) return;
+    
+    const amount = balanceNum * percentage;
+    // Round to 7 decimals to respect asset precision
+    const rounded = Math.floor(amount * 10000000) / 10000000;
+    setFromAmount(rounded.toString());
   }, [fromBalance, setFromAmount]);
 
   const handleSwitchTokens = useCallback(() => {
@@ -89,70 +277,161 @@ export function SwapCard() {
     switchTokens();
   }, [switchTokens]);
 
-  const telemetryPayload = useMemo(() => {
-    const hasDex = quote.data?.path.some(step => step.source === 'sdex') ?? false;
-    const hasAmm = quote.data?.path.some(step => step.source === 'soroban' || step.source === 'amm') ?? false;
-    return {
-      fromAssetCode: fromSymbol,
-      toAssetCode: toSymbol,
-      routeLength: Math.max(1, quote.data?.path.length ?? 1),
-      priceImpactTier: getPriceImpactTier(quote.priceImpact),
-      hasDex,
-      hasAmm,
-    };
-  }, [fromSymbol, toSymbol, quote.data?.path, quote.priceImpact]);
-
-  // Emit route_view when a new quote is successfully loaded
   useEffect(() => {
-    if (quote.data && !quote.loading && parseFloat(fromAmount) > 0) {
-      emitRouteEvent('route_view', telemetryPayload);
-    }
-  }, [quote.data, quote.loading, fromAmount, telemetryPayload]);
+    const onKeydown = (event: KeyboardEvent) => {
+      const target = event.target as HTMLElement | null;
+      const isEditable = target
+        ? target.tagName === "INPUT" ||
+          target.tagName === "TEXTAREA" ||
+          target.isContentEditable
+        : false;
 
-  const handleRouteSelect = useCallback((route: AlternativeRoute) => {
-    setSelectedRoute(route);
-    emitRouteEvent('route_select', {
-      ...telemetryPayload,
-      hasDex: route.venue.includes('SDEX'),
-      hasAmm: route.venue.includes('Pool') || route.venue.includes('AMM'),
+      if (event.key === "?" && !isEditable) {
+        event.preventDefault();
+        lastFocusedElementRef.current = document.activeElement as HTMLElement;
+        setShortcutHelpOpen(true);
+      }
+
+      if (event.key.toLowerCase() === "r" && event.altKey) {
+        event.preventDefault();
+        quote.refresh();
+      }
+
+      if (event.key === "1" && event.altKey) {
+        event.preventDefault();
+        document.querySelectorAll<HTMLInputElement>('input[placeholder="0.00"]')[0]?.focus();
+      }
+
+      if (event.key === "2" && event.altKey) {
+        event.preventDefault();
+        document.querySelectorAll<HTMLInputElement>('input[placeholder="0.00"]')[1]?.focus();
+      }
+    };
+
+    window.addEventListener("keydown", onKeydown);
+    return () => window.removeEventListener("keydown", onKeydown);
+  }, [quote]);
+
+  const handleShortcutOpenChange = useCallback((open: boolean) => {
+    setShortcutHelpOpen(open);
+    if (!open) {
+      lastFocusedElementRef.current?.focus();
+    }
+  }, []);
+
+  const handleExport = useCallback((format: "json" | "csv") => {
+    const payload: QuoteExportPayload = {
+      exportedAt: new Date().toISOString(),
+      market: {
+        fromAsset: fromSymbol,
+        toAsset: toSymbol,
+        fromAmount,
+        expectedToAmount: toAmount,
+      },
+      pricing: {
+        rate: formattedRate,
+        priceImpactPct: quote.priceImpact.toFixed(2),
+        minimumReceived: `${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`,
+        networkFee: quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM',
+      },
+      route: {
+        selectedVenue: selectedRoute?.venue ?? "auto",
+        routeSummary:
+          selectedRoute?.hops?.map((hop) => `${hop.fromAsset}->${hop.toAsset}`).join(" | ") ??
+          "best-route",
+      },
+    };
+    const serialized = format === "json"
+      ? JSON.stringify(payload, null, 2)
+      : quoteExportToCsv(payload);
+    const blob = new Blob([serialized], {
+      type: format === "json" ? "application/json" : "text/csv;charset=utf-8",
     });
-  }, [telemetryPayload]);
-
-  const executeSwapWithTelemetry = useCallback(async () => {
-    emitRouteEvent('route_confirm', telemetryPayload);
-    await executeSwap();
-  }, [executeSwap, telemetryPayload]);
-
-  const handleSwapWithTelemetry = useCallback(async () => {
-    if (quote.priceImpact > 5) {
-      setIsConfirmModalOpen(true);
-      return;
-    }
-    await executeSwapWithTelemetry();
-  }, [quote.priceImpact, executeSwapWithTelemetry]);
+    const url = URL.createObjectURL(blob);
+    const anchor = document.createElement("a");
+    anchor.href = url;
+    anchor.download = `stellarroute-quote-summary.${format}`;
+    anchor.click();
+    URL.revokeObjectURL(url);
+    toast.success(t("swap.quote.exportSuccess", { format: format.toUpperCase() }));
+  }, [formattedRate, fromAmount, fromSymbol, quote.fee, quote.priceImpact, selectedRoute, slippage, t, toAmount, toSymbol]);
 
   return (
     <div data-testid="swap-card" className="w-full max-w-[480px] mx-auto perspective-1000">
-      <Card className="relative overflow-hidden border-border/40 bg-background/60 backdrop-blur-xl shadow-2xl rounded-[32px] transition-all duration-500 hover:shadow-primary/5">
+      {/* Network Mismatch Banner */}
+      <NetworkMismatchBanner className="mb-4" />
+      
+      {/* Wallet Capabilities Banner */}
+      <WalletCapabilitiesBanner className="mb-4" />
+      
+      {/* Shared Quote Stale Warning */}
+      {isSharedQuoteStale && refreshSharedQuote && (
+        <div className="mb-4 p-3 rounded-xl border border-amber-500/50 bg-amber-500/10">
+          <p className="text-xs text-amber-800 dark:text-amber-200 mb-2">
+            This shared quote is outdated. Refresh to get current pricing.
+          </p>
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={refreshSharedQuote}
+            className="h-7 text-xs"
+          >
+            Refresh Quote
+          </Button>
+        </div>
+      )}
+      
+      <Card className={cn(
+        "relative overflow-hidden border-border/40 bg-background/60 backdrop-blur-xl shadow-2xl rounded-[32px] transition-all duration-500 hover:shadow-primary/5",
+        isCompact && "rounded-2xl"
+      )}>
         {/* Animated Background Gradients */}
         <div className="absolute -top-24 -left-24 w-48 h-48 bg-primary/10 rounded-full blur-3xl animate-pulse" />
         <div className="absolute -bottom-24 -right-24 w-48 h-48 bg-blue-500/10 rounded-full blur-3xl animate-pulse delay-700" />
         
-        <CardContent className="p-6 space-y-4">
+        <CardContent className={cn(
+          "space-y-4",
+          isCompact ? "p-4" : "p-6"
+        )}>
           {/* Header */}
           <div className="flex items-center justify-between mb-2">
-            <h2 className="text-xl font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/60 bg-clip-text text-transparent">
+            <h2 className={cn(
+              "font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/60 bg-clip-text text-transparent",
+              isCompact ? "text-lg" : "text-xl"
+            )}>
               Swap
             </h2>
             <div className="flex items-center gap-1">
               <QuoteStreamStatusIndicator status={streamStatus} mode={streamMode} />
-              <SettingsPanel />
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={toggleCompact}
+                aria-label={isCompact ? "Expand layout" : "Compact layout"}
+                className="h-9 w-9 rounded-xl hover:bg-muted/80"
+              >
+                {isCompact ? (
+                  <Maximize2 className="h-4.5 w-4.5 text-muted-foreground" />
+                ) : (
+                  <Minimize2 className="h-4.5 w-4.5 text-muted-foreground" />
+                )}
+              </Button>
+              <SettingsPanel
+                slippage={slippage}
+                onSlippageChange={setSlippage}
+                deadline={deadline}
+                onDeadlineChange={setDeadline}
+                onReset={() => {
+      reset();
+      setSelectedRoute(null);
+    }}
+              />
               <Button 
                 variant="ghost" 
                 size="icon" 
                 onClick={() => quote.refresh()} 
                 disabled={quote.loading}
-                aria-label="Refresh quote"
+                aria-label={t("swap.card.refreshQuote")}
                 className="h-9 w-9 rounded-xl hover:bg-muted/80"
               >
                 <RefreshCw className={cn("h-4.5 w-4.5 text-muted-foreground", quote.loading && "animate-spin")} />
@@ -161,15 +440,20 @@ export function SwapCard() {
           </div>
 
           {/* Pay Section */}
-          <div className="space-y-2 group">
-            <div className="bg-muted/30 hover:bg-muted/40 transition-colors rounded-2xl p-4 border border-border/20 focus-within:border-primary/30 focus-within:ring-4 focus-within:ring-primary/5">
+          <div className={cn("space-y-2 group", isCompact && "space-y-1")}>
+            <div className={cn(
+              "bg-muted/30 hover:bg-muted/40 transition-colors rounded-2xl border border-border/20 focus-within:border-primary/30 focus-within:ring-4 focus-within:ring-primary/5",
+              isCompact ? "p-3 rounded-xl" : "p-4"
+            )}>
               <div className="flex justify-between items-start mb-1">
                 <AmountInput
-                  label="You Pay"
+                  label={t("swap.pair.youPay")}
                   value={fromAmount}
                   onChange={setFromAmount}
                   onMax={handleMax}
+                  onPresetSelect={handlePresetSelect}
                   balance={`${fromBalance} ${fromSymbol}`}
+                  showPresets={isConnected}
                   className="flex-1"
                 />
                 <TokenSelector
@@ -194,11 +478,14 @@ export function SwapCard() {
           </div>
 
           {/* Receive Section */}
-          <div className="space-y-2">
-            <div className="bg-muted/30 rounded-2xl p-4 border border-border/20">
+          <div className={cn("space-y-2", isCompact && "space-y-1")}>
+            <div className={cn(
+              "bg-muted/30 rounded-2xl border border-border/20",
+              isCompact ? "p-3 rounded-xl" : "p-4"
+            )}>
               <div className="flex justify-between items-start mb-1">
                 <AmountInput
-                  label="You Receive"
+                  label={t("swap.pair.youReceive")}
                   value={selectedRoute?.expectedAmount ?? toAmount}
                   readOnly
                   placeholder="0.00"
@@ -216,19 +503,36 @@ export function SwapCard() {
 
           {/* Info Panels (Conditional) */}
           {parseFloat(fromAmount) > 0 && (
-            <div className="space-y-3 pt-2 animate-in fade-in slide-in-from-bottom-2 duration-500">
+            <div className={cn(
+              "space-y-3 animate-in fade-in slide-in-from-bottom-2 duration-500",
+              isCompact ? "space-y-2 pt-1" : "pt-2"
+            )}>
               <PriceInfoPanel
                 rate={formattedRate}
                 priceImpact={quote.priceImpact}
                 minReceived={`${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`}
                 networkFee={quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM'}
                 isLoading={quote.loading}
+                onExportJson={() => handleExport("json")}
+                onExportCsv={() => handleExport("csv")}
               />
               <RouteDisplay
                 amountOut={selectedRoute?.expectedAmount ?? toAmount}
                 isLoading={quote.loading}
-                onSelect={handleRouteSelect}
+                onSelect={setSelectedRoute}
               />
+              {/* Share Quote Button */}
+              <div className="flex justify-end">
+                <ShareQuoteButton
+                  params={{
+                    from: fromToken,
+                    to: toToken,
+                    amount: fromAmount,
+                    slippage: slippage.toString(),
+                  }}
+                  disabled={!fromAmount || parseFloat(fromAmount) === 0}
+                />
+              </div>
             </div>
           )}
 
@@ -238,7 +542,41 @@ export function SwapCard() {
               data-testid="stale-indicator"
               className="text-xs text-amber-500 font-medium"
             >
-              Quote outdated — refresh for latest price
+              {t("swap.card.outdated")}
+            </span>
+          )}
+          {quote.isRecovering && (
+            <div
+              data-testid="recovering-indicator"
+              className="flex items-center justify-between gap-3 rounded-xl border border-blue-500/20 bg-blue-500/5 px-3 py-2"
+            >
+              <span className="text-xs text-blue-500 font-medium">
+                {quote.hasPendingRetry
+                  ? t("swap.card.recoveringQuoteCountdown", {
+                      seconds: Math.max(1, Math.ceil(quote.pendingRetryRemainingMs / 1000)),
+                    })
+                  : t("swap.card.recoveringQuote")}
+              </span>
+              {quote.hasPendingRetry && (
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={quote.cancelRetry}
+                  className="h-7 rounded-lg px-2 text-[11px] font-semibold text-blue-600 hover:bg-blue-500/10 hover:text-blue-700"
+                >
+                  {t("swap.card.cancelRetry")}
+                </Button>
+              )}
+            </div>
+          )}
+
+          {requiresFreshQuote && (
+            <span
+              data-testid="recovery-refresh-indicator"
+              className="text-xs font-medium text-primary"
+            >
+              {t("swap.card.sessionRestored")}
             </span>
           )}
 
@@ -246,12 +584,12 @@ export function SwapCard() {
           <div className="pt-2">
             <SwapButton
               state={buttonState}
-              onSwap={handleSwapWithTelemetry}
+              onSwap={handleSwap}
               onConnectWallet={() => setIsConnected(true)}
               isLoading={quote.loading}
             />
           </div>
-          
+
           {/* Status/Error Messages */}
           {quote.error && (
             <p className="text-center text-xs font-medium text-destructive animate-pulse">
@@ -260,12 +598,15 @@ export function SwapCard() {
           )}
         </CardContent>
       </Card>
-      
-      {/* High Impact Confirmation Modal */}
+
+      {/* High Impact Confirmation Modal — separate purpose: warns before the review step */}
       <HighImpactConfirmModal
         isOpen={isConfirmModalOpen}
         onClose={() => setIsConfirmModalOpen(false)}
-        onConfirm={executeSwapWithTelemetry}
+        onConfirm={() => {
+          setIsConfirmModalOpen(false);
+          handleConfirm();
+        }}
         priceImpact={quote.priceImpact}
         fromAmount={fromAmount}
         fromSymbol={fromSymbol}
@@ -273,11 +614,34 @@ export function SwapCard() {
         toSymbol={toSymbol}
       />
 
+      <SessionRecoveryModal
+        isOpen={recoveryReason !== null}
+        reason={recoveryReason ?? 'refresh'}
+        snapshot={recoveryReason === 'refresh' ? pendingRecovery : wakeSnapshot}
+        isRecovering={isRecoveringSession}
+        onRestore={handleRestoreRecovery}
+        onDiscard={handleDiscardRecovery}
+      />
+
       {/* Footer Info */}
       <p className="text-center text-[10px] text-muted-foreground/60 mt-4 px-8 uppercase tracking-widest font-bold">
-        Powered by StellarRoute Aggregator
+        {t("swap.card.poweredBy")}
       </p>
+
+      <Dialog open={shortcutHelpOpen} onOpenChange={handleShortcutOpenChange}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>{t("swap.shortcuts.title")}</DialogTitle>
+          </DialogHeader>
+          <ul className="space-y-3 text-sm">
+            <li className="flex justify-between"><span>{t("swap.shortcuts.openHelp")}</span><kbd className="font-mono">?</kbd></li>
+            <li className="flex justify-between"><span>{t("swap.shortcuts.closeHelp")}</span><kbd className="font-mono">Esc</kbd></li>
+            <li className="flex justify-between"><span>{t("swap.shortcuts.refreshQuote")}</span><kbd className="font-mono">Alt+R</kbd></li>
+            <li className="flex justify-between"><span>{t("swap.shortcuts.focusPayAmount")}</span><kbd className="font-mono">Alt+1</kbd></li>
+            <li className="flex justify-between"><span>{t("swap.shortcuts.focusReceiveAmount")}</span><kbd className="font-mono">Alt+2</kbd></li>
+          </ul>
+        </DialogContent>
+      </Dialog>
     </div>
   );
 }
-

--- a/frontend/lib/wallet/index.ts
+++ b/frontend/lib/wallet/index.ts
@@ -6,7 +6,7 @@ import {
   signTransaction,
 } from "@stellar/freighter-api";
 
-import type { AvailableWallet, SupportedWallet, WalletSession } from "./types";
+import type { AvailableWallet, SupportedWallet, WalletSession, Capabilities, Capability, CapabilityStatus } from "./types";
 
 export const WALLET_LABELS: Record<SupportedWallet, string> = {
   freighter: "Freighter",
@@ -84,6 +84,123 @@ export async function connectWallet(
   }
 
   throw new Error(`Unsupported wallet: ${walletId}`);
+}
+
+function getCapabilityResolution(capability: Capability): string {
+  switch (capability) {
+    case "sign_transaction":
+      return "Allow transaction signing in your wallet settings";
+    case "view_address":
+      return "Allow account access in your wallet settings";
+    case "view_network":
+      return "Switch to the matching network in your wallet";
+    case "request_access":
+      return "Reconnect your wallet to grant access";
+  }
+}
+
+export async function checkWalletCapabilities(
+  walletId: SupportedWallet,
+  network: string
+): Promise<Capabilities> {
+  const statuses: CapabilityStatus[] = [];
+
+  if (walletId === "freighter") {
+    try {
+      const accessRes = await requestAccess();
+      statuses.push({
+        capability: "request_access",
+        allowed: !accessRes.error,
+        reason: accessRes.error?.message,
+        resolution: accessRes.error ? getCapabilityResolution("request_access") : undefined,
+      });
+    } catch (e) {
+      statuses.push({
+        capability: "request_access",
+        allowed: false,
+        reason: "Failed to check wallet access",
+        resolution: getCapabilityResolution("request_access"),
+      });
+    }
+
+    try {
+      const addressRes = await getAddress();
+      const hasAddress = !addressRes.error && !!addressRes.address;
+      statuses.push({
+        capability: "view_address",
+        allowed: hasAddress,
+        reason: addressRes.error?.message,
+        resolution: hasAddress ? undefined : getCapabilityResolution("view_address"),
+      });
+    } catch (e) {
+      statuses.push({
+        capability: "view_address",
+        allowed: false,
+        reason: "Failed to get address",
+        resolution: getCapabilityResolution("view_address"),
+      });
+    }
+
+    try {
+      const networkRes = await getNetworkDetails();
+      const hasNetwork = !networkRes.error && !!networkRes.network;
+      const networkMatch = hasNetwork && networkRes.network === network;
+      statuses.push({
+        capability: "view_network",
+        allowed: networkMatch,
+        reason: networkMatch ? undefined : `Wallet on ${networkRes.network}, expected ${network}`,
+        resolution: networkMatch ? undefined : "Switch wallet network to match the app",
+      });
+    } catch (e) {
+      statuses.push({
+        capability: "view_network",
+        allowed: false,
+        reason: "Failed to get network details",
+        resolution: getCapabilityResolution("view_network"),
+      });
+    }
+
+    const signCap = statuses.find((s) => s.capability === "view_address");
+    const netCap = statuses.find((s) => s.capability === "view_network");
+    statuses.push({
+      capability: "sign_transaction",
+      allowed: signCap?.allowed && netCap?.allowed,
+      reason: !signCap?.allowed
+        ? "No address available"
+        : !netCap?.allowed
+          ? "Network mismatch"
+          : undefined,
+      resolution: !signCap?.allowed || !netCap?.allowed
+        ? getCapabilityResolution("sign_transaction")
+        : undefined,
+    });
+  } else if (walletId === "xbull") {
+    statuses.push({
+      capability: "request_access",
+      allowed: true,
+    });
+    statuses.push({
+      capability: "view_address",
+      allowed: true,
+    });
+    statuses.push({
+      capability: "view_network",
+      allowed: true,
+      reason: network === "testnet" ? undefined : "xBull only supports testnet",
+      resolution: network !== "testnet" ? "Switch app to testnet" : undefined,
+    });
+    statuses.push({
+      capability: "sign_transaction",
+      allowed: network === "testnet",
+      reason: network === "testnet" ? undefined : "xBull only supports testnet",
+      resolution: network !== "testnet" ? "Switch app to testnet" : undefined,
+    });
+  }
+
+  return {
+    checkedAt: Date.now(),
+    statuses,
+  };
 }
 
 export function disconnectWallet(): WalletSession {

--- a/frontend/lib/wallet/types.ts
+++ b/frontend/lib/wallet/types.ts
@@ -25,3 +25,21 @@ export type AccountSwitchState = {
   hasChanged: boolean;
   previousAddress: string | null;
 };
+
+export type Capability =
+  | "sign_transaction"
+  | "view_address"
+  | "view_network"
+  | "request_access";
+
+export type CapabilityStatus = {
+  capability: Capability;
+  allowed: boolean;
+  reason?: string;
+  resolution?: string;
+};
+
+export type Capabilities = {
+  checkedAt: number;
+  statuses: CapabilityStatus[];
+};


### PR DESCRIPTION
Summary
- Add wallet capability/permission status display to show why swap actions are enabled or blocked
- Capability cache invalidates automatically on account/network change in WalletProvider
- Integration tests cover capability denial paths
Changes
frontend/lib/wallet/types.ts
- Added Capability, CapabilityStatus, and Capabilities types
frontend/lib/wallet/index.ts
- Added checkWalletCapabilities() function that checks request_access, view_address, view_network, and sign_transaction capabilities
- Returns status with reason and resolution guidance for each capability
frontend/components/providers/wallet-provider.tsx
- Added capabilities and refreshCapabilities() to context
- Automatic invalidation on account/network change via refs
frontend/components/shared/WalletCapabilitiesBanner.tsx
- New component showing denied capabilities with actionable resolution links
- Refresh button to re-check permissions
frontend/components/swap/SwapButton.tsx
- Added permission_blocked state with shield icon and "Wallet permissions required" label
frontend/components/swap/SwapCard.tsx
- Integrated capability check into button state logic
frontend/components/shared/WalletCapabilitiesBanner.test.tsx
- 10 integration tests covering banner display, refresh behavior, and ARIA attributes

Closes #427 