### PR TITLE
feat(routing): execution quality weighting, snapshot isolation, AMM fallback, regression benchmark

### DIFF
--- a/crates/routing/Cargo.toml
+++ b/crates/routing/Cargo.toml
@@ -34,3 +34,7 @@ harness = false
 [[bench]]
 name = "hybrid_optimizer_benchmarks"
 harness = false
+
+[[bench]]
+name = "deterministic_regression_benchmark"
+harness = false

--- a/crates/routing/benches/deterministic_regression_benchmark.rs
+++ b/crates/routing/benches/deterministic_regression_benchmark.rs
@@ -1,0 +1,80 @@
+/// Criterion benchmark that exercises the deterministic regression runner.
+///
+/// This benchmark intentionally uses a fixed seed so results are comparable
+/// across commits.  CI should run:
+///
+///   cargo bench --bench deterministic_regression_benchmark
+///
+/// and pipe the output through `cargo-criterion` or compare HTML reports.
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use stellarroute_routing::regression::{
+    BenchmarkFixture, RegressionRunner, RegressionRunnerConfig,
+};
+
+fn bench_standard_suite(c: &mut Criterion) {
+    let fixtures = BenchmarkFixture::standard_suite();
+    let runner = RegressionRunner::new(RegressionRunnerConfig {
+        iterations: 1,
+        max_score_regression: 0.05,
+        max_latency_regression_us: 10_000,
+    });
+
+    c.bench_function("regression_standard_suite", |b| {
+        b.iter(|| {
+            let report = runner.run(black_box(&fixtures), None);
+            black_box(report)
+        })
+    });
+}
+
+fn bench_single_fixture_2hop(c: &mut Criterion) {
+    let fixture = BenchmarkFixture {
+        name: "bench_xlm_usdc_2hop".to_string(),
+        seed: 0xCAFE_BABE,
+        from_asset: "XLM".to_string(),
+        to_asset: "USDC".to_string(),
+        amount_in: 100_000_000,
+        graph_size: 3,
+    };
+    let runner = RegressionRunner::new(RegressionRunnerConfig {
+        iterations: 1,
+        ..Default::default()
+    });
+
+    c.bench_function("regression_single_2hop", |b| {
+        b.iter(|| {
+            let report = runner.run(black_box(&[fixture.clone()]), None);
+            black_box(report)
+        })
+    });
+}
+
+fn bench_single_fixture_large_graph(c: &mut Criterion) {
+    let fixture = BenchmarkFixture {
+        name: "bench_xlm_usdc_large".to_string(),
+        seed: 0xCAFE_BABE,
+        from_asset: "XLM".to_string(),
+        to_asset: "USDC".to_string(),
+        amount_in: 1_000_000_000,
+        graph_size: 10,
+    };
+    let runner = RegressionRunner::new(RegressionRunnerConfig {
+        iterations: 1,
+        ..Default::default()
+    });
+
+    c.bench_function("regression_single_large_graph", |b| {
+        b.iter(|| {
+            let report = runner.run(black_box(&[fixture.clone()]), None);
+            black_box(report)
+        })
+    });
+}
+
+criterion_group!(
+    benches,
+    bench_standard_suite,
+    bench_single_fixture_2hop,
+    bench_single_fixture_large_graph
+);
+criterion_main!(benches);

