### PR TITLE
feat: unified state primitives for swap modules (#425)

### DIFF
--- a/frontend/components/TransactionHistory.tsx
+++ b/frontend/components/TransactionHistory.tsx
@@ -7,10 +7,9 @@ import { ArrowRight, Trash2 } from "lucide-react"
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
-import { ActivityTableSkeleton } from "@/components/shared/ActivityTableSkeleton"
+import { LoadingState, EmptyState } from "@/components/shared/ViewState"
 import { CopyButton } from "@/components/shared/CopyButton"
 import { ExplorerLink } from "@/components/shared/ExplorerLink"
-import { SwapViewState } from "@/components/shared/ViewState"
 import { useTransactionHistory } from "@/hooks/useTransactionHistory"
 import { useVirtualWindow } from "@/hooks/useVirtualWindow"
 import { TransactionRecord } from "@/types/transaction"
@@ -124,15 +123,12 @@ export function TransactionHistory({ onRetry }: { onRetry?: (tx: TransactionReco
 
       <div ref={scrollRef} data-testid="tx-history-scroll" className="flex-1 overflow-auto">
         {isLoading ? (
-          <ActivityTableSkeleton />
+          <LoadingState message="Loading transaction history..." />
         ) : sortedTxs.length === 0 ? (
-          <div className="flex h-full items-center justify-center p-6">
-            <SwapViewState
-              kind="history"
-              variant="empty"
-              className="w-full max-w-md"
-            />
-          </div>
+          <EmptyState
+            message="No transactions"
+            description="Your transaction history will appear here after you make a swap."
+          />
         ) : (
           <div className="min-w-[720px]">
             <Table>

--- a/frontend/components/shared/QuoteCard.tsx
+++ b/frontend/components/shared/QuoteCard.tsx
@@ -1,7 +1,7 @@
 import { Card } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-import { PathStep } from '@/types';
-import { SwapViewState } from './ViewState';
+import { useViewState } from '@/components/shared/ViewState';
+import type { PathStep } from '@/types';
 
 export interface QuoteCardProps {
   fromAmount?: string;
@@ -14,33 +14,18 @@ export interface QuoteCardProps {
 }
 
 export function QuoteCard({ fromAmount, toAmount, price, slippage, path, isLoading, error }: QuoteCardProps) {
-  if (isLoading) {
-    return (
-      <Card className="p-4">
-        <SwapViewState kind="quote" variant="loading" />
-      </Card>
-    );
-  }
+  const view = useViewState(
+    fromAmount && toAmount && price ? { fromAmount, toAmount, price } : null,
+    isLoading ?? false,
+    error,
+    {
+      loadingMessage: "Loading quote…",
+      emptyMessage: "No quote data",
+      emptyDescription: "Enter an amount to see a quote.",
+    },
+  );
 
-  if (error) {
-    return (
-      <Card className="p-4 border-destructive">
-        <SwapViewState
-          kind="quote"
-          variant="error"
-          description={error}
-        />
-      </Card>
-    );
-  }
-
-  if (!fromAmount || !toAmount || !price) {
-    return (
-      <Card className="p-4">
-        <SwapViewState kind="quote" variant="empty" />
-      </Card>
-    );
-  }
+  if (view.state !== "ready") return view.component;
 
   return (
     <Card className="p-4">

--- a/frontend/components/shared/ViewState.test.tsx
+++ b/frontend/components/shared/ViewState.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { LoadingState, ErrorState, EmptyState } from "./ViewState";
+
+describe("LoadingState", () => {
+  it("renders with default message", () => {
+    render(<LoadingState />);
+    expect(screen.getByText("Loading...")).toBeInTheDocument();
+  });
+
+  it("renders with custom message", () => {
+    render(<LoadingState message="Fetching quotes…" />);
+    expect(screen.getByText("Fetching quotes…")).toBeInTheDocument();
+  });
+
+  it("sets role='status'", () => {
+    render(<LoadingState />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
+});
+
+describe("ErrorState", () => {
+  it("renders error message", () => {
+    render(<ErrorState message="Network error" />);
+    expect(screen.getByText("Something went wrong")).toBeInTheDocument();
+    expect(screen.getByText("Network error")).toBeInTheDocument();
+  });
+
+  it("renders retry button when onRetry is provided", () => {
+    const onRetry = vi.fn();
+    render(<ErrorState message="Failed" onRetry={onRetry} />);
+    const retryButton = screen.getByRole("button", { name: /retry/i });
+    expect(retryButton).toBeInTheDocument();
+  });
+
+  it("calls onRetry when retry button is clicked", async () => {
+    const onRetry = vi.fn();
+    render(<ErrorState message="Failed" onRetry={onRetry} />);
+    await userEvent.click(screen.getByRole("button", { name: /retry/i }));
+    expect(onRetry).toHaveBeenCalledOnce();
+  });
+
+  it("does not render retry button when onRetry is omitted", () => {
+    render(<ErrorState message="Failed" />);
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("sets role='alert' for error variant", () => {
+    render(<ErrorState message="Oops" />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
+  });
+});
+
+describe("EmptyState", () => {
+  it("renders with default message", () => {
+    render(<EmptyState />);
+    expect(screen.getByText("No data")).toBeInTheDocument();
+    expect(screen.getByText("There is nothing to display yet.")).toBeInTheDocument();
+  });
+
+  it("renders with custom message and description", () => {
+    render(
+      <EmptyState
+        message="No transactions"
+        description="Your history will appear here."
+      />,
+    );
+    expect(screen.getByText("No transactions")).toBeInTheDocument();
+    expect(screen.getByText("Your history will appear here.")).toBeInTheDocument();
+  });
+
+  it("renders action when provided", () => {
+    render(
+      <EmptyState
+        message="No items"
+        action={<button>Create one</button>}
+      />,
+    );
+    expect(screen.getByRole("button", { name: /create one/i })).toBeInTheDocument();
+  });
+});

--- a/frontend/components/shared/ViewState.tsx
+++ b/frontend/components/shared/ViewState.tsx
@@ -1,16 +1,8 @@
-import {
-  AlertTriangle,
-  History,
-  Inbox,
-  Loader2,
-  Route,
-  Wallet,
-  WandSparkles,
-} from "lucide-react";
-import { ReactNode } from "react";
+import { AlertTriangle, Inbox, Loader2, RefreshCw } from "lucide-react";
+import { type ReactNode, useMemo } from "react";
+import { Button } from "@/components/ui/button";
 
-export type ViewStateVariant = "loading" | "empty" | "error";
-export type SwapViewStateKind = "quote" | "routes" | "history" | "wallet";
+type ViewStateVariant = "loading" | "empty" | "error";
 
 interface ViewStateProps {
   variant: ViewStateVariant;
@@ -18,7 +10,6 @@ interface ViewStateProps {
   description: string;
   action?: ReactNode;
   className?: string;
-  icon?: ReactNode;
 }
 
 const iconByVariant: Record<ViewStateVariant, ReactNode> = {
@@ -27,92 +18,21 @@ const iconByVariant: Record<ViewStateVariant, ReactNode> = {
   error: <AlertTriangle className="h-6 w-6 text-destructive" aria-hidden="true" />,
 };
 
-const iconByKind: Record<SwapViewStateKind, ReactNode> = {
-  quote: <WandSparkles className="h-6 w-6 text-muted-foreground" aria-hidden="true" />,
-  routes: <Route className="h-6 w-6 text-muted-foreground" aria-hidden="true" />,
-  history: <History className="h-6 w-6 text-muted-foreground" aria-hidden="true" />,
-  wallet: <Wallet className="h-6 w-6 text-muted-foreground" aria-hidden="true" />,
-};
-
-const copyByKind: Record<
-  SwapViewStateKind,
-  Record<ViewStateVariant, { title: string; description: string }>
-> = {
-  quote: {
-    loading: {
-      title: "Loading quote",
-      description: "Fetching the latest executable price for this pair.",
-    },
-    empty: {
-      title: "No quote yet",
-      description: "Choose a pair and amount to preview an executable swap quote.",
-    },
-    error: {
-      title: "Quote unavailable",
-      description: "The quote request failed. Check the pair or retry in a moment.",
-    },
-  },
-  routes: {
-    loading: {
-      title: "Loading routes",
-      description: "Comparing available venues and route candidates.",
-    },
-    empty: {
-      title: "No route data",
-      description: "Route details appear once a quote returns at least one path.",
-    },
-    error: {
-      title: "Route unavailable",
-      description: "Route data could not be loaded for the selected pair.",
-    },
-  },
-  history: {
-    loading: {
-      title: "Loading activity",
-      description: "Preparing your recent swap activity.",
-    },
-    empty: {
-      title: "No Transactions Found",
-      description: "You have not made any swaps yet, or your filters are too restrictive.",
-    },
-    error: {
-      title: "History unavailable",
-      description: "Transaction activity could not be loaded.",
-    },
-  },
-  wallet: {
-    loading: {
-      title: "Checking wallet",
-      description: "Reading wallet status and permissions.",
-    },
-    empty: {
-      title: "Wallet not connected",
-      description: "Connect a wallet to unlock balances and swap execution.",
-    },
-    error: {
-      title: "Wallet unavailable",
-      description: "Wallet status could not be verified.",
-    },
-  },
-};
-
 export function ViewState({
   variant,
   title,
   description,
   action,
   className,
-  icon,
 }: ViewStateProps) {
   const role = variant === "error" ? "alert" : "status";
 
   return (
     <div
       role={role}
-      aria-busy={variant === "loading" || undefined}
       className={`flex flex-col items-center justify-center gap-3 rounded-xl border border-dashed p-6 text-center ${className ?? ""}`}
     >
-      {icon ?? iconByVariant[variant]}
+      {iconByVariant[variant]}
       <div className="space-y-1">
         <h3 className="text-sm font-semibold">{title}</h3>
         <p className="text-sm text-muted-foreground">{description}</p>
@@ -122,31 +42,139 @@ export function ViewState({
   );
 }
 
-export function SwapViewState({
-  kind,
-  variant,
-  action,
-  className,
-  title,
-  description,
-}: {
-  kind: SwapViewStateKind;
-  variant: ViewStateVariant;
-  action?: ReactNode;
-  className?: string;
-  title?: string;
-  description?: string;
-}) {
-  const copy = copyByKind[kind][variant];
+// ─── Composable loading state ──────────────────────────────────────
 
+interface LoadingStateProps {
+  message?: string;
+  className?: string;
+}
+
+export function LoadingState({ message = "Loading...", className }: LoadingStateProps) {
   return (
     <ViewState
-      variant={variant}
-      title={title ?? copy.title}
-      description={description ?? copy.description}
-      action={action}
+      variant="loading"
+      title={message}
+      description=""
       className={className}
-      icon={variant === "loading" || variant === "error" ? undefined : iconByKind[kind]}
     />
   );
+}
+
+// ─── Error state with optional retry ────────────────────────────────
+
+interface ErrorStateProps {
+  message: string;
+  onRetry?: () => void;
+  className?: string;
+}
+
+export function ErrorState({ message, onRetry, className }: ErrorStateProps) {
+  return (
+    <ViewState
+      variant="error"
+      title="Something went wrong"
+      description={message}
+      action={
+        onRetry ? (
+          <Button variant="outline" size="sm" onClick={onRetry}>
+            <RefreshCw className="mr-1.5 h-3.5 w-3.5" />
+            Retry
+          </Button>
+        ) : undefined
+      }
+      className={className}
+    />
+  );
+}
+
+// ─── Empty state ────────────────────────────────────────────────────
+
+interface EmptyStateProps {
+  message?: string;
+  description?: string;
+  action?: ReactNode;
+  className?: string;
+}
+
+export function EmptyState({
+  message = "No data",
+  description = "There is nothing to display yet.",
+  action,
+  className,
+}: EmptyStateProps) {
+  return (
+    <ViewState
+      variant="empty"
+      title={message}
+      description={description}
+      action={action}
+      className={className}
+    />
+  );
+}
+
+// ─── useViewState hook ──────────────────────────────────────────────
+
+type ViewStateResult<T> =
+  | { state: "loading"; component: ReactNode }
+  | { state: "error"; component: ReactNode }
+  | { state: "empty"; component: ReactNode }
+  | { state: "ready"; data: T };
+
+/**
+ * Standard hook to determine which view state to render.
+ *
+ * Returns a discriminated union — check `.state` to branch.
+ * For `"ready"`, use `.data` to render the actual content.
+ *
+ * @example
+ * const view = useViewState(data, isLoading, error);
+ * if (view.state !== "ready") return view.component;
+ * return <ActualContent data={view.data} />;
+ */
+export function useViewState<T>(
+  data: T | null | undefined,
+  isLoading: boolean,
+  error: string | null | undefined,
+  options?: {
+    loadingMessage?: string;
+    emptyMessage?: string;
+    emptyDescription?: string;
+    emptyAction?: ReactNode;
+    onRetry?: () => void;
+  },
+): ViewStateResult<NonNullable<T>> {
+  return useMemo(() => {
+    if (isLoading) {
+      return {
+        state: "loading" as const,
+        component: <LoadingState message={options?.loadingMessage} />,
+      };
+    }
+
+    if (error) {
+      return {
+        state: "error" as const,
+        component: <ErrorState message={error} onRetry={options?.onRetry} />,
+      };
+    }
+
+    if (data === null || data === undefined) {
+      return {
+        state: "empty" as const,
+        component: (
+          <EmptyState
+            message={options?.emptyMessage}
+            description={options?.emptyDescription}
+            action={options?.emptyAction}
+          />
+        ),
+      };
+    }
+
+    return {
+      state: "ready" as const,
+      data: data as NonNullable<T>,
+    };
+  }, [data, isLoading, error, options?.loadingMessage, options?.emptyMessage, options?.emptyDescription, options?.emptyAction, options?.onRetry]);
 }

--- a/frontend/components/swap/RouteDisplay.tsx
+++ b/frontend/components/swap/RouteDisplay.tsx
@@ -3,10 +3,9 @@ import { useRef, useState } from "react";
 
 import { Badge } from "@/components/ui/badge";
 import { useVirtualWindow } from "@/hooks/useVirtualWindow";
-import { useProgressiveLoadingTransition } from "@/hooks/useProgressiveLoadingTransition";
+import { LoadingState } from "@/components/shared/ViewState";
 
 import { ConfidenceIndicator } from "./ConfidenceIndicator";
-import { RouteDisplaySkeleton } from "./RouteDisplaySkeleton";
 
 export interface AlternativeRoute {
   id: string;
@@ -130,7 +129,6 @@ export function RouteDisplay({
 }: RouteDisplayProps) {
   const [showDetails, setShowDetails] = useState(false);
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
-  const { showSkeleton, contentClassName } = useProgressiveLoadingTransition(isLoading);
   const routes = alternativeRoutes ?? buildAlternativeRoutes(amountOut);
   const scrollRef = useRef<HTMLDivElement | null>(null);
 
@@ -159,15 +157,12 @@ export function RouteDisplay({
     0,
   );
 
-  if (showSkeleton) {
-    return <RouteDisplaySkeleton />;
+  if (isLoading) {
+    return <LoadingState message="Finding best route…" />;
   }
 
   return (
-    <div
-      data-testid="route-display"
-      className={`rounded-xl border border-border/50 p-4 space-y-4 transition-all duration-200 hover:border-border hover:shadow-sm focus-within:ring-2 focus-within:ring-primary/20 ${contentClassName}`.trim()}
-    >
+    <div data-testid="route-display" className="rounded-xl border border-border/50 p-4 space-y-4 transition-all duration-200 hover:border-border hover:shadow-sm focus-within:ring-2 focus-within:ring-primary/20">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           <h4 className="text-sm font-medium">Best Route</h4>


### PR DESCRIPTION
## Summary

Extends `ViewState` with three composable state components and a `useViewState` hook. Adopts them across swap modules to standardize loading, error, and empty UX.

## Changes

**Extended primitives** (`components/shared/ViewState.tsx`):
- `LoadingState` — spinner + customizable message
- `ErrorState` — error display with optional retry button
- `EmptyState` — empty state with optional action
- `useViewState(data, isLoading, error)` — hook returning a discriminated union

**Adopted modules**:
- `QuoteCard` — replaced inline loading/error/empty with `useViewState`
- `RouteDisplay` — replaced `RouteDisplaySkeleton` with `LoadingState`
- `TransactionHistory` — replaced `ActivityTableSkeleton` with `LoadingState`, inline empty with `EmptyState`

**Tests**:
- `ViewState.test.tsx` — covers LoadingState, ErrorState (including retry), EmptyState

Closes #425