--- a/crates/routing/src/amm_fallback.rs
+++ b/crates/routing/src/amm_fallback.rs
@@ -1,0 +1,371 @@
+//! Tiered fallback strategy for degraded AMM data availability.
+//!
+//! # Problem
+//! AMM pool state (reserves, fees) can be partially unavailable: a single pool
+//! may be stale, an entire data source may be down, or reserve data may be
+//! missing altogether.  The router must not hard-fail in these situations if
+//! viable routes still exist at a lower tier.
+//!
+//! # Tiers (highest → lowest preference)
+//!
+//! | Tier | Name | Description |
+//! |------|------|-------------|
+//! | 0 | `LiveAmm` | Fresh AMM data within the staleness threshold. |
+//! | 1 | `CachedAmm` | Slightly stale AMM data (beyond threshold but within `max_cache_age_secs`). |
+//! | 2 | `SdexOnly` | No AMM data at all; route only through the SDEX orderbook. |
+//! | 3 | `Empty` | No viable data source. |
+//!
+//! Tiers are tried in order until one succeeds.  The tier actually used is
+//! recorded in [`FallbackResult`] so quote responses can surface it to clients
+//! (e.g. `"data_tier": "cached_amm"`).
+//!
+//! # Configuration
+//! All tier thresholds are configurable via [`AmmFallbackConfig`].
+
+use crate::pathfinder::LiquidityEdge;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+use thiserror::Error;
+
+// ── Tier enumeration ──────────────────────────────────────────────────────────
+
+/// The data availability tier used for a given quote.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AmmFallbackTier {
+    /// Fresh AMM reserves within the normal staleness threshold.
+    LiveAmm = 0,
+    /// AMM reserves that have exceeded the freshness threshold but are still
+    /// within the configurable `max_cache_age_secs` window.
+    CachedAmm = 1,
+    /// No AMM data available; routes are assembled from SDEX orderbook only.
+    SdexOnly = 2,
+    /// No viable edges remain.  Quote must fail.
+    Empty = 3,
+}
+
+impl std::fmt::Display for AmmFallbackTier {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let s = match self {
+            Self::LiveAmm => "live_amm",
+            Self::CachedAmm => "cached_amm",
+            Self::SdexOnly => "sdex_only",
+            Self::Empty => "empty",
+        };
+        f.write_str(s)
+    }
+}
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+/// Configuration for the tiered AMM fallback strategy.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct AmmFallbackConfig {
+    /// Maximum age of live AMM data (edges are considered fresh below this).
+    pub live_threshold: Duration,
+    /// Maximum age before an edge is no longer usable even as cached data.
+    pub max_cache_age: Duration,
+    /// When `true` (default), fall through to SDEX-only if all AMM tiers fail.
+    pub allow_sdex_fallback: bool,
+}
+
+impl Default for AmmFallbackConfig {
+    fn default() -> Self {
+        Self {
+            live_threshold: Duration::from_secs(60),
+            max_cache_age: Duration::from_secs(300),
+            allow_sdex_fallback: true,
+        }
+    }
+}
+
+// ── Edge metadata ─────────────────────────────────────────────────────────────
+
+/// A liquidity edge annotated with the age of its underlying pool state.
+#[derive(Clone, Debug)]
+pub struct AmmEdgeWithAge {
+    pub edge: LiquidityEdge,
+    /// How long ago the pool state was captured.
+    pub data_age: Duration,
+}
+
+// ── Result ────────────────────────────────────────────────────────────────────
+
+/// Outcome of a fallback resolution attempt.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FallbackResult {
+    /// The tier that was ultimately used to assemble the edge set.
+    pub tier: AmmFallbackTier,
+    /// Edges selected for routing (filtered to the chosen tier).
+    pub edges: Vec<LiquidityEdge>,
+    /// Informational message describing why this tier was chosen.
+    pub reason: String,
+    /// Number of edges dropped due to data staleness.
+    pub dropped_edge_count: usize,
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+/// Returned when no tier produces viable edges.
+#[derive(Debug, Error)]
+pub enum FallbackError {
+    #[error("no viable edges in any fallback tier")]
+    NoViableEdges,
+}
+
+// ── Strategy ──────────────────────────────────────────────────────────────────
+
+/// Tiered fallback resolver.  Accepts a mixed set of age-annotated edges and
+/// returns the best available subset together with the tier label.
+pub struct TieredAmmFallback {
+    config: AmmFallbackConfig,
+}
+
+impl TieredAmmFallback {
+    /// Create a new strategy with the given config.
+    pub fn new(config: AmmFallbackConfig) -> Self {
+        Self { config }
+    }
+
+    /// Resolve the best available edge set given the annotated input.
+    ///
+    /// # Algorithm
+    /// 1. Try **Tier 0** (LiveAmm): all edges whose `data_age < live_threshold`.
+    /// 2. Try **Tier 1** (CachedAmm): all AMM edges whose `data_age < max_cache_age`.
+    /// 3. Try **Tier 2** (SdexOnly): all edges whose `venue_type == "sdex"`.
+    /// 4. Return `Err(FallbackError::NoViableEdges)`.
+    pub fn resolve(&self, candidates: &[AmmEdgeWithAge]) -> Result<FallbackResult, FallbackError> {
+        // Tier 0 – live AMM (only AMM-typed edges within the freshness window)
+        let live: Vec<LiquidityEdge> = candidates
+            .iter()
+            .filter(|c| c.edge.venue_type == "amm" && c.data_age < self.config.live_threshold)
+            .map(|c| c.edge.clone())
+            .collect();
+
+        if !live.is_empty() {
+            let dropped = candidates.len() - live.len();
+            tracing::debug!(tier = "live_amm", kept = live.len(), dropped, "fallback resolved");
+            return Ok(FallbackResult {
+                tier: AmmFallbackTier::LiveAmm,
+                edges: live,
+                reason: "fresh AMM data available".to_string(),
+                dropped_edge_count: dropped,
+            });
+        }
+
+        // Tier 1 – cached AMM (AMM edges beyond live threshold but within max_cache_age)
+        let cached: Vec<LiquidityEdge> = candidates
+            .iter()
+            .filter(|c| {
+                c.edge.venue_type == "amm" && c.data_age < self.config.max_cache_age
+            })
+            .map(|c| c.edge.clone())
+            .collect();
+
+        if !cached.is_empty() {
+            let dropped = candidates.len() - cached.len();
+            tracing::warn!(
+                tier = "cached_amm",
+                kept = cached.len(),
+                dropped,
+                "falling back to cached AMM data"
+            );
+            return Ok(FallbackResult {
+                tier: AmmFallbackTier::CachedAmm,
+                edges: cached,
+                reason: "AMM data is stale but within cache window".to_string(),
+                dropped_edge_count: dropped,
+            });
+        }
+
+        // Tier 2 – SDEX only
+        if self.config.allow_sdex_fallback {
+            let sdex: Vec<LiquidityEdge> = candidates
+                .iter()
+                .filter(|c| c.edge.venue_type == "sdex")
+                .map(|c| c.edge.clone())
+                .collect();
+
+            if !sdex.is_empty() {
+                let dropped = candidates.len() - sdex.len();
+                tracing::warn!(
+                    tier = "sdex_only",
+                    kept = sdex.len(),
+                    dropped,
+                    "falling back to SDEX-only routing"
+                );
+                return Ok(FallbackResult {
+                    tier: AmmFallbackTier::SdexOnly,
+                    edges: sdex,
+                    reason: "AMM data unavailable; routing via SDEX only".to_string(),
+                    dropped_edge_count: dropped,
+                });
+            }
+        }
+
+        // Tier 3 – nothing viable
+        tracing::error!(tier = "empty", "all fallback tiers exhausted; no viable edges");
+        Err(FallbackError::NoViableEdges)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn amm_edge(venue_ref: &str) -> LiquidityEdge {
+        LiquidityEdge {
+            from: "XLM".to_string(),
+            to: "USDC".to_string(),
+            venue_type: "amm".to_string(),
+            venue_ref: venue_ref.to_string(),
+            liquidity: 1_000_000_000,
+            price: 1.0,
+            fee_bps: 30,
+            anomaly_score: 0.0,
+            anomaly_reasons: vec![],
+        }
+    }
+
+    fn sdex_edge(venue_ref: &str) -> LiquidityEdge {
+        LiquidityEdge {
+            from: "XLM".to_string(),
+            to: "USDC".to_string(),
+            venue_type: "sdex".to_string(),
+            venue_ref: venue_ref.to_string(),
+            liquidity: 500_000_000,
+            price: 1.0,
+            fee_bps: 10,
+            anomaly_score: 0.0,
+            anomaly_reasons: vec![],
+        }
+    }
+
+    fn default_strategy() -> TieredAmmFallback {
+        TieredAmmFallback::new(AmmFallbackConfig {
+            live_threshold: Duration::from_secs(60),
+            max_cache_age: Duration::from_secs(300),
+            allow_sdex_fallback: true,
+        })
+    }
+
+    #[test]
+    fn test_tier0_live_amm_selected_when_fresh() {
+        let strategy = default_strategy();
+        let candidates = vec![AmmEdgeWithAge {
+            edge: amm_edge("pool_fresh"),
+            data_age: Duration::from_secs(10),
+        }];
+        let result = strategy.resolve(&candidates).unwrap();
+        assert_eq!(result.tier, AmmFallbackTier::LiveAmm);
+        assert_eq!(result.edges.len(), 1);
+    }
+
+    #[test]
+    fn test_tier1_cached_amm_when_stale_but_within_cache() {
+        let strategy = default_strategy();
+        let candidates = vec![AmmEdgeWithAge {
+            edge: amm_edge("pool_stale"),
+            data_age: Duration::from_secs(120), // >60s live threshold, <300s max_cache
+        }];
+        let result = strategy.resolve(&candidates).unwrap();
+        assert_eq!(result.tier, AmmFallbackTier::CachedAmm);
+    }
+
+    #[test]
+    fn test_tier2_sdex_only_when_amm_expired() {
+        let strategy = default_strategy();
+        let candidates = vec![
+            AmmEdgeWithAge {
+                edge: amm_edge("pool_expired"),
+                data_age: Duration::from_secs(400), // beyond max_cache_age
+            },
+            AmmEdgeWithAge {
+                edge: sdex_edge("offer_1"),
+                data_age: Duration::from_secs(5),
+            },
+        ];
+        let result = strategy.resolve(&candidates).unwrap();
+        assert_eq!(result.tier, AmmFallbackTier::SdexOnly);
+        assert!(result.edges.iter().all(|e| e.venue_type == "sdex"));
+    }
+
+    #[test]
+    fn test_no_viable_edges_returns_error() {
+        let strategy = default_strategy();
+        let candidates = vec![AmmEdgeWithAge {
+            edge: amm_edge("pool_expired"),
+            data_age: Duration::from_secs(9999),
+        }];
+        // SDEX-only fallback won't help since there are no SDEX edges.
+        assert!(matches!(strategy.resolve(&candidates), Err(FallbackError::NoViableEdges)));
+    }
+
+    #[test]
+    fn test_sdex_fallback_disabled() {
+        let strategy = TieredAmmFallback::new(AmmFallbackConfig {
+            live_threshold: Duration::from_secs(60),
+            max_cache_age: Duration::from_secs(300),
+            allow_sdex_fallback: false,
+        });
+        let candidates = vec![
+            AmmEdgeWithAge {
+                edge: amm_edge("pool_expired"),
+                data_age: Duration::from_secs(400),
+            },
+            AmmEdgeWithAge {
+                edge: sdex_edge("offer_1"),
+                data_age: Duration::from_secs(5),
+            },
+        ];
+        assert!(matches!(strategy.resolve(&candidates), Err(FallbackError::NoViableEdges)));
+    }
+
+    #[test]
+    fn test_tier0_preferred_over_cached() {
+        let strategy = default_strategy();
+        let candidates = vec![
+            AmmEdgeWithAge {
+                edge: amm_edge("pool_fresh"),
+                data_age: Duration::from_secs(10),
+            },
+            AmmEdgeWithAge {
+                edge: amm_edge("pool_stale"),
+                data_age: Duration::from_secs(150),
+            },
+        ];
+        let result = strategy.resolve(&candidates).unwrap();
+        assert_eq!(result.tier, AmmFallbackTier::LiveAmm);
+        // Only the fresh pool is in the result
+        assert_eq!(result.edges.len(), 1);
+        assert_eq!(result.edges[0].venue_ref, "pool_fresh");
+        assert_eq!(result.dropped_edge_count, 1);
+    }
+
+    #[test]
+    fn test_fallback_result_serializable() {
+        let result = FallbackResult {
+            tier: AmmFallbackTier::CachedAmm,
+            edges: vec![],
+            reason: "test".to_string(),
+            dropped_edge_count: 2,
+        };
+        let json = serde_json::to_string(&result).unwrap();
+        assert!(json.contains("cached_amm"));
+    }
+
+    #[test]
+    fn test_tier_ordering() {
+        assert!(AmmFallbackTier::LiveAmm < AmmFallbackTier::CachedAmm);
+        assert!(AmmFallbackTier::CachedAmm < AmmFallbackTier::SdexOnly);
+        assert!(AmmFallbackTier::SdexOnly < AmmFallbackTier::Empty);
+    }
+
+    #[test]
+    fn test_empty_candidates_returns_error() {
+        let strategy = default_strategy();
+        assert!(matches!(strategy.resolve(&[]), Err(FallbackError::NoViableEdges)));
+    }
+}

--- a/crates/routing/src/execution_quality.rs
+++ b/crates/routing/src/execution_quality.rs
@@ -1,0 +1,373 @@
+//! Dynamic routing-source weighting based on recent execution quality.
+//!
+//! # Overview
+//!
+//! Maintains per-source exponential moving averages (EMAs) for two signals:
+//! - **quality_score** – a [0.0, 1.0] measure of route execution fidelity
+//!   (e.g. slippage vs. quoted price, fill rate, route consistency).
+//! - **error_rate** – fraction of recent requests that resulted in an error.
+//!
+//! These are combined into a single *reliability weight* that is fed back into
+//! [`crate::consensus::ConsensusPolicy::source_weights`].
+//!
+//! ## Bounds
+//! Weights are clamped to [`WeightBounds`] so that no single source can
+//! dominate or be starved entirely, preventing runaway feedback loops.
+//!
+//! ## Observability
+//! Every weight update is emitted as a structured `tracing::info!` event so
+//! that log aggregators (Grafana Loki, Datadog, etc.) can alert on drift.
+
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+use tracing::{info, warn};
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+/// Safe bounds for source weights.  Ensures no source is fully silenced
+/// and no single source becomes an uncontested monopoly.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct WeightBounds {
+    /// Minimum allowed weight for any source (default 0.1).
+    pub min: f64,
+    /// Maximum allowed weight for any source (default 0.95).
+    pub max: f64,
+}
+
+impl Default for WeightBounds {
+    fn default() -> Self {
+        Self { min: 0.1, max: 0.95 }
+    }
+}
+
+/// Configuration for the quality-tracker EMA.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct QualityTrackerConfig {
+    /// EMA smoothing factor α ∈ (0, 1].  Larger = more responsive to recent
+    /// observations, smaller = smoother / more stable.  Default 0.1.
+    pub ema_alpha: f64,
+    /// Initial weight assigned to unknown sources.
+    pub default_weight: f64,
+    /// Clamp parameters so weights stay in a safe operating range.
+    pub bounds: WeightBounds,
+    /// How much the error-rate signal reduces the weight relative to quality.
+    /// Combined weight = quality_ema * (1 - error_penalty * error_rate_ema).
+    pub error_penalty: f64,
+}
+
+impl Default for QualityTrackerConfig {
+    fn default() -> Self {
+        Self {
+            ema_alpha: 0.1,
+            default_weight: 0.5,
+            bounds: WeightBounds::default(),
+            error_penalty: 0.5,
+        }
+    }
+}
+
+// ── Per-source state ──────────────────────────────────────────────────────────
+
+/// Live EMA state for a single routing source.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SourceState {
+    /// Source identifier (matches keys in ConsensusPolicy::source_weights).
+    pub source: String,
+    /// EMA of quality scores ∈ [0.0, 1.0].
+    pub quality_ema: f64,
+    /// EMA of error indicator (1.0 on error, 0.0 on success).
+    pub error_rate_ema: f64,
+    /// Derived weight after applying bounds.
+    pub weight: f64,
+    /// Total observations recorded for this source.
+    pub observation_count: u64,
+}
+
+/// An execution quality observation for a single source.
+#[derive(Clone, Debug)]
+pub struct QualityObservation {
+    /// Source being measured.
+    pub source: String,
+    /// Quality score for this execution ∈ [0.0, 1.0].
+    pub quality_score: f64,
+    /// Whether this observation was an error (true) or success (false).
+    pub is_error: bool,
+}
+
+// ── Tracker ───────────────────────────────────────────────────────────────────
+
+/// Thread-safe tracker that maintains EMA state and derives routing weights.
+///
+/// # Example
+/// ```rust
+/// use stellarroute_routing::execution_quality::{ExecutionQualityTracker, QualityObservation, QualityTrackerConfig};
+///
+/// let tracker = ExecutionQualityTracker::new(QualityTrackerConfig::default());
+/// tracker.record(QualityObservation { source: "amm".into(), quality_score: 0.9, is_error: false });
+/// let weights = tracker.current_weights();
+/// assert!(weights.contains_key("amm"));
+/// ```
+pub struct ExecutionQualityTracker {
+    config: QualityTrackerConfig,
+    state: Arc<RwLock<HashMap<String, SourceState>>>,
+}
+
+impl ExecutionQualityTracker {
+    /// Create a new tracker with the given config.
+    pub fn new(config: QualityTrackerConfig) -> Self {
+        Self {
+            config,
+            state: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Record a new quality observation for a source.
+    ///
+    /// Updates the EMA state and recomputes the source's weight.  The update
+    /// is logged via `tracing::info!` for observability.
+    pub fn record(&self, obs: QualityObservation) {
+        if !(0.0..=1.0).contains(&obs.quality_score) {
+            warn!(
+                source = %obs.source,
+                quality_score = obs.quality_score,
+                "quality_score out of [0,1]; clamping"
+            );
+        }
+        let quality_score = obs.quality_score.clamp(0.0, 1.0);
+        let error_signal = if obs.is_error { 1.0 } else { 0.0 };
+        let alpha = self.config.ema_alpha;
+
+        let mut guard = self.state.write().expect("weight state lock poisoned");
+        let entry = guard.entry(obs.source.clone()).or_insert_with(|| SourceState {
+            source: obs.source.clone(),
+            quality_ema: self.config.default_weight,
+            error_rate_ema: 0.0,
+            weight: self.config.default_weight,
+            observation_count: 0,
+        });
+
+        let prev_weight = entry.weight;
+        entry.quality_ema = alpha * quality_score + (1.0 - alpha) * entry.quality_ema;
+        entry.error_rate_ema = alpha * error_signal + (1.0 - alpha) * entry.error_rate_ema;
+        entry.observation_count += 1;
+
+        let raw_weight = entry.quality_ema * (1.0 - self.config.error_penalty * entry.error_rate_ema);
+        entry.weight = raw_weight.clamp(self.config.bounds.min, self.config.bounds.max);
+
+        info!(
+            source = %obs.source,
+            quality_ema = entry.quality_ema,
+            error_rate_ema = entry.error_rate_ema,
+            prev_weight = prev_weight,
+            new_weight = entry.weight,
+            observation_count = entry.observation_count,
+            "source weight updated"
+        );
+    }
+
+    /// Return a snapshot of the current weight for every tracked source.
+    pub fn current_weights(&self) -> HashMap<String, f64> {
+        self.state
+            .read()
+            .expect("weight state lock poisoned")
+            .iter()
+            .map(|(k, v)| (k.clone(), v.weight))
+            .collect()
+    }
+
+    /// Return the full state snapshot for all tracked sources.
+    pub fn source_states(&self) -> Vec<SourceState> {
+        self.state
+            .read()
+            .expect("weight state lock poisoned")
+            .values()
+            .cloned()
+            .collect()
+    }
+
+    /// Return the current weight for a single source, or `default_weight` if unseen.
+    pub fn weight_for(&self, source: &str) -> f64 {
+        self.state
+            .read()
+            .expect("weight state lock poisoned")
+            .get(source)
+            .map(|s| s.weight)
+            .unwrap_or(self.config.default_weight)
+    }
+
+    /// Bulk-apply the current weights into a `ConsensusPolicy`-compatible map.
+    ///
+    /// Only sources that have been observed at least once are included; unknown
+    /// sources will fall back to `ConsensusPolicy`'s built-in default.
+    pub fn apply_to_policy_weights(&self, weights: &mut HashMap<String, f64>) {
+        for (source, weight) in self.current_weights() {
+            weights.insert(source, weight);
+        }
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_tracker() -> ExecutionQualityTracker {
+        ExecutionQualityTracker::new(QualityTrackerConfig {
+            ema_alpha: 0.5,
+            default_weight: 0.5,
+            bounds: WeightBounds { min: 0.1, max: 0.95 },
+            error_penalty: 0.5,
+        })
+    }
+
+    #[test]
+    fn test_new_source_starts_at_default() {
+        let tracker = make_tracker();
+        assert_eq!(tracker.weight_for("amm"), 0.5);
+    }
+
+    #[test]
+    fn test_high_quality_raises_weight() {
+        let tracker = make_tracker();
+        for _ in 0..20 {
+            tracker.record(QualityObservation {
+                source: "amm".into(),
+                quality_score: 1.0,
+                is_error: false,
+            });
+        }
+        let w = tracker.weight_for("amm");
+        assert!(w > 0.5, "weight should increase with consistent high quality; got {w}");
+        assert!(w <= 0.95, "weight must not exceed max bound; got {w}");
+    }
+
+    #[test]
+    fn test_errors_reduce_weight() {
+        let tracker = make_tracker();
+        // Seed with decent quality first
+        for _ in 0..10 {
+            tracker.record(QualityObservation {
+                source: "sdex".into(),
+                quality_score: 0.8,
+                is_error: false,
+            });
+        }
+        let w_before = tracker.weight_for("sdex");
+
+        // Now inject errors
+        for _ in 0..10 {
+            tracker.record(QualityObservation {
+                source: "sdex".into(),
+                quality_score: 0.2,
+                is_error: true,
+            });
+        }
+        let w_after = tracker.weight_for("sdex");
+        assert!(w_after < w_before, "errors should reduce weight; before={w_before}, after={w_after}");
+    }
+
+    #[test]
+    fn test_weight_never_below_min_bound() {
+        let tracker = make_tracker();
+        for _ in 0..100 {
+            tracker.record(QualityObservation {
+                source: "bad".into(),
+                quality_score: 0.0,
+                is_error: true,
+            });
+        }
+        assert!(tracker.weight_for("bad") >= 0.1);
+    }
+
+    #[test]
+    fn test_weight_never_above_max_bound() {
+        let tracker = make_tracker();
+        for _ in 0..100 {
+            tracker.record(QualityObservation {
+                source: "perfect".into(),
+                quality_score: 1.0,
+                is_error: false,
+            });
+        }
+        assert!(tracker.weight_for("perfect") <= 0.95);
+    }
+
+    #[test]
+    fn test_apply_to_policy_weights() {
+        let tracker = make_tracker();
+        tracker.record(QualityObservation {
+            source: "amm".into(),
+            quality_score: 0.9,
+            is_error: false,
+        });
+        let mut map = HashMap::new();
+        map.insert("sdex".to_string(), 0.7_f64);
+        tracker.apply_to_policy_weights(&mut map);
+        assert!(map.contains_key("amm"), "amm should be injected");
+        assert!(map.contains_key("sdex"), "sdex should be preserved");
+    }
+
+    #[test]
+    fn test_observation_count_increments() {
+        let tracker = make_tracker();
+        for i in 1..=5u64 {
+            tracker.record(QualityObservation {
+                source: "amm".into(),
+                quality_score: 0.5,
+                is_error: false,
+            });
+            let states = tracker.source_states();
+            let amm = states.iter().find(|s| s.source == "amm").unwrap();
+            assert_eq!(amm.observation_count, i);
+        }
+    }
+
+    #[test]
+    fn test_out_of_range_quality_clamped() {
+        let tracker = make_tracker();
+        // Should not panic
+        tracker.record(QualityObservation {
+            source: "amm".into(),
+            quality_score: 1.5,
+            is_error: false,
+        });
+        tracker.record(QualityObservation {
+            source: "amm".into(),
+            quality_score: -0.3,
+            is_error: false,
+        });
+        let w = tracker.weight_for("amm");
+        assert!(w >= 0.1 && w <= 0.95);
+    }
+
+    #[test]
+    fn test_static_vs_dynamic_weighting() {
+        // Static: always weight 0.5 for amm, 0.5 for sdex
+        let static_amm = 0.5_f64;
+        let static_sdex = 0.5_f64;
+
+        // Dynamic: amm gets high quality, sdex gets errors
+        let tracker = make_tracker();
+        for _ in 0..30 {
+            tracker.record(QualityObservation {
+                source: "amm".into(),
+                quality_score: 0.95,
+                is_error: false,
+            });
+            tracker.record(QualityObservation {
+                source: "sdex".into(),
+                quality_score: 0.2,
+                is_error: true,
+            });
+        }
+
+        let dynamic_amm = tracker.weight_for("amm");
+        let dynamic_sdex = tracker.weight_for("sdex");
+
+        // Dynamic weights should diverge from static
+        assert!(dynamic_amm > static_amm, "dynamic amm weight should exceed static after good performance");
+        assert!(dynamic_sdex < static_sdex, "dynamic sdex weight should fall below static after poor performance");
+    }
+}

--- a/crates/routing/src/lib.rs
+++ b/crates/routing/src/lib.rs
@@ -5,10 +5,12 @@
 
 pub mod adaptive_routing;
 pub mod adaptive_timeout;
+pub mod amm_fallback;
 pub mod canary;
 pub mod compaction;
 pub mod consensus;
 pub mod error;
+pub mod execution_quality;
 pub mod fixtures;
 pub mod health;
 pub mod impact;
@@ -16,9 +18,11 @@ pub mod normalization;
 pub mod optimizer;
 pub mod pathfinder;
 pub mod policy;
+pub mod regression;
 pub mod risk;
 pub mod scorer;
 pub mod simulator;
+pub mod snapshot;
 
 pub use adaptive_routing::{AdaptiveError, AdaptivePolicy, AdaptiveRouter, QualityMetrics};
 pub use adaptive_timeout::{TimeoutConfig, TimeoutController};
@@ -37,6 +41,18 @@ pub use risk::{AssetRiskLimit, ExclusionReason, RiskLimitConfig, RiskValidator, 
 pub use scorer::{
     BenchmarkHarness, BenchmarkReport, DefaultScorer, FeeMinimizingScorer, OutputMaximizingScorer,
     RouteScorer, ScorerInput, ScorerOutput, ScorerRegistry, ScorerResult,
+};
+pub use amm_fallback::{AmmFallbackConfig, AmmFallbackTier, FallbackResult, TieredAmmFallback};
+pub use execution_quality::{
+    ExecutionQualityTracker, QualityObservation, QualityTrackerConfig, SourceState, WeightBounds,
+};
+pub use regression::{
+    BaselineStore, BenchmarkFixture, RegressionReport, RegressionRunner, RegressionRunnerConfig,
+    RouteRegressionEntry,
+};
+pub use snapshot::{
+    SnapshotId, SnapshotIsolationError, SnapshotIsolationMetrics, SnapshotIsolationValidator,
+    SnapshotValidatorConfig, ValidatedHop,
 };
 
 /// Routing engine with integrated pathfinding and impact calculations

--- a/crates/routing/src/optimizer.rs
+++ b/crates/routing/src/optimizer.rs
@@ -608,6 +608,8 @@ mod tests {
             liquidity: 10_000_000,
             price: 0.1,
             fee_bps: 30,
+            anomaly_score: 0.0,
+            anomaly_reasons: vec![],
         }];
         let policy = RoutingPolicy::default();
         let result = optimizer.find_optimal_routes("XLM", "USDC", &edges, 1_000_000, &policy);
@@ -629,6 +631,8 @@ mod tests {
                 venue_ref: "pool1".to_string(),
                 price: 0.1,
                 fee_bps: 30,
+                anomaly_score: 0.0,
+                anomaly_reasons: vec![],
             }],
             estimated_output: 900_000,
         }];

--- a/crates/routing/src/pathfinder.rs
+++ b/crates/routing/src/pathfinder.rs
@@ -44,7 +44,7 @@ pub struct SwapPath {
     pub estimated_output: i128,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PathHop {
     pub source_asset: String,
     pub destination_asset: String,

--- a/crates/routing/src/regression.rs
+++ b/crates/routing/src/regression.rs
@@ -1,0 +1,590 @@
+//! Deterministic benchmark runner for routing regression detection.
+//!
+//! # Purpose
+//! Provides repeatable, seed-controlled benchmark fixtures so that CI can
+//! detect regressions in route quality (score) and routing latency across
+//! commits.
+//!
+//! # How it works
+//! 1. A [`BenchmarkFixture`] describes a named test case: a seed, the
+//!    from/to asset pair, the swap amount, and the edge set to use.
+//! 2. [`RegressionRunner`] runs all fixtures, records latency and the top
+//!    route score for each, and compares them against a stored baseline.
+//! 3. A [`RegressionReport`] is produced with per-fixture deltas and a
+//!    `passed` flag suitable for CI exit-code gating.
+//! 4. Baselines are persisted as JSON via [`BaselineStore`] so they can be
+//!    updated and committed alongside source code.
+//!
+//! # CI usage
+//! ```text
+//! # First run: write baseline
+//! cargo test --package stellarroute-routing regression -- --nocapture
+//!
+//! # Subsequent runs: compare against baseline; fail if regression detected
+//! cargo test --package stellarroute-routing regression
+//! ```
+//!
+//! # Seeding
+//! All randomness in synthetic edge generation uses `rand_chacha::ChaCha8Rng`
+//! seeded from the fixture's `seed` field, guaranteeing identical outputs
+//! across platforms and Rust versions.
+
+use crate::pathfinder::{LiquidityEdge, Pathfinder, PathfinderConfig};
+use crate::policy::RoutingPolicy;
+use crate::scorer::{BenchmarkHarness, ScorerRegistry};
+use rand::SeedableRng;
+use rand_chacha::ChaCha8Rng;
+use rand::Rng;
+use serde::{Deserialize, Serialize};
+use std::time::Instant;
+
+// ── Fixture ───────────────────────────────────────────────────────────────────
+
+/// A single named regression test case.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct BenchmarkFixture {
+    /// Unique name for this fixture (used as the baseline key).
+    pub name: String,
+    /// RNG seed – changing this changes the generated graph.
+    pub seed: u64,
+    /// Source asset.
+    pub from_asset: String,
+    /// Destination asset.
+    pub to_asset: String,
+    /// Amount in (e7 scale).
+    pub amount_in: i128,
+    /// Number of synthetic intermediate assets to generate.
+    pub graph_size: usize,
+}
+
+impl BenchmarkFixture {
+    /// Deterministically generate a [`Vec<LiquidityEdge>`] from this fixture's
+    /// seed and graph parameters.
+    pub fn generate_edges(&self) -> Vec<LiquidityEdge> {
+        let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
+        let assets: Vec<String> = (0..self.graph_size)
+            .map(|i| format!("ASSET_{i}"))
+            .collect();
+
+        // Always include direct and indirect paths between from/to
+        let mut edges = vec![
+            LiquidityEdge {
+                from: self.from_asset.clone(),
+                to: self.to_asset.clone(),
+                venue_type: "amm".to_string(),
+                venue_ref: "direct_pool".to_string(),
+                liquidity: rng.gen_range(500_000_000..5_000_000_000i128),
+                price: rng.gen_range(0.8..1.2),
+                fee_bps: rng.gen_range(10..100),
+                anomaly_score: 0.0,
+                anomaly_reasons: vec![],
+            },
+            LiquidityEdge {
+                from: self.from_asset.clone(),
+                to: self.to_asset.clone(),
+                venue_type: "sdex".to_string(),
+                venue_ref: "direct_offer".to_string(),
+                liquidity: rng.gen_range(200_000_000..2_000_000_000i128),
+                price: rng.gen_range(0.85..1.15),
+                fee_bps: rng.gen_range(5..50),
+                anomaly_score: 0.0,
+                anomaly_reasons: vec![],
+            },
+        ];
+
+        // Add intermediate hop edges
+        for asset in &assets {
+            let liquidity: i128 = rng.gen_range(100_000_000..10_000_000_000i128);
+            let venue_type = if rng.gen_bool(0.5) { "amm" } else { "sdex" };
+            edges.push(LiquidityEdge {
+                from: self.from_asset.clone(),
+                to: asset.clone(),
+                venue_type: venue_type.to_string(),
+                venue_ref: format!("{}_in_pool", asset),
+                liquidity,
+                price: rng.gen_range(0.5..2.0),
+                fee_bps: rng.gen_range(5..200),
+                anomaly_score: 0.0,
+                anomaly_reasons: vec![],
+            });
+            edges.push(LiquidityEdge {
+                from: asset.clone(),
+                to: self.to_asset.clone(),
+                venue_type: venue_type.to_string(),
+                venue_ref: format!("{}_out_pool", asset),
+                liquidity: rng.gen_range(100_000_000..10_000_000_000i128),
+                price: rng.gen_range(0.5..2.0),
+                fee_bps: rng.gen_range(5..200),
+                anomaly_score: 0.0,
+                anomaly_reasons: vec![],
+            });
+        }
+
+        edges
+    }
+
+    /// Built-in set of regression fixtures covering common trading pairs.
+    pub fn standard_suite() -> Vec<BenchmarkFixture> {
+        vec![
+            BenchmarkFixture {
+                name: "xlm_to_usdc_2hop".to_string(),
+                seed: 0xDEAD_BEEF_0001,
+                from_asset: "XLM".to_string(),
+                to_asset: "USDC".to_string(),
+                amount_in: 100_000_000,
+                graph_size: 3,
+            },
+            BenchmarkFixture {
+                name: "xlm_to_btc_4hop".to_string(),
+                seed: 0xDEAD_BEEF_0002,
+                from_asset: "XLM".to_string(),
+                to_asset: "BTC".to_string(),
+                amount_in: 500_000_000,
+                graph_size: 6,
+            },
+            BenchmarkFixture {
+                name: "usdc_to_eurt_direct".to_string(),
+                seed: 0xDEAD_BEEF_0003,
+                from_asset: "USDC".to_string(),
+                to_asset: "EURT".to_string(),
+                amount_in: 10_000_000_000,
+                graph_size: 2,
+            },
+            BenchmarkFixture {
+                name: "xlm_to_usdc_large_graph".to_string(),
+                seed: 0xDEAD_BEEF_0004,
+                from_asset: "XLM".to_string(),
+                to_asset: "USDC".to_string(),
+                amount_in: 1_000_000_000,
+                graph_size: 10,
+            },
+        ]
+    }
+}
+
+// ── Baseline ──────────────────────────────────────────────────────────────────
+
+/// Baseline measurements for a single fixture.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RouteRegressionEntry {
+    /// Fixture name.
+    pub fixture_name: String,
+    /// Best route score recorded at baseline time.
+    pub baseline_score: f64,
+    /// Median routing latency at baseline time, in microseconds.
+    pub baseline_latency_us: u64,
+}
+
+/// Persisted collection of baseline measurements.
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
+pub struct BaselineStore {
+    pub entries: Vec<RouteRegressionEntry>,
+}
+
+impl BaselineStore {
+    /// Look up the baseline for a fixture by name.
+    pub fn get(&self, fixture_name: &str) -> Option<&RouteRegressionEntry> {
+        self.entries.iter().find(|e| e.fixture_name == fixture_name)
+    }
+
+    /// Upsert a baseline entry.
+    pub fn set(&mut self, entry: RouteRegressionEntry) {
+        if let Some(existing) = self.entries.iter_mut().find(|e| e.fixture_name == entry.fixture_name) {
+            *existing = entry;
+        } else {
+            self.entries.push(entry);
+        }
+    }
+
+    /// Serialize to JSON for storage alongside source code.
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        serde_json::to_string_pretty(self)
+    }
+
+    /// Deserialize from JSON.
+    pub fn from_json(s: &str) -> Result<Self, serde_json::Error> {
+        serde_json::from_str(s)
+    }
+}
+
+// ── Per-fixture result ────────────────────────────────────────────────────────
+
+/// Outcome of running a single fixture.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct FixtureResult {
+    pub fixture_name: String,
+    /// Best route score in this run.
+    pub score: f64,
+    /// Routing latency for this run, in microseconds.
+    pub latency_us: u64,
+    /// Delta from baseline score (positive = improvement, negative = regression).
+    pub score_delta: Option<f64>,
+    /// Delta from baseline latency in microseconds (positive = slower, negative = faster).
+    pub latency_delta_us: Option<i64>,
+    /// Whether this fixture passes the regression thresholds.
+    pub passed: bool,
+    /// Human-readable reason if the fixture failed.
+    pub failure_reason: Option<String>,
+}
+
+// ── Regression report ─────────────────────────────────────────────────────────
+
+/// CI-friendly summary of all fixture runs.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RegressionReport {
+    /// Per-fixture results.
+    pub results: Vec<FixtureResult>,
+    /// `true` iff all fixtures passed their regression thresholds.
+    pub passed: bool,
+    /// Total number of fixtures run.
+    pub total: usize,
+    /// Number of fixtures that failed.
+    pub failed: usize,
+}
+
+impl RegressionReport {
+    /// Format as a CI-friendly human-readable summary (plain text).
+    pub fn ci_summary(&self) -> String {
+        let mut out = String::new();
+        out.push_str(&format!(
+            "Regression runner: {}/{} passed\n",
+            self.total - self.failed,
+            self.total
+        ));
+        for r in &self.results {
+            let status = if r.passed { "PASS" } else { "FAIL" };
+            out.push_str(&format!(
+                "  [{status}] {name}: score={score:.4} latency={lat}µs",
+                name = r.fixture_name,
+                score = r.score,
+                lat = r.latency_us,
+            ));
+            if let Some(ds) = r.score_delta {
+                out.push_str(&format!(" score_delta={ds:+.4}"));
+            }
+            if let Some(dl) = r.latency_delta_us {
+                out.push_str(&format!(" latency_delta={dl:+}µs"));
+            }
+            if let Some(ref reason) = r.failure_reason {
+                out.push_str(&format!(" ({reason})"));
+            }
+            out.push('\n');
+        }
+        out
+    }
+}
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+/// Configuration for the regression runner.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct RegressionRunnerConfig {
+    /// Maximum acceptable score regression (e.g. 0.05 = 5% drop allowed).
+    pub max_score_regression: f64,
+    /// Maximum acceptable latency increase in microseconds.
+    pub max_latency_regression_us: u64,
+    /// Number of times each fixture is run to compute median latency.
+    pub iterations: usize,
+}
+
+impl Default for RegressionRunnerConfig {
+    fn default() -> Self {
+        Self {
+            max_score_regression: 0.05,
+            max_latency_regression_us: 5_000,
+            iterations: 5,
+        }
+    }
+}
+
+// ── Runner ────────────────────────────────────────────────────────────────────
+
+/// Runs benchmark fixtures and compares results against an optional baseline.
+pub struct RegressionRunner {
+    config: RegressionRunnerConfig,
+    pathfinder: Pathfinder,
+    routing_policy: RoutingPolicy,
+    scorer_registry: ScorerRegistry,
+}
+
+impl RegressionRunner {
+    /// Create a runner with default pathfinder and scorer settings.
+    pub fn new(config: RegressionRunnerConfig) -> Self {
+        Self {
+            config,
+            pathfinder: Pathfinder::new(PathfinderConfig::default()),
+            routing_policy: RoutingPolicy::default(),
+            scorer_registry: ScorerRegistry::new(),
+        }
+    }
+
+    /// Run all fixtures, comparing against `baseline` if provided.
+    pub fn run(
+        &self,
+        fixtures: &[BenchmarkFixture],
+        baseline: Option<&BaselineStore>,
+    ) -> RegressionReport {
+        let mut results = Vec::new();
+
+        for fixture in fixtures {
+            let result = self.run_fixture(fixture, baseline);
+            results.push(result);
+        }
+
+        let failed = results.iter().filter(|r| !r.passed).count();
+        RegressionReport {
+            total: results.len(),
+            failed,
+            passed: failed == 0,
+            results,
+        }
+    }
+
+    fn run_fixture(
+        &self,
+        fixture: &BenchmarkFixture,
+        baseline: Option<&BaselineStore>,
+    ) -> FixtureResult {
+        let edges = fixture.generate_edges();
+        let mut latencies = Vec::with_capacity(self.config.iterations);
+        let mut best_score = 0.0_f64;
+
+        for _ in 0..self.config.iterations {
+            let start = Instant::now();
+            let paths = self
+                .pathfinder
+                .find_paths(
+                    &fixture.from_asset,
+                    &fixture.to_asset,
+                    &edges,
+                    fixture.amount_in,
+                    &self.routing_policy,
+                )
+                .unwrap_or_default();
+            let latency = start.elapsed().as_micros() as u64;
+            latencies.push(latency);
+
+            if !paths.is_empty() {
+                let report = BenchmarkHarness::run(&paths, &edges, fixture.amount_in, &self.scorer_registry);
+                if let Some(top) = report.scorer_results.iter().find(|r| r.scorer_name == "default") {
+                    if let Some((_, out)) = top.ranked_paths.first() {
+                        best_score = best_score.max(out.score);
+                    }
+                }
+            }
+        }
+
+        latencies.sort_unstable();
+        let median_latency = latencies[latencies.len() / 2];
+
+        let baseline_entry = baseline.and_then(|b| b.get(&fixture.name));
+        let score_delta = baseline_entry.map(|b| best_score - b.baseline_score);
+        let latency_delta = baseline_entry
+            .map(|b| median_latency as i64 - b.baseline_latency_us as i64);
+
+        let (passed, failure_reason) = self.evaluate(best_score, median_latency, baseline_entry);
+
+        FixtureResult {
+            fixture_name: fixture.name.clone(),
+            score: best_score,
+            latency_us: median_latency,
+            score_delta,
+            latency_delta_us: latency_delta,
+            passed,
+            failure_reason,
+        }
+    }
+
+    fn evaluate(
+        &self,
+        score: f64,
+        latency_us: u64,
+        baseline: Option<&RouteRegressionEntry>,
+    ) -> (bool, Option<String>) {
+        let Some(b) = baseline else {
+            // No baseline yet – first run always passes; caller should persist results.
+            return (true, None);
+        };
+
+        let score_drop = b.baseline_score - score;
+        if score_drop > self.config.max_score_regression {
+            return (
+                false,
+                Some(format!(
+                    "score regressed by {score_drop:.4} (threshold: {:.4})",
+                    self.config.max_score_regression
+                )),
+            );
+        }
+
+        let latency_increase = latency_us.saturating_sub(b.baseline_latency_us);
+        if latency_increase > self.config.max_latency_regression_us {
+            return (
+                false,
+                Some(format!(
+                    "latency regressed by {latency_increase}µs (threshold: {}µs)",
+                    self.config.max_latency_regression_us
+                )),
+            );
+        }
+
+        (true, None)
+    }
+
+    /// Convenience: build a new baseline by running all fixtures once.
+    pub fn build_baseline(&self, fixtures: &[BenchmarkFixture]) -> BaselineStore {
+        let report = self.run(fixtures, None);
+        let mut store = BaselineStore::default();
+        for result in &report.results {
+            store.set(RouteRegressionEntry {
+                fixture_name: result.fixture_name.clone(),
+                baseline_score: result.score,
+                baseline_latency_us: result.latency_us,
+            });
+        }
+        store
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn simple_fixture() -> BenchmarkFixture {
+        BenchmarkFixture {
+            name: "test_xlm_usdc".to_string(),
+            seed: 42,
+            from_asset: "XLM".to_string(),
+            to_asset: "USDC".to_string(),
+            amount_in: 100_000_000,
+            graph_size: 3,
+        }
+    }
+
+    #[test]
+    fn test_seeded_fixture_is_deterministic() {
+        let f = simple_fixture();
+        let edges_a = f.generate_edges();
+        let edges_b = f.generate_edges();
+        assert_eq!(
+            serde_json::to_string(&edges_a).unwrap(),
+            serde_json::to_string(&edges_b).unwrap(),
+            "seeded edge generation must be deterministic"
+        );
+    }
+
+    #[test]
+    fn test_different_seeds_produce_different_edges() {
+        let f1 = BenchmarkFixture { seed: 1, ..simple_fixture() };
+        let f2 = BenchmarkFixture { seed: 2, ..simple_fixture() };
+        let e1 = f1.generate_edges();
+        let e2 = f2.generate_edges();
+        // At minimum the liquidity values should differ
+        let liq1: Vec<i128> = e1.iter().map(|e| e.liquidity).collect();
+        let liq2: Vec<i128> = e2.iter().map(|e| e.liquidity).collect();
+        assert_ne!(liq1, liq2);
+    }
+
+    #[test]
+    fn test_runner_produces_report() {
+        let runner = RegressionRunner::new(RegressionRunnerConfig {
+            iterations: 2,
+            ..Default::default()
+        });
+        let fixtures = vec![simple_fixture()];
+        let report = runner.run(&fixtures, None);
+        assert_eq!(report.total, 1);
+        assert!(report.passed);
+        assert_eq!(report.results.len(), 1);
+    }
+
+    #[test]
+    fn test_baseline_roundtrip() {
+        let runner = RegressionRunner::new(RegressionRunnerConfig {
+            iterations: 2,
+            ..Default::default()
+        });
+        let fixtures = vec![simple_fixture()];
+        let baseline = runner.build_baseline(&fixtures);
+        assert_eq!(baseline.entries.len(), 1);
+
+        let json = baseline.to_json().unwrap();
+        let restored = BaselineStore::from_json(&json).unwrap();
+        assert_eq!(restored.entries.len(), 1);
+        assert_eq!(restored.entries[0].fixture_name, "test_xlm_usdc");
+    }
+
+    #[test]
+    fn test_no_regression_against_identical_baseline() {
+        let runner = RegressionRunner::new(RegressionRunnerConfig {
+            iterations: 2,
+            ..Default::default()
+        });
+        let fixtures = vec![simple_fixture()];
+        let baseline = runner.build_baseline(&fixtures);
+        let report = runner.run(&fixtures, Some(&baseline));
+        assert!(report.passed, "identical baseline should not trigger regression");
+    }
+
+    #[test]
+    fn test_score_regression_detected() {
+        let runner = RegressionRunner::new(RegressionRunnerConfig {
+            iterations: 1,
+            max_score_regression: 0.001, // very tight threshold
+            max_latency_regression_us: 1_000_000,
+        });
+        let fixtures = vec![simple_fixture()];
+        let mut baseline = BaselineStore::default();
+        // Inject an artificially high baseline score
+        baseline.set(RouteRegressionEntry {
+            fixture_name: "test_xlm_usdc".to_string(),
+            baseline_score: 1.0,
+            baseline_latency_us: 1,
+        });
+        let report = runner.run(&fixtures, Some(&baseline));
+        assert!(!report.passed, "should detect score regression vs inflated baseline");
+        assert_eq!(report.failed, 1);
+    }
+
+    #[test]
+    fn test_ci_summary_format() {
+        let runner = RegressionRunner::new(RegressionRunnerConfig {
+            iterations: 1,
+            ..Default::default()
+        });
+        let fixtures = vec![simple_fixture()];
+        let report = runner.run(&fixtures, None);
+        let summary = report.ci_summary();
+        assert!(summary.contains("PASS") || summary.contains("FAIL"));
+        assert!(summary.contains("test_xlm_usdc"));
+    }
+
+    #[test]
+    fn test_standard_suite_is_deterministic() {
+        let suite_a = BenchmarkFixture::standard_suite();
+        let suite_b = BenchmarkFixture::standard_suite();
+        for (a, b) in suite_a.iter().zip(suite_b.iter()) {
+            let ea = a.generate_edges();
+            let eb = b.generate_edges();
+            assert_eq!(
+                serde_json::to_string(&ea).unwrap(),
+                serde_json::to_string(&eb).unwrap(),
+                "standard suite fixture {} must be deterministic",
+                a.name
+            );
+        }
+    }
+
+    #[test]
+    fn test_report_serializes_to_json() {
+        let runner = RegressionRunner::new(RegressionRunnerConfig {
+            iterations: 1,
+            ..Default::default()
+        });
+        let report = runner.run(&[simple_fixture()], None);
+        let json = serde_json::to_string(&report).unwrap();
+        assert!(json.contains("test_xlm_usdc"));
+    }
+}

--- a/crates/routing/src/snapshot.rs
+++ b/crates/routing/src/snapshot.rs
@@ -1,0 +1,359 @@
+//! Snapshot isolation validator for multi-hop quote assembly.
+//!
+//! # Problem
+//! In a multi-hop swap (e.g. XLM → USDC → BTC) each hop reads pool/orderbook
+//! state.  If two hops read from *different* market snapshots (different ledger
+//! sequences), the assembled quote is internally inconsistent: the price used
+//! for hop 1 may no longer hold by the time hop 2 executes.
+//!
+//! # Solution
+//! Every [`LiquidityEdge`] that enters a multi-hop path must carry the same
+//! `snapshot_id` (an opaque monotonic counter derived from the ledger sequence
+//! at which pool state was captured).  This module validates that invariant and
+//! returns a machine-readable [`SnapshotIsolationError`] when it is violated.
+//!
+//! # Metrics
+//! A [`SnapshotIsolationMetrics`] counter is updated on every validation call
+//! so Prometheus scrapers can alert on isolation violations.
+
+use crate::pathfinder::SwapPath;
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use thiserror::Error;
+
+// ── Snapshot identifier ───────────────────────────────────────────────────────
+
+/// Opaque monotonic snapshot identifier derived from a ledger sequence number.
+///
+/// Two hops are considered *snapshot-compatible* if and only if their
+/// `SnapshotId`s are equal.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct SnapshotId(pub u64);
+
+impl fmt::Display for SnapshotId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "snapshot#{}", self.0)
+    }
+}
+
+// ── Errors ────────────────────────────────────────────────────────────────────
+
+/// Machine-readable error returned when snapshot isolation is violated.
+#[derive(Debug, Clone, Error, Serialize, Deserialize)]
+pub enum SnapshotIsolationError {
+    /// Two or more hops in the path used state from different snapshots.
+    #[error("mixed snapshot ids in path: hop {hop_index} uses {hop_snapshot}, expected {expected_snapshot}")]
+    MixedSnapshots {
+        /// Zero-based index of the offending hop.
+        hop_index: usize,
+        /// The snapshot id on the first hop (the expected baseline).
+        expected_snapshot: SnapshotId,
+        /// The snapshot id found on the offending hop.
+        hop_snapshot: SnapshotId,
+        /// Human-readable venue reference of the offending hop.
+        venue_ref: String,
+    },
+    /// The path carries no hops and therefore cannot be validated.
+    #[error("path contains no hops")]
+    EmptyPath,
+}
+
+// ── Validated hop ─────────────────────────────────────────────────────────────
+
+/// A path hop that has been stamped with its market snapshot id.
+///
+/// Callers that assemble multi-hop paths should attach a `snapshot_id` to each
+/// hop at the time pool state is read.  The validator then checks consistency.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct ValidatedHop {
+    /// The snapshot at which this hop's pool/orderbook state was captured.
+    pub snapshot_id: SnapshotId,
+    /// The venue reference (e.g. AMM pool address or SDEX offer-book key).
+    pub venue_ref: String,
+    /// Source asset key.
+    pub source_asset: String,
+    /// Destination asset key.
+    pub destination_asset: String,
+}
+
+// ── Metrics ───────────────────────────────────────────────────────────────────
+
+/// Shared atomic counters tracking validator outcomes.
+///
+/// Mount these in your Prometheus registry by reading them in the metrics
+/// scrape handler.
+#[derive(Clone, Default)]
+pub struct SnapshotIsolationMetrics {
+    inner: Arc<SnapshotIsolationMetricsInner>,
+}
+
+#[derive(Default)]
+struct SnapshotIsolationMetricsInner {
+    total_validations: AtomicU64,
+    violations: AtomicU64,
+    empty_paths: AtomicU64,
+}
+
+impl SnapshotIsolationMetrics {
+    /// Number of times `validate` has been called.
+    pub fn total_validations(&self) -> u64 {
+        self.inner.total_validations.load(Ordering::Relaxed)
+    }
+
+    /// Number of validation calls that detected a snapshot mismatch.
+    pub fn violations(&self) -> u64 {
+        self.inner.violations.load(Ordering::Relaxed)
+    }
+
+    /// Number of validation calls that received an empty path.
+    pub fn empty_paths(&self) -> u64 {
+        self.inner.empty_paths.load(Ordering::Relaxed)
+    }
+}
+
+// ── Config ────────────────────────────────────────────────────────────────────
+
+/// Configuration for the snapshot isolation validator.
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct SnapshotValidatorConfig {
+    /// When `true` the validator strictly rejects any mixed-snapshot path.
+    /// When `false` it records the violation in metrics but returns `Ok`.
+    /// Defaults to `true` (strict).
+    pub strict: bool,
+}
+
+impl Default for SnapshotValidatorConfig {
+    fn default() -> Self {
+        Self { strict: true }
+    }
+}
+
+// ── Validator ─────────────────────────────────────────────────────────────────
+
+/// Validates that all hops in a multi-hop path share the same snapshot id.
+pub struct SnapshotIsolationValidator {
+    config: SnapshotValidatorConfig,
+    metrics: SnapshotIsolationMetrics,
+}
+
+impl SnapshotIsolationValidator {
+    /// Create a new validator with default (strict) config and fresh metrics.
+    pub fn new(config: SnapshotValidatorConfig) -> Self {
+        Self {
+            config,
+            metrics: SnapshotIsolationMetrics::default(),
+        }
+    }
+
+    /// Shared read access to the metrics counters.
+    pub fn metrics(&self) -> &SnapshotIsolationMetrics {
+        &self.metrics
+    }
+
+    /// Validate snapshot consistency across a slice of stamped hops.
+    ///
+    /// Returns `Err(SnapshotIsolationError::MixedSnapshots)` if any hop
+    /// deviates from the snapshot of the first hop.
+    pub fn validate_hops(
+        &self,
+        hops: &[ValidatedHop],
+    ) -> Result<(), SnapshotIsolationError> {
+        self.metrics
+            .inner
+            .total_validations
+            .fetch_add(1, Ordering::Relaxed);
+
+        if hops.is_empty() {
+            self.metrics.inner.empty_paths.fetch_add(1, Ordering::Relaxed);
+            if self.config.strict {
+                return Err(SnapshotIsolationError::EmptyPath);
+            }
+            return Ok(());
+        }
+
+        let baseline = hops[0].snapshot_id;
+        for (idx, hop) in hops.iter().enumerate().skip(1) {
+            if hop.snapshot_id != baseline {
+                self.metrics.inner.violations.fetch_add(1, Ordering::Relaxed);
+                tracing::warn!(
+                    hop_index = idx,
+                    expected = %baseline,
+                    found = %hop.snapshot_id,
+                    venue_ref = %hop.venue_ref,
+                    "snapshot isolation violation detected"
+                );
+                if self.config.strict {
+                    return Err(SnapshotIsolationError::MixedSnapshots {
+                        hop_index: idx,
+                        expected_snapshot: baseline,
+                        hop_snapshot: hop.snapshot_id,
+                        venue_ref: hop.venue_ref.clone(),
+                    });
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Convenience: extract `ValidatedHop`s from a [`SwapPath`] using a
+    /// uniform `snapshot_id` (i.e. the snapshot captured when the path was
+    /// assembled).  This is the common case where the caller already knows
+    /// the snapshot under which the whole path was built.
+    ///
+    /// For paths where each hop may have been read from a different snapshot
+    /// use `validate_hops` directly with individually stamped hops.
+    pub fn validate_path_uniform(
+        &self,
+        path: &SwapPath,
+        snapshot_id: SnapshotId,
+    ) -> Result<(), SnapshotIsolationError> {
+        let hops: Vec<ValidatedHop> = path
+            .hops
+            .iter()
+            .map(|h| ValidatedHop {
+                snapshot_id,
+                venue_ref: h.venue_ref.clone(),
+                source_asset: h.source_asset.clone(),
+                destination_asset: h.destination_asset.clone(),
+            })
+            .collect();
+        self.validate_hops(&hops)
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn hop(snapshot: u64, venue: &str) -> ValidatedHop {
+        ValidatedHop {
+            snapshot_id: SnapshotId(snapshot),
+            venue_ref: venue.to_string(),
+            source_asset: "XLM".to_string(),
+            destination_asset: "USDC".to_string(),
+        }
+    }
+
+    fn strict_validator() -> SnapshotIsolationValidator {
+        SnapshotIsolationValidator::new(SnapshotValidatorConfig { strict: true })
+    }
+
+    fn lenient_validator() -> SnapshotIsolationValidator {
+        SnapshotIsolationValidator::new(SnapshotValidatorConfig { strict: false })
+    }
+
+    #[test]
+    fn test_consistent_snapshots_pass() {
+        let v = strict_validator();
+        let hops = vec![hop(42, "pool_a"), hop(42, "pool_b"), hop(42, "pool_c")];
+        assert!(v.validate_hops(&hops).is_ok());
+    }
+
+    #[test]
+    fn test_mixed_snapshot_rejected_strict() {
+        let v = strict_validator();
+        let hops = vec![hop(42, "pool_a"), hop(43, "pool_b")];
+        let err = v.validate_hops(&hops).unwrap_err();
+        match err {
+            SnapshotIsolationError::MixedSnapshots {
+                hop_index,
+                expected_snapshot,
+                hop_snapshot,
+                venue_ref,
+            } => {
+                assert_eq!(hop_index, 1);
+                assert_eq!(expected_snapshot, SnapshotId(42));
+                assert_eq!(hop_snapshot, SnapshotId(43));
+                assert_eq!(venue_ref, "pool_b");
+            }
+            other => panic!("unexpected error: {other}"),
+        }
+    }
+
+    #[test]
+    fn test_mixed_snapshot_allowed_lenient() {
+        let v = lenient_validator();
+        let hops = vec![hop(42, "pool_a"), hop(99, "pool_b")];
+        assert!(v.validate_hops(&hops).is_ok());
+        assert_eq!(v.metrics().violations(), 1);
+    }
+
+    #[test]
+    fn test_empty_path_rejected_strict() {
+        let v = strict_validator();
+        assert!(matches!(
+            v.validate_hops(&[]),
+            Err(SnapshotIsolationError::EmptyPath)
+        ));
+        assert_eq!(v.metrics().empty_paths(), 1);
+    }
+
+    #[test]
+    fn test_empty_path_allowed_lenient() {
+        let v = lenient_validator();
+        assert!(v.validate_hops(&[]).is_ok());
+    }
+
+    #[test]
+    fn test_metrics_total_validations_increment() {
+        let v = strict_validator();
+        for _ in 0..5 {
+            let _ = v.validate_hops(&[hop(1, "pool_a"), hop(1, "pool_b")]);
+        }
+        assert_eq!(v.metrics().total_validations(), 5);
+    }
+
+    #[test]
+    fn test_metrics_violation_count() {
+        let v = strict_validator();
+        let _ = v.validate_hops(&[hop(1, "pool_a"), hop(2, "pool_b")]);
+        let _ = v.validate_hops(&[hop(1, "pool_a"), hop(2, "pool_b")]);
+        let _ = v.validate_hops(&[hop(1, "pool_a"), hop(1, "pool_b")]); // ok
+        assert_eq!(v.metrics().violations(), 2);
+    }
+
+    #[test]
+    fn test_single_hop_always_passes() {
+        let v = strict_validator();
+        assert!(v.validate_hops(&[hop(77, "pool_x")]).is_ok());
+    }
+
+    #[test]
+    fn test_error_is_serializable() {
+        let err = SnapshotIsolationError::MixedSnapshots {
+            hop_index: 2,
+            expected_snapshot: SnapshotId(10),
+            hop_snapshot: SnapshotId(11),
+            venue_ref: "pool_z".to_string(),
+        };
+        let json = serde_json::to_string(&err).expect("should serialize");
+        assert!(json.contains("mixed_snapshots") || json.contains("MixedSnapshots") || json.contains("hop_index"));
+    }
+
+    #[test]
+    fn test_concurrent_update_detection() {
+        // Simulates two concurrent indexer updates producing different ledger seqs.
+        // Hop 0 was read at ledger 1000, hop 1 at ledger 1001 due to a concurrent update.
+        let v = strict_validator();
+        let hops = vec![
+            ValidatedHop {
+                snapshot_id: SnapshotId(1000),
+                venue_ref: "xlm_usdc_amm".into(),
+                source_asset: "XLM".into(),
+                destination_asset: "USDC".into(),
+            },
+            ValidatedHop {
+                snapshot_id: SnapshotId(1001), // concurrent update bumped this
+                venue_ref: "usdc_btc_sdex".into(),
+                source_asset: "USDC".into(),
+                destination_asset: "BTC".into(),
+            },
+        ];
+        assert!(v.validate_hops(&hops).is_err(), "concurrent-update mixed snapshot must be rejected");
+    }
+}

--- a/crates/routing/tests/hybrid_optimizer_tests.rs
+++ b/crates/routing/tests/hybrid_optimizer_tests.rs
@@ -184,6 +184,7 @@ fn test_policy_constraints() {
         max_impact_bps: 10,     // Very low impact tolerance
         max_compute_time_ms: 1, // Very low time tolerance
         environment: "restrictive".to_string(),
+        scorer: None,
     };
 
     optimizer.add_policy(restrictive_policy).unwrap();
@@ -216,6 +217,7 @@ fn test_custom_policy() {
         max_impact_bps: 1000,
         max_compute_time_ms: 50,
         environment: "latency_first".to_string(),
+        scorer: None,
     };
 
     optimizer.add_policy(latency_first_policy).unwrap();


### PR DESCRIPTION
## Summary

This PR implements four backend enhancements from the Stellar Wave program, all contained within the `stellarroute-routing` crate with no breaking changes to existing public APIs.

### Issue #446 – Dynamic routing-source weighting based on recent execution quality
- New module `execution_quality.rs` — thread-safe `ExecutionQualityTracker` maintains per-source exponential moving averages (EMA) for quality score and error rate
- Combined into a reliability weight clamped within configurable `WeightBounds` (default min 0.1 / max 0.95), preventing runaway feedback loops
- Every weight update emitted as a `tracing::info!` structured event for log-aggregator observability
- `apply_to_policy_weights()` injects live weights directly into `ConsensusPolicy::source_weights`
- Benchmark test (`test_static_vs_dynamic_weighting`) demonstrates measurable divergence from static weights after sustained quality differences

### Issue #447 – Snapshot isolation validator for multi-hop quote assembly
- New module `snapshot.rs` — `SnapshotIsolationValidator` ensures all hops in a multi-hop path were built from the same `SnapshotId` (ledger-sequence-derived)
- Returns machine-readable `SnapshotIsolationError::MixedSnapshots` with `hop_index`, `expected_snapshot`, `hop_snapshot`, and `venue_ref`
- Strict (default) and lenient modes — lenient records violation metrics without failing
- `SnapshotIsolationMetrics` atomic counters (`total_validations`, `violations`, `empty_paths`) ready for Prometheus scraping
- Dedicated `test_concurrent_update_detection` integration test simulates two concurrent indexer ledger updates producing a mixed-snapshot path

### Issue #448 – Tiered fallback strategy for degraded AMM data availability
- New module `amm_fallback.rs` — `TieredAmmFallback::resolve()` walks a configurable tier hierarchy: **LiveAmm → CachedAmm → SdexOnly → Error**
- Tiers are documented, serializable (`AmmFallbackTier` as `snake_case`), and comparable with `Ord`
- `FallbackResult` includes `tier`, selected `edges`, human-readable `reason`, and `dropped_edge_count` for quote response surfacing to clients
- `allow_sdex_fallback: bool` flag lets operators disable SDEX routing entirely when needed
- Tests cover all four tier transitions including disabled-SDEX and empty-candidate cases

### Issue #449 – Deterministic benchmark runner for routing regressions
- New module `regression.rs` — `BenchmarkFixture` uses `rand_chacha::ChaCha8Rng` seeded from a `u64` field for platform-identical, version-stable edge generation
- `RegressionRunner` runs each fixture N times, takes median latency, compares score and latency deltas against a `BaselineStore`
- `RegressionReport::ci_summary()` produces plain-text output suitable for CI log gating; full JSON via serde
- `BenchmarkFixture::standard_suite()` ships four built-in fixtures covering 2-hop, 4-hop, and large-graph scenarios
- New Criterion bench `deterministic_regression_benchmark.rs` (registered in `Cargo.toml`) for `cargo bench` integration
- **Also fixes two pre-existing compile errors** in `optimizer.rs` and `hybrid_optimizer_tests.rs` (missing struct fields with serde `#[serde(default)]` already present on the fields)

## Test coverage

All 140 unit + integration tests pass:

```
test result: ok. 140 passed; 0 failed; 0 ignored
```

New tests added per module:
- `execution_quality` — 8 tests (bounds, EMA convergence, static vs dynamic benchmark)
- `snapshot` — 10 tests (strict/lenient modes, metrics counters, concurrent-update scenario, serde)
- `amm_fallback` — 9 tests (all tier transitions, disabled SDEX, empty candidates, serde, tier ordering)
- `regression` — 8 tests (determinism, seed sensitivity, baseline round-trip, regression detection, CI summary)

## Closes

Closes #446
Closes #447
Closes #448
Closes #449