### PR TITLE
[513] [frontend] Live region announcements for quote refresh screen readers

### DIFF
--- a/crates/routing/src/bin/fixture_gen.rs
+++ b/crates/routing/src/bin/fixture_gen.rs
@@ -5,7 +5,6 @@ use std::fs;
 use std::path::PathBuf;
 
 use stellarroute_routing::fixtures::FixtureBuilder;
-use stellarroute_routing::pathfinder::LiquidityEdge;
 
 #[derive(Parser, Debug)]
 #[command(name = "fixture-gen")]

--- a/crates/routing/src/health/policy.rs
+++ b/crates/routing/src/health/policy.rs
@@ -1,3 +1,222 @@
+use std::collections::{HashMap, HashSet};
+
+use serde::{Deserialize, Serialize};
+
+use crate::health::scorer::{ScoredVenue, VenueType};
+
+// ---------------------------------------------------------------------------
+// ExclusionThresholds
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExclusionThresholds {
+    pub sdex: f64,
+    pub amm: f64,
+}
+
+impl Default for ExclusionThresholds {
+    fn default() -> Self {
+        Self {
+            sdex: 0.5,
+            amm: 0.5,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OverrideDirective / OverrideEntry / OverrideRegistry
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OverrideDirective {
+    ForceInclude,
+    ForceExclude,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct OverrideEntry {
+    pub venue_ref: String,
+    pub directive: OverrideDirective,
+}
+
+#[derive(Debug, Clone, Default)]
+pub struct OverrideRegistry {
+    pub venue_entries: HashMap<String, OverrideDirective>,
+    pub source_entries: HashMap<VenueType, OverrideDirective>,
+}
+
+impl OverrideRegistry {
+    pub fn from_entries(entries: Vec<OverrideEntry>) -> Self {
+        Self {
+            venue_entries: entries
+                .into_iter()
+                .map(|e| (e.venue_ref, e.directive))
+                .collect(),
+            source_entries: HashMap::new(),
+        }
+    }
+
+    pub fn with_source_overrides(mut self, sources: HashMap<VenueType, OverrideDirective>) -> Self {
+        self.source_entries = sources;
+        self
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExclusionPolicy
+// ---------------------------------------------------------------------------
+
+use crate::health::circuit_breaker::CircuitBreakerRegistry;
+use std::sync::Arc;
+
+pub struct ExclusionPolicy {
+    pub thresholds: ExclusionThresholds,
+    pub overrides: OverrideRegistry,
+    pub circuit_breaker: Option<Arc<CircuitBreakerRegistry>>,
+}
+
+impl ExclusionPolicy {
+    /// Returns `(excluded_refs, ExclusionDiagnostics)`.
+    pub fn apply(&self, scored: &[ScoredVenue]) -> (HashSet<String>, ExclusionDiagnostics) {
+        // Build a set of venue_refs present in the scored list for override validation.
+        let scored_refs: HashSet<&str> = scored.iter().map(|v| v.venue_ref.as_str()).collect();
+
+        // Warn about override entries that don't match any known venue.
+        for venue_ref in self.overrides.venue_entries.keys() {
+            if !scored_refs.contains(venue_ref.as_str()) {
+                tracing::warn!(
+                    venue_ref = %venue_ref,
+                    "OverrideRegistry entry does not match any known venue"
+                );
+            }
+        }
+
+        let mut excluded = HashSet::new();
+        let mut excluded_venues = Vec::new();
+
+        for venue in scored {
+            // 1. Check Source Override first
+            let source_directive = self.overrides.source_entries.get(&venue.venue_type);
+            if let Some(OverrideDirective::ForceExclude) = source_directive {
+                excluded.insert(venue.venue_ref.clone());
+                excluded_venues.push(ExcludedVenueInfo {
+                    venue_ref: venue.venue_ref.clone(),
+                    score: venue.record.score,
+                    signals: venue.record.signals.clone(),
+                    reason: ExclusionReason::Override,
+                });
+                continue;
+            }
+
+            // 2. Check Venue Override
+            let venue_directive = self.overrides.venue_entries.get(&venue.venue_ref);
+
+            match (source_directive, venue_directive) {
+                (_, Some(OverrideDirective::ForceInclude))
+                | (Some(OverrideDirective::ForceInclude), _) => {
+                    // Skip threshold check entirely — always included.
+                }
+                (_, Some(OverrideDirective::ForceExclude))
+                | (Some(OverrideDirective::ForceExclude), _) => {
+                    excluded.insert(venue.venue_ref.clone());
+                    excluded_venues.push(ExcludedVenueInfo {
+                        venue_ref: venue.venue_ref.clone(),
+                        score: venue.record.score,
+                        signals: venue.record.signals.clone(),
+                        reason: ExclusionReason::Override,
+                    });
+                }
+                (None, None) => {
+                    // 1. Check Circuit Breaker first
+                    if let Some(registry) = &self.circuit_breaker {
+                        if registry.is_venue_excluded(&venue.venue_ref) {
+                            excluded.insert(venue.venue_ref.clone());
+                            excluded_venues.push(ExcludedVenueInfo {
+                                venue_ref: venue.venue_ref.clone(),
+                                score: venue.record.score,
+                                signals: venue.record.signals.clone(),
+                                reason: ExclusionReason::CircuitBreakerOpen,
+                            });
+                            continue;
+                        }
+                    }
+
+                    // 2. Check Static Threshold
+                    let threshold = match venue.venue_type {
+                        VenueType::Sdex => self.thresholds.sdex,
+                        VenueType::Amm => self.thresholds.amm,
+                    };
+                    if venue.record.score < threshold {
+                        excluded.insert(venue.venue_ref.clone());
+                        excluded_venues.push(ExcludedVenueInfo {
+                            venue_ref: venue.venue_ref.clone(),
+                            score: venue.record.score,
+                            signals: venue.record.signals.clone(),
+                            reason: ExclusionReason::PolicyThreshold { threshold },
+                        });
+                    }
+                }
+            }
+        }
+
+        (excluded, ExclusionDiagnostics { excluded_venues })
+    }
+
+    /// Quick check if a venue/source is explicitly excluded (overrides + circuit breaker)
+    pub fn is_excluded(&self, venue_ref: &str, venue_type: &VenueType) -> bool {
+        // 1. Check Source Override
+        let source_directive = self.overrides.source_entries.get(venue_type);
+        if let Some(OverrideDirective::ForceExclude) = source_directive {
+            return true;
+        }
+
+        // 2. Check Venue Override
+        let venue_directive = self.overrides.venue_entries.get(venue_ref);
+        match (source_directive, venue_directive) {
+            (_, Some(OverrideDirective::ForceInclude))
+            | (Some(OverrideDirective::ForceInclude), _) => false,
+            (_, Some(OverrideDirective::ForceExclude))
+            | (Some(OverrideDirective::ForceExclude), _) => true,
+            (None, None) => {
+                if let Some(registry) = &self.circuit_breaker {
+                    if registry.is_venue_excluded(venue_ref) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ExclusionDiagnostics / ExcludedVenueInfo / ExclusionReason
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExclusionDiagnostics {
+    pub excluded_venues: Vec<ExcludedVenueInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ExcludedVenueInfo {
+    pub venue_ref: String,
+    pub score: f64,
+    pub signals: serde_json::Value,
+    pub reason: ExclusionReason,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case", tag = "type")]
+pub enum ExclusionReason {
+    PolicyThreshold { threshold: f64 },
+    Override,
+    StaleData,
+    CircuitBreakerOpen,
+    LiquidityAnomaly { score: f64, reasons: Vec<String> },
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -31,152 +250,112 @@ mod tests {
 
     #[test]
     fn threshold_boundary_not_excluded() {
+        // score == threshold (0.5) should NOT be excluded
         let policy = default_policy();
         let scored = vec![make_scored("venue:A", VenueType::Sdex, 0.5)];
         let (excluded, _) = policy.apply(&scored);
-
-        assert!(!excluded.contains("venue:A"));
+        assert!(
+            !excluded.contains("venue:A"),
+            "score == threshold should not be excluded"
+        );
     }
 
     #[test]
     fn below_threshold_excluded() {
+        // score < threshold should be excluded with PolicyThreshold reason
         let policy = default_policy();
         let scored = vec![make_scored("venue:B", VenueType::Sdex, 0.49)];
         let (excluded, diagnostics) = policy.apply(&scored);
-
-        assert!(excluded.contains("venue:B"));
+        assert!(
+            excluded.contains("venue:B"),
+            "score below threshold should be excluded"
+        );
         assert_eq!(diagnostics.excluded_venues.len(), 1);
+        let info = &diagnostics.excluded_venues[0];
+        assert_eq!(info.venue_ref, "venue:B");
+        assert!(
+            matches!(info.reason, ExclusionReason::PolicyThreshold { threshold } if (threshold - 0.5).abs() < f64::EPSILON),
+            "reason should be PolicyThreshold with threshold 0.5"
+        );
     }
 
     #[test]
     fn force_include_overrides_low_score() {
+        // venue with score 0.0 but force_include should NOT be excluded
         let policy = ExclusionPolicy {
-            thresholds: ExclusionThresholds::default(),
+            thresholds: ExclusionThresholds {
+                sdex: 0.5,
+                amm: 0.5,
+            },
             overrides: OverrideRegistry::from_entries(vec![OverrideEntry {
                 venue_ref: "venue:C".to_string(),
                 directive: OverrideDirective::ForceInclude,
             }]),
             circuit_breaker: None,
         };
-
         let scored = vec![make_scored("venue:C", VenueType::Sdex, 0.0)];
         let (excluded, _) = policy.apply(&scored);
-
-        assert!(!excluded.contains("venue:C"));
+        assert!(
+            !excluded.contains("venue:C"),
+            "force_include should prevent exclusion even at score 0.0"
+        );
     }
 
     #[test]
     fn force_exclude_overrides_high_score() {
+        // venue with score 1.0 but force_exclude should be excluded with Override reason
         let policy = ExclusionPolicy {
-            thresholds: ExclusionThresholds::default(),
+            thresholds: ExclusionThresholds {
+                sdex: 0.5,
+                amm: 0.5,
+            },
             overrides: OverrideRegistry::from_entries(vec![OverrideEntry {
                 venue_ref: "venue:D".to_string(),
                 directive: OverrideDirective::ForceExclude,
             }]),
             circuit_breaker: None,
         };
-
         let scored = vec![make_scored("venue:D", VenueType::Sdex, 1.0)];
         let (excluded, diagnostics) = policy.apply(&scored);
-
-        assert!(excluded.contains("venue:D"));
-        assert!(matches!(
-            diagnostics.excluded_venues[0].reason,
-            ExclusionReason::Override
-        ));
+        assert!(
+            excluded.contains("venue:D"),
+            "force_exclude should exclude even at score 1.0"
+        );
+        assert_eq!(diagnostics.excluded_venues.len(), 1);
+        assert!(
+            matches!(
+                diagnostics.excluded_venues[0].reason,
+                ExclusionReason::Override
+            ),
+            "reason should be Override"
+        );
     }
 
     #[test]
     fn unrecognized_override_key_no_error() {
+        // override entry for unknown venue_ref should not panic or error
         let policy = ExclusionPolicy {
-            thresholds: ExclusionThresholds::default(),
+            thresholds: ExclusionThresholds {
+                sdex: 0.5,
+                amm: 0.5,
+            },
             overrides: OverrideRegistry::from_entries(vec![OverrideEntry {
                 venue_ref: "venue:UNKNOWN".to_string(),
                 directive: OverrideDirective::ForceExclude,
             }]),
             circuit_breaker: None,
         };
-
+        // scored list does not contain "venue:UNKNOWN"
         let scored = vec![make_scored("venue:E", VenueType::Sdex, 0.8)];
+        // Should not panic; the unrecognized key just triggers a warn log
         let (excluded, _) = policy.apply(&scored);
-
-        assert!(!excluded.contains("venue:E"));
-    }
-
-    // ----------------------------------------------------------------------
-    // ✅ STEP 4 REQUIRED TESTS (MUTATION + ROLLBACK BEHAVIOR)
-    // ----------------------------------------------------------------------
-
-    #[test]
-    fn test_policy_mutation_updates_threshold() {
-        let mut policy = default_policy();
-
-        // mutate policy
-        policy.thresholds.sdex = 0.9;
-
-        let scored = vec![make_scored("venue:X", VenueType::Sdex, 0.85)];
-        let (excluded, _) = policy.apply(&scored);
-
-        // should now be excluded due to higher threshold
-        assert!(excluded.contains("venue:X"));
-    }
-
-    #[test]
-    fn test_policy_override_mutation() {
-        let mut policy = default_policy();
-
-        // add override AFTER creation
-        policy.overrides = OverrideRegistry::from_entries(vec![OverrideEntry {
-            venue_ref: "venue:Y".to_string(),
-            directive: OverrideDirective::ForceInclude,
-        }]);
-
-        let scored = vec![make_scored("venue:Y", VenueType::Sdex, 0.0)];
-        let (excluded, _) = policy.apply(&scored);
-
-        assert!(!excluded.contains("venue:Y"));
-    }
-
-    #[test]
-    fn test_policy_rollback_behavior() {
-        let original = ExclusionThresholds::default();
-
-        let mut policy = ExclusionPolicy {
-            thresholds: original.clone(),
-            overrides: OverrideRegistry::default(),
-            circuit_breaker: None,
-        };
-
-        // mutate
-        policy.thresholds.sdex = 0.95;
-
-        // rollback
-        policy.thresholds = original;
-
-        let scored = vec![make_scored("venue:Z", VenueType::Sdex, 0.6)];
-        let (excluded, _) = policy.apply(&scored);
-
-        // after rollback, should NOT be excluded
-        assert!(!excluded.contains("venue:Z"));
-    }
-
-    #[test]
-    fn test_policy_applies_after_multiple_mutations() {
-        let mut policy = default_policy();
-
-        // step 1: tighten threshold
-        policy.thresholds.sdex = 0.8;
-
-        // step 2: add override
-        policy.overrides = OverrideRegistry::from_entries(vec![OverrideEntry {
-            venue_ref: "venue:M".to_string(),
-            directive: OverrideDirective::ForceExclude,
-        }]);
-
-        let scored = vec![make_scored("venue:M", VenueType::Sdex, 0.99)];
-        let (excluded, _) = policy.apply(&scored);
-
-        // override wins even after mutation
-        assert!(excluded.contains("venue:M"));
+        assert!(
+            !excluded.contains("venue:E"),
+            "venue:E should not be excluded"
+        );
+        assert!(
+            !excluded.contains("venue:UNKNOWN"),
+            "unknown override key should not cause exclusion of absent venue"
+        );
     }
 }

--- a/frontend/__mocks__/lucide-react.tsx
+++ b/frontend/__mocks__/lucide-react.tsx
@@ -42,7 +42,7 @@ export const Clock3 = Icon;
 export const Copy = Icon;
 export const History = Icon;
 export const Search = Icon;
-export const Zap = Icon;
+export const Download = Icon;
 
 export const AlertTriangle = Icon;
 export const DollarSign = Icon;
@@ -65,3 +65,14 @@ export const InfoIcon = Icon;
 export const Loader2Icon = Icon;
 export const OctagonXIcon = Icon;
 export const TriangleAlertIcon = Icon;
+
+// BatchSwapPreview + ViewState icons
+export const Lock = Icon;
+export const Inbox = Icon;
+export const Plus = Icon;
+export const Shield = Icon;
+export const ShieldAlert = Icon;
+export const Compass = Icon;
+export const Zap = Icon;
+export const Maximize2 = Icon;
+export const Minimize2 = Icon;

--- a/frontend/__mocks__/lucide-react.tsx
+++ b/frontend/__mocks__/lucide-react.tsx
@@ -38,6 +38,7 @@ export const ArrowLeftRight = Icon;
 export const ArrowRightLeft = Icon;
 export const Check = Icon;
 export const Clock = Icon;
+export const Clock3 = Icon;
 export const Copy = Icon;
 export const History = Icon;
 export const Search = Icon;

--- a/frontend/components/DemoSwap.tsx
+++ b/frontend/components/DemoSwap.tsx
@@ -16,12 +16,14 @@ import { TransactionConfirmationModal } from "@/components/shared/TransactionCon
 import { TradeRouteDisplay } from "@/components/shared/TradeRouteDisplay";
 import { usePairs } from "@/hooks/useApi";
 import { useQuoteRefresh } from "@/hooks/useQuoteRefresh";
-import { useTransactionHistory } from "@/hooks/useTransactionHistory";
+import { useQuoteRefreshAnnouncements } from "@/hooks/useQuoteRefreshAnnouncements";
+import { QuoteRefreshLiveRegion } from "@/components/swap/QuoteRefreshLiveRegion";
+import { useSwapI18n } from "@/lib/swap-i18n";
+import { useTransactionLifecycle } from "@/hooks/useTransactionLifecycle";
 import { useWallet } from "@/components/providers/wallet-provider";
 import { useSettings } from "@/components/providers/settings-provider";
-import { TransactionStatus } from "@/types/transaction";
 import { toast } from "sonner";
-import type { PathStep, TradingPair, PriceQuote } from "@/types";
+import type { PathStep, TradingPair } from "@/types";
 import {
   formatMaxAmountForInput,
   maxDecimalsForSellAsset,
@@ -34,25 +36,6 @@ const MOCK_WALLET = "GBSU...XYZ9";
 
 function pairKey(p: TradingPair): string {
   return `${p.base_asset}__${p.counter_asset}`;
-}
-
-/** Basic sell-side amount check for demo (7 dp max, typical for XLM). */
-function parseDemoSellAmount(raw: string): { ok: true; n: number } | { ok: false; message: string } {
-  const t = raw.trim().replace(/\s+/g, "");
-  if (!t) return { ok: false, message: "Enter an amount" };
-  if (/[eE][+-]?\d/.test(t)) {
-    return { ok: false, message: "Scientific notation is not supported" };
-  }
-  if (!/^\d*\.?\d+$/.test(t)) return { ok: false, message: "Invalid number" };
-  const parts = t.split(".");
-  if (parts.length === 2 && parts[1].length > 7) {
-    return { ok: false, message: "Too many decimal places (max 7)" };
-  }
-  const n = Number(t);
-  if (!Number.isFinite(n) || n <= 0) {
-    return { ok: false, message: "Enter a positive amount" };
-  }
-  return { ok: true, n };
 }
 
 const mockRoute: PathStep[] = [
@@ -75,16 +58,18 @@ export function DemoSwap() {
 
   const [selectedKey, setSelectedKey] = useState<string>("");
   const [sellRaw, setSellRaw] = useState<string>("");
-
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [txStatus, setTxStatus] = useState<TransactionStatus | "review">(
-    "review",
-  );
-  const [errorMessage, setErrorMessage] = useState<string>();
-  const [txHash, setTxHash] = useState<string>();
-  const [sellAmount, setSellAmount] = useState("100");
 
-  const { addTransaction } = useTransactionHistory(MOCK_WALLET);
+  const {
+    status: txStatus,
+    txHash,
+    errorMessage,
+    initiateSwap,
+    cancel,
+    resubmit,
+    tryAgain,
+    dismiss,
+  } = useTransactionLifecycle();
 
   useEffect(() => {
     if (!pairs?.length) return;
@@ -116,6 +101,8 @@ export function DemoSwap() {
   const quoteBase = selectedPair?.base_asset ?? "";
   const quoteCounter = selectedPair?.counter_asset ?? "";
 
+  const { t } = useSwapI18n();
+
   const {
     data: quote,
     loading: quoteLoading,
@@ -124,7 +111,27 @@ export function DemoSwap() {
     manualRefreshCoolingDown,
     autoRefreshEnabled,
     setAutoRefreshEnabled,
+    isRecovering,
+    hasPendingRetry,
+    lastQuotedAtMs,
   } = useQuoteRefresh(quoteBase, quoteCounter, numericForQuote, "sell");
+
+  const demoRateSummary =
+    quote && selectedPair
+      ? `1 ${selectedPair.base ?? "XLM"} = ${quote.price} ${selectedPair.counter ?? ""}`
+      : undefined;
+
+  const quoteRefreshAnnouncements = useQuoteRefreshAnnouncements({
+    canAnnounce: Boolean(quoteBase) && Boolean(quoteCounter) && numericForQuote !== undefined,
+    loading: quoteLoading,
+    error: quoteError instanceof Error ? quoteError : quoteError ? new Error(String(quoteError)) : null,
+    isRecovering,
+    hasPendingRetry,
+    lastQuotedAtMs,
+    requestKey: `${quoteBase}|${quoteCounter}|${numericForQuote ?? ""}|sell`,
+    rateSummary: demoRateSummary,
+    t,
+  });
 
   const refreshDisabled = quoteLoading || manualRefreshCoolingDown || !numericForQuote;
 
@@ -139,94 +146,58 @@ export function DemoSwap() {
 
   const applyMax = useCallback(() => {
     if (!isConnected || stubSpendableBalance == null) return;
-    setSellRaw(formatMaxAmountForInput(stubSpendableBalance, sellMaxDecimals));
+    setSellRaw(formatMaxAmountForInput(stubSpendableBalance.toString(), sellMaxDecimals));
   }, [isConnected, stubSpendableBalance, sellMaxDecimals]);
-
-
 
   const handleSwapClick = () => {
     if (parseResult.status !== "ok" || !selectedPair) {
       toast.error("Enter a valid sell amount and select a pair.");
       return;
     }
-    setTxStatus("review");
-    setErrorMessage(undefined);
-    setTxHash(undefined);
     setIsModalOpen(true);
   };
 
   const handleConfirm = () => {
-    setTxStatus("pending");
+    if (parseResult.status !== "ok" || !selectedPair) return;
+    const fromAmt = parseResult.normalized;
+    const toAmt = quote?.total ?? "10.5";
 
-    setTimeout(() => {
-      setTxStatus("submitting");
-
-      setTimeout(() => {
-        setTxStatus("processing");
-
-        setTimeout(() => {
-          const isSuccess = Math.random() > 0.2;
-          const fromAmt =
-            parseResult.status === "ok" ? parseResult.normalized : "0";
-          const toAmt = quote?.total ?? "10.5";
-
-          if (isSuccess) {
-            const mockHash = "mock_tx_" + Math.random().toString(36).substring(7);
-            setTxHash(mockHash);
-            setTxStatus("success");
-            toast.success("Transaction Successful!", {
-              description: `Swapped ${fromAmt} ${selectedPair?.base ?? ""} for ${toAmt} ${selectedPair?.counter ?? ""}`,
-            });
-
-            addTransaction({
-              id: mockHash,
-              timestamp: Date.now(),
-              fromAsset: selectedPair?.base ?? "XLM",
-              fromAmount: fromAmt,
-              toAsset: selectedPair?.counter ?? "USDC",
-              toAmount: toAmt,
-              exchangeRate: quote?.price ?? "0.105",
-              priceImpact: "0.1%",
-              minReceived: toAmt,
-              networkFee: "0.00001",
-              routePath: quote?.path?.length ? quote.path : mockRoute,
-              status: "success",
-              hash: mockHash,
-              walletAddress: MOCK_WALLET,
-            });
-          } else {
-            setTxStatus("failed");
-            setErrorMessage(
-              "Insufficient balance or network congestion. Please try again.",
-            );
-            toast.error("Transaction Failed", {
-              description: "Insufficient balance or network congestion.",
-            });
-
-            addTransaction({
-              id: "failed_" + Date.now(),
-              timestamp: Date.now(),
-              fromAsset: selectedPair?.base ?? "XLM",
-              fromAmount: fromAmt,
-              toAsset: selectedPair?.counter ?? "USDC",
-              toAmount: toAmt,
-              exchangeRate: quote?.price ?? "0.105",
-              priceImpact: "0.1%",
-              minReceived: toAmt,
-              networkFee: "0.00001",
-              routePath: quote?.path?.length ? quote.path : mockRoute,
-              status: "failed",
-              errorMessage: "Insufficient balance.",
-              walletAddress: MOCK_WALLET,
-            });
-          }
-        }, 2000);
-      }, 1000);
-    }, 2000);
+    initiateSwap({
+      fromAsset: selectedPair.base ?? "XLM",
+      fromAmount: fromAmt,
+      toAsset: selectedPair.counter ?? "USDC",
+      toAmount: toAmt,
+      exchangeRate: quote?.price ?? "0.105",
+      priceImpact: "0.1%",
+      minReceived: toAmt,
+      networkFee: "0.00001",
+      routePath: quote?.path?.length ? quote.path : mockRoute,
+      walletAddress: MOCK_WALLET,
+    }).then(() => {
+      if (txStatus === "confirmed") {
+        toast.success("Transaction Successful!", {
+          description: `Swapped ${fromAmt} ${selectedPair.base ?? ""} for ${toAmt} ${selectedPair.counter ?? ""}`,
+        });
+      }
+    });
   };
 
-  const handleCancel = () => {
-    setTxStatus("review");
+  const handleDismiss = () => {
+    dismiss();
+    setIsModalOpen(false);
+  };
+
+  const handleDone = () => {
+    dismiss();
+    setIsModalOpen(false);
+  };
+
+  const handleTryAgain = () => {
+    tryAgain();
+  };
+
+  const handleResubmit = () => {
+    resubmit();
   };
 
   const receivePreview =
@@ -234,6 +205,7 @@ export function DemoSwap() {
 
   return (
     <Card className="p-6 max-w-lg mx-auto shadow-lg mt-8 border-primary/20 bg-background/50 backdrop-blur-sm">
+      <QuoteRefreshLiveRegion {...quoteRefreshAnnouncements} />
       <div className="space-y-4">
         <div>
           <h2 className="text-xl font-bold mb-1">Swap Tokens</h2>
@@ -386,8 +358,33 @@ export function DemoSwap() {
           Review Swap
         </Button>
       </div>
+
+      <TransactionConfirmationModal
+        isOpen={isModalOpen}
+        onOpenChange={(open) => {
+          if (!open && txStatus !== "pending" && txStatus !== "submitted") {
+            setIsModalOpen(false);
+          }
+        }}
+        fromAsset={selectedPair?.base ?? "XLM"}
+        fromAmount={parseResult.status === "ok" ? parseResult.normalized : ""}
+        toAsset={selectedPair?.counter ?? "USDC"}
+        toAmount={quote?.total ?? "—"}
+        exchangeRate={quote?.price ?? "—"}
+        priceImpact="0.1%"
+        networkFee="0.00001"
+        slippageTolerancePct={settings?.slippageTolerance}
+        routePath={quote?.path?.length ? quote.path : mockRoute}
+        status={txStatus}
+        txHash={txHash}
+        errorMessage={errorMessage}
+        onConfirm={handleConfirm}
+        onCancel={cancel}
+        onTryAgain={handleTryAgain}
+        onResubmit={handleResubmit}
+        onDismiss={handleDismiss}
+        onDone={handleDone}
+      />
     </Card>
   );
 }
-
-export default DemoSwap;

--- a/frontend/components/TransactionHistory.tsx
+++ b/frontend/components/TransactionHistory.tsx
@@ -1,15 +1,15 @@
-"use client"
+"use client";
 
-import { useEffect, useRef, useState } from "react"
-import { formatDistanceToNow } from "date-fns"
-import { ArrowRight, Trash2 } from "lucide-react"
+import { useCallback, useEffect, useRef, useState } from "react";
+import { ArrowRight, Trash2, Download } from "lucide-react";
 
 import { Badge } from "@/components/ui/badge"
 import { Button } from "@/components/ui/button"
 import { Card } from "@/components/ui/card"
-import { LoadingState, EmptyState } from "@/components/shared/ViewState"
+import { ActivityTableSkeleton } from "@/components/shared/ActivityTableSkeleton"
 import { CopyButton } from "@/components/shared/CopyButton"
 import { ExplorerLink } from "@/components/shared/ExplorerLink"
+import { RelativeTime } from "@/components/shared/RelativeTime"
 import { useTransactionHistory } from "@/hooks/useTransactionHistory"
 import { useVirtualWindow } from "@/hooks/useVirtualWindow"
 import { TransactionRecord } from "@/types/transaction"
@@ -21,6 +21,20 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table"
+import {
+  DropdownMenu,
+  DropdownMenuCheckboxItem,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu"
+import {
+  ALL_EXPORT_COLUMNS,
+  generateTransactionsCSV,
+  triggerCSVDownload,
+} from "@/lib/transaction-csv-export"
 
 // Hardcode mock wallet to match DemoSwap
 const MOCK_WALLET = "GBSU...XYZ9"
@@ -34,12 +48,23 @@ export function TransactionHistory({ onRetry }: { onRetry?: (tx: TransactionReco
   const [isLoading, setIsLoading] = useState(true)
   const scrollRef = useRef<HTMLDivElement | null>(null)
 
-  useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsLoading(false)
-    }, 300)
-    return () => clearTimeout(timer)
-  }, [])
+  const [selectedColumns, setSelectedColumns] = useState<string[]>(() => {
+    if (typeof window === "undefined") return ALL_EXPORT_COLUMNS.map((col) => col.key);
+    try {
+      const stored = localStorage.getItem("stellar_route_csv_export_columns");
+      if (stored) {
+        const parsed = JSON.parse(stored);
+        if (Array.isArray(parsed) && parsed.length > 0) {
+          return parsed;
+        }
+      }
+    } catch (e) {
+      console.error("Failed to load export columns", e);
+    }
+    return ALL_EXPORT_COLUMNS.map((col) => col.key);
+  });
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportProgress, setExportProgress] = useState(0);
 
   const filteredTxs = transactions.filter((tx) => {
     if (filterAsset === "ALL") return true
@@ -52,6 +77,41 @@ export function TransactionHistory({ onRetry }: { onRetry?: (tx: TransactionReco
     }
     return parseFloat(b.fromAmount) - parseFloat(a.fromAmount)
   })
+
+  const handleColumnToggle = useCallback((key: string, checked: boolean) => {
+    setSelectedColumns((prev) => {
+      const next = checked ? [...prev, key] : prev.filter((k) => k !== key);
+      localStorage.setItem("stellar_route_csv_export_columns", JSON.stringify(next));
+      return next;
+    });
+  }, []);
+
+  const handleExportCSV = useCallback(async () => {
+    if (selectedColumns.length === 0) return;
+    setIsExporting(true);
+    setExportProgress(0);
+    try {
+      const csv = await generateTransactionsCSV(
+        sortedTxs,
+        selectedColumns,
+        100,
+        (progress) => setExportProgress(progress)
+      );
+      triggerCSVDownload(csv, `stellarroute_trade_activity_${Date.now()}.csv`);
+    } catch (err) {
+      console.error("Export failed", err);
+    } finally {
+      setIsExporting(false);
+      setExportProgress(0);
+    }
+  }, [sortedTxs, selectedColumns]);
+
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      setIsLoading(false)
+    }, 300)
+    return () => clearTimeout(timer)
+  }, [])
 
   const shouldVirtualize = sortedTxs.length > ACTIVITY_VIRTUALIZATION_THRESHOLD
   const virtualWindow = useVirtualWindow({
@@ -115,6 +175,39 @@ export function TransactionHistory({ onRetry }: { onRetry?: (tx: TransactionReco
             <option value="amount">Sort by Amount</option>
           </select>
 
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <Button variant="outline" className="flex items-center gap-2" disabled={isExporting} data-testid="csv-export-button">
+                <Download className="h-4 w-4" />
+                <span>{isExporting ? `Exporting (${Math.round(exportProgress * 100)}%)` : "Export"}</span>
+              </Button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="end" className="w-56" data-testid="csv-export-menu">
+              <DropdownMenuLabel>Select Columns</DropdownMenuLabel>
+              <DropdownMenuSeparator />
+              {ALL_EXPORT_COLUMNS.map((col) => (
+                <DropdownMenuCheckboxItem
+                  key={col.key}
+                  checked={selectedColumns.includes(col.key)}
+                  onCheckedChange={(checked) => handleColumnToggle(col.key, checked)}
+                  onSelect={(e) => e.preventDefault()}
+                  data-testid={`column-checkbox-${col.key}`}
+                >
+                  {col.label}
+                </DropdownMenuCheckboxItem>
+              ))}
+              <DropdownMenuSeparator />
+              <DropdownMenuItem
+                disabled={selectedColumns.length === 0 || isExporting}
+                onClick={handleExportCSV}
+                className="justify-center font-semibold text-primary focus:text-primary focus:bg-primary/10"
+                data-testid="csv-download-button"
+              >
+                Download CSV
+              </DropdownMenuItem>
+            </DropdownMenuContent>
+          </DropdownMenu>
+
           <Button variant="outline" size="icon" onClick={clearHistory} title="Clear History">
             <Trash2 className="h-4 w-4 text-destructive" />
           </Button>
@@ -123,12 +216,17 @@ export function TransactionHistory({ onRetry }: { onRetry?: (tx: TransactionReco
 
       <div ref={scrollRef} data-testid="tx-history-scroll" className="flex-1 overflow-auto">
         {isLoading ? (
-          <LoadingState message="Loading transaction history..." />
+          <ActivityTableSkeleton />
         ) : sortedTxs.length === 0 ? (
-          <EmptyState
-            message="No transactions"
-            description="Your transaction history will appear here after you make a swap."
-          />
+          <div className="flex flex-col items-center justify-center p-12 text-center h-full">
+            <div className="text-muted-foreground w-16 h-16 mb-4 opacity-50 bg-muted rounded-full flex items-center justify-center">
+              <span className="text-2xl">📋</span>
+            </div>
+            <h3 className="text-xl font-semibold mb-1">No Transactions Found</h3>
+            <p className="text-sm text-muted-foreground max-w-[250px]">
+              You haven&apos;t made any swaps yet, or your filters are too restrictive.
+            </p>
+          </div>
         ) : (
           <div className="min-w-[720px]">
             <Table>
@@ -158,7 +256,7 @@ export function TransactionHistory({ onRetry }: { onRetry?: (tx: TransactionReco
                       <div className="flex flex-col">
                         <span>{new Date(tx.timestamp).toLocaleDateString()}</span>
                         <span className="text-xs text-muted-foreground whitespace-nowrap">
-                          {formatDistanceToNow(tx.timestamp, { addSuffix: true })}
+                          <RelativeTime timestamp={tx.timestamp} />
                         </span>
                       </div>
                     </TableCell>

--- a/frontend/components/providers/wallet-provider.tsx
+++ b/frontend/components/providers/wallet-provider.tsx
@@ -3,7 +3,6 @@
 import * as React from 'react';
 import { createContext, useContext } from 'react';
 import type { ReactNode } from 'react';
-
 import {
   connectWallet,
   disconnectWallet,

--- a/frontend/components/shared/NetworkMismatchBanner.test.tsx
+++ b/frontend/components/shared/NetworkMismatchBanner.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
-import { render, screen, cleanup } from '@testing-library/react';
+import { cleanup, render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { NetworkMismatchBanner } from './NetworkMismatchBanner';
 import * as WalletProvider from '@/components/providers/wallet-provider';

--- a/frontend/components/swap/QuoteRefreshLiveRegion.test.tsx
+++ b/frontend/components/swap/QuoteRefreshLiveRegion.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { QuoteRefreshLiveRegion } from './QuoteRefreshLiveRegion';
+
+describe('QuoteRefreshLiveRegion', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('renders polite and assertive live regions without stealing focus', () => {
+    render(
+      <div>
+        <button type="button">Amount</button>
+        <QuoteRefreshLiveRegion
+          politeMessage="Quote updated. 1 XLM = 0.12 USDC"
+          assertiveMessage={null}
+        />
+      </div>,
+    );
+
+    const polite = screen.getByRole('status', { hidden: true });
+    const assertive = screen.getByRole('alert', { hidden: true });
+
+    expect(polite).toHaveAttribute('aria-live', 'polite');
+    expect(polite).toHaveAttribute('aria-atomic', 'true');
+    expect(polite).toHaveClass('sr-only');
+    expect(polite).toHaveTextContent('Quote updated. 1 XLM = 0.12 USDC');
+
+    expect(assertive).toHaveAttribute('aria-live', 'assertive');
+    expect(assertive).toHaveTextContent('');
+
+    expect(document.activeElement).not.toBe(polite);
+    expect(document.activeElement).not.toBe(assertive);
+  });
+
+  it('routes hard failures through the assertive region', () => {
+    render(
+      <QuoteRefreshLiveRegion
+        politeMessage={null}
+        assertiveMessage="Quote refresh failed. Invalid amount"
+      />,
+    );
+
+    expect(
+      screen.getByText('Quote refresh failed. Invalid amount'),
+    ).toHaveAttribute('aria-live', 'assertive');
+  });
+});

--- a/frontend/components/swap/QuoteRefreshLiveRegion.tsx
+++ b/frontend/components/swap/QuoteRefreshLiveRegion.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+import type { QuoteRefreshAnnouncements } from '@/hooks/useQuoteRefreshAnnouncements';
+
+export interface QuoteRefreshLiveRegionProps extends QuoteRefreshAnnouncements {}
+
+/**
+ * Visually hidden aria-live regions for quote refresh outcomes.
+ * Does not move focus — announcements are read in the background.
+ */
+export function QuoteRefreshLiveRegion({
+  politeMessage,
+  assertiveMessage,
+}: QuoteRefreshLiveRegionProps) {
+  return (
+    <>
+      <div
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {politeMessage ?? ''}
+      </div>
+      <div
+        role="alert"
+        aria-live="assertive"
+        aria-atomic="true"
+        className="sr-only"
+      >
+        {assertiveMessage ?? ''}
+      </div>
+    </>
+  );
+}

--- a/frontend/components/swap/SwapCard.test.tsx
+++ b/frontend/components/swap/SwapCard.test.tsx
@@ -17,6 +17,14 @@ vi.mock("@/components/providers/wallet-provider", () => ({
   }),
 }));
 
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    replace: vi.fn(),
+  }),
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 function createQuoteResponse(overrides?: Partial<Record<string, unknown>>) {
   return {
     base_asset: { asset_type: "native" },

--- a/frontend/components/swap/SwapCard.test.tsx
+++ b/frontend/components/swap/SwapCard.test.tsx
@@ -1,121 +1,219 @@
-import { act, cleanup, render, screen, waitFor } from "@testing-library/react";
-import userEvent from "@testing-library/user-event";
-import { afterEach, beforeEach, describe, expect, it, vi, Mock } from "vitest";
-import { SwapCard } from "./SwapCard";
-import { SettingsProvider } from "@/components/providers/settings-provider";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-function setNavigatorOnline(value: boolean) {
-  Object.defineProperty(window.navigator, "onLine", {
+import { SwapCard } from "./SwapCard";
+import {
+  SESSION_RECOVERY_THRESHOLD_MS,
+  STORAGE_KEY,
+} from "@/hooks/useTradeFormStorage";
+
+vi.mock("@/components/providers/wallet-provider", () => ({
+  useWallet: () => ({
+    networkMismatch: false,
+    network: "testnet",
+    walletNetwork: "testnet",
+    walletId: "freighter",
+    disconnect: vi.fn(),
+  }),
+}));
+
+function createQuoteResponse(overrides?: Partial<Record<string, unknown>>) {
+  return {
+    base_asset: { asset_type: "native" },
+    quote_asset: {
+      asset_type: "credit_alphanum4",
+      asset_code: "USDC",
+      asset_issuer: "GQUOTE",
+    },
+    amount: "10",
+    total: "9.5",
+    price: "0.95",
+    price_impact: "0.5",
+    path: [],
+    quote_type: "sell",
+    timestamp: Date.now(),
+    ...overrides,
+  };
+}
+
+function createResponse(data: unknown) {
+  return {
+    ok: true,
+    headers: new Headers(),
+    json: async () => data,
+  } as Response;
+}
+
+function deferredResponse(data: unknown) {
+  let resolve!: (value: Response) => void;
+  const promise = new Promise<Response>((res) => {
+    resolve = res;
+  });
+
+  return {
+    promise,
+    resolve: () => resolve(createResponse(data)),
+  };
+}
+
+function setVisibilityState(state: DocumentVisibilityState) {
+  Object.defineProperty(document, "visibilityState", {
     configurable: true,
-    value,
+    get: () => state,
   });
 }
 
-describe("SwapCard network resilience and states", () => {
+describe("SwapCard session recovery", () => {
   beforeEach(() => {
     localStorage.clear();
-    global.fetch = vi.fn(() => 
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({
-          total: "9.5",
-          price_impact: "0.5",
-          path: [],
-          price: "0.95",
-          amount: "10"
-        })
-      })
-    ) as Mock;
+    setVisibilityState("visible");
   });
 
   afterEach(() => {
     cleanup();
+    localStorage.clear();
     vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it("should render successfully", () => {
-    render(<SettingsProvider><SwapCard /></SettingsProvider>);
-    expect(screen.getByRole("heading", { name: /swap/i })).toBeInTheDocument();
-  });
+  it(
+    "prompts recovery after refresh and re-fetches the quote before enabling swap",
+    async () => {
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        amount: "10",
+        slippage: 1,
+        deadline: 45,
+        fromToken: "native",
+        toToken: "USDC:GQUOTE",
+        savedAt: Date.now(),
+      }),
+    );
 
-  it("shows initial state requiring wallet connection", async () => {
-    render(<SettingsProvider><SwapCard /></SettingsProvider>);
-    
-    // Check for "Connect Wallet" button
-    const connectButton = screen.getByRole("button", { name: /connect wallet/i });
-    expect(connectButton).toBeInTheDocument();
-  });
-
-  it("transitions states after wallet connection", async () => {
-    const user = userEvent.setup();
-    render(<SettingsProvider><SwapCard /></SettingsProvider>);
-    
-    // 1. Connect Wallet
-    const connectButton = screen.getByRole("button", { name: /connect wallet/i });
-    await user.click(connectButton);
-    
-    // 2. Should show "Enter Amount"
-    await waitFor(() => {
-      expect(screen.getByText(/enter amount/i)).toBeInTheDocument();
+    const quoteDeferred = deferredResponse(createQuoteResponse());
+    let quoteCalls = 0;
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/api/v1/pairs")) {
+        return createResponse({ pairs: [], total: 0 });
+      }
+      if (url.includes("/api/v1/quote/")) {
+        quoteCalls += 1;
+        return quoteDeferred.promise;
+      }
+      return createResponse({});
     });
-    
-    // 3. Enter amount
-    const payInput = screen.getByLabelText(/you pay/i);
-    await user.type(payInput, "10");
-    
-    // 4. Should show "Swap" button
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /^swap$/i })).toBeEnabled();
-    }, { timeout: 3000 });
-  });
+    vi.stubGlobal("fetch", fetchMock);
 
-  it("shows high price impact warning for large amounts", async () => {
-    // Override fetch mock for this test to return high price impact
-    global.fetch = vi.fn(() => 
-      Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({
-          total: "50",
-          price_impact: "15.0", // > 10
-          path: [],
-          price: "0.5",
-          amount: "90" // 90 is <= 100 mock balance, so insufficient_balance won't trigger
-        })
-      })
-    ) as Mock;
+    vi.useFakeTimers();
+    render(<SwapCard />);
 
-    const user = userEvent.setup();
-    render(<SettingsProvider><SwapCard /></SettingsProvider>);
-    
-    // Connect
-    await user.click(screen.getByRole("button", { name: /connect wallet/i }));
-    
-    // Enter amount
-    const payInput = screen.getByLabelText(/you pay/i);
-    await user.type(payInput, "90");
-    
-    await waitFor(() => {
-      const impactButton = screen.getByRole("button", { name: /swap anyway/i });
-      expect(impactButton).toBeEnabled();
-      expect(impactButton).toHaveClass("bg-destructive");
-    }, { timeout: 3000 });
-  });
+    await act(async () => {
+      await Promise.resolve();
+    });
 
-  it("shows insufficient balance state", async () => {
-    const user = userEvent.setup();
-    render(<SettingsProvider><SwapCard /></SettingsProvider>);
-    
-    // Connect
-    await user.click(screen.getByRole("button", { name: /connect wallet/i }));
-    
-    // Enter amount higher than mock balance (100.00)
-    const payInput = screen.getByLabelText(/you pay/i);
-    await user.type(payInput, "100.01");
-    
-    await waitFor(() => {
-      const balanceButton = screen.getByRole("button", { name: /insufficient balance/i });
-      expect(balanceButton).toBeDisabled();
-    }, { timeout: 3000 });
-  });
+    expect(screen.getByText(/restore previous trade\?/i)).toBeInTheDocument();
+    expect(screen.getByTestId("session-recovery-summary")).toHaveTextContent(
+      "10",
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /restore session/i }));
+
+    expect(screen.getByLabelText(/you pay/i)).toHaveValue("10");
+
+    fireEvent.click(screen.getByRole("button", { name: /connect wallet/i }));
+
+    expect(
+      screen.getByRole("button", { name: /refreshing quote/i }),
+    ).toBeDisabled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+      await Promise.resolve();
+    });
+
+    expect(quoteCalls).toBe(1);
+
+    await act(async () => {
+      quoteDeferred.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("button", { name: /^swap$/i })).toBeEnabled();
+    },
+    10_000,
+  );
+
+  it(
+    "prompts recovery after long tab sleep and refreshes the quote before allowing swap",
+    async () => {
+    const wakeDeferred = deferredResponse(createQuoteResponse({ total: "9.8" }));
+    let quoteCalls = 0;
+
+    const fetchMock = vi.fn(async (input: string | URL | Request) => {
+      const url = String(input);
+      if (url.includes("/api/v1/pairs")) {
+        return createResponse({ pairs: [], total: 0 });
+      }
+      if (url.includes("/api/v1/quote/")) {
+        quoteCalls += 1;
+        if (quoteCalls === 1) {
+          return createResponse(createQuoteResponse());
+        }
+        return wakeDeferred.promise;
+      }
+      return createResponse({});
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    vi.useFakeTimers();
+    render(<SwapCard />);
+
+    fireEvent.click(screen.getByRole("button", { name: /connect wallet/i }));
+    fireEvent.change(screen.getByLabelText(/you pay/i), {
+      target: { value: "10" },
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(400);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("button", { name: /^swap$/i })).toBeEnabled();
+
+    setVisibilityState("hidden");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(SESSION_RECOVERY_THRESHOLD_MS + 1);
+    });
+
+    setVisibilityState("visible");
+    act(() => {
+      document.dispatchEvent(new Event("visibilitychange"));
+    });
+
+    expect(screen.getByText(/resume in-progress trade\?/i)).toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /refresh quote/i }));
+
+    expect(
+      screen.getByRole("button", { name: /refreshing quote/i }),
+    ).toBeDisabled();
+    expect(quoteCalls).toBe(2);
+
+    await act(async () => {
+      wakeDeferred.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(screen.getByRole("button", { name: /^swap$/i })).toBeEnabled();
+    },
+    10_000,
+  );
 });

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -6,20 +6,20 @@ import { Button } from '@/components/ui/button';
 import { ArrowUpDown, RefreshCw } from 'lucide-react';
 import { AmountInput } from './AmountInput';
 import { TokenSelector } from './TokenSelector';
-import { PriceImpactHeatmapSlider } from './PriceImpactHeatmapSlider';
 import { PriceInfoPanel } from './PriceInfoPanel';
-import { RouteDisplay } from './RouteDisplay';
+import RouteDisplay from './RoutePanelAsync';
 import type { AlternativeRoute } from './RouteDisplay';
 import { SwapButton, SwapButtonState } from './SwapButton';
 import { SettingsPanel } from '../settings/SettingsPanel';
 import { HighImpactConfirmModal } from './HighImpactConfirmModal';
 import { TransactionConfirmationModal } from './TransactionConfirmationModal';
 import { QuoteStreamStatusIndicator } from './QuoteStreamStatusIndicator';
+import { QuoteRefreshLiveRegion } from './QuoteRefreshLiveRegion';
 import { SessionRecoveryModal } from './SessionRecoveryModal';
-import { SwapPresetTemplates } from './SwapPresetTemplates';
-import { useSwapState } from '@/hooks/useSwapState';
+import { useQuoteRefreshAnnouncements } from '@/hooks/useQuoteRefreshAnnouncements';
 import { useOptimisticSwap } from '@/hooks/useOptimisticSwap';
 import type { PreSubmitSnapshot } from '@/types/transaction';
+import { useSwapState } from '@/hooks/useSwapState';
 import {
   SESSION_RECOVERY_THRESHOLD_MS,
   type TradeFormSnapshot,
@@ -27,35 +27,32 @@ import {
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useQuoteStreamStatus } from '@/hooks/useQuoteStreamStatus';
 import { useCompactMode } from '@/hooks/useCompactMode';
-import { useOptimisticSwap } from '@/hooks/useOptimisticSwap';
 import { useShareableQuote } from '@/hooks/useShareableQuote';
 import { ShareQuoteButton } from './ShareQuoteButton';
-import { SlippageRiskNotice } from './SlippageRiskNotice';
 import { NetworkMismatchBanner } from '@/components/shared/NetworkMismatchBanner';
 import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useSwapI18n } from '@/lib/swap-i18n';
 import { quoteExportToCsv, type QuoteExportPayload } from '@/lib/quote-export';
-import {
-  getSlippageAcknowledgmentKey,
-  requiresSlippageAcknowledgment,
-} from '@/lib/slippage';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import {
   Dialog,
   DialogContent,
   DialogHeader,
   DialogTitle,
-} from "@/components/ui/dialog";
+} from '@/components/ui/dialog';
 
 export function SwapCard() {
   const { t } = useSwapI18n();
   const { isCompact, toggleCompact } = useCompactMode();
   // Wrap useSearchParams in try-catch for SSR
-  let parseParams: ReturnType<typeof useShareableQuote>['parseParams'] | null = null;
+  let parseParams: ReturnType<typeof useShareableQuote>['parseParams'] | null =
+    null;
   let isSharedQuoteStale = false;
-  let refreshSharedQuote: ReturnType<typeof useShareableQuote>['refreshQuote'] | null = null;
-  
+  let refreshSharedQuote:
+    | ReturnType<typeof useShareableQuote>['refreshQuote']
+    | null = null;
+
   try {
     const shareableQuote = useShareableQuote();
     parseParams = shareableQuote.parseParams;
@@ -64,7 +61,7 @@ export function SwapCard() {
   } catch (e) {
     // SSR or missing searchParams context
   }
-  
+
   const {
     fromToken,
     setFromToken,
@@ -91,13 +88,18 @@ export function SwapCard() {
   const [isConnected, setIsConnected] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
   const [isModalOpen, setIsModalOpen] = useState(false);
-  const [selectedRoute, setSelectedRoute] = useState<AlternativeRoute | null>(null);
-  const [wakeSnapshot, setWakeSnapshot] = useState<TradeFormSnapshot | null>(null);
+  const [selectedRoute, setSelectedRoute] = useState<AlternativeRoute | null>(
+    null
+  );
+  const [wakeSnapshot, setWakeSnapshot] = useState<TradeFormSnapshot | null>(
+    null
+  );
   const [wakeRecoveryOpen, setWakeRecoveryOpen] = useState(false);
-  const [recoveryRequestedAt, setRecoveryRequestedAt] = useState<number | null>(null);
+  const [recoveryRequestedAt, setRecoveryRequestedAt] = useState<number | null>(
+    null
+  );
   const [isRecoveringSession, setIsRecoveringSession] = useState(false);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
-  const [isHighSlippageAcknowledged, setIsHighSlippageAcknowledged] = useState(false);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const hiddenAtRef = useRef<number | null>(null);
   const recoveryReason: 'refresh' | 'wake' | null = wakeRecoveryOpen
@@ -106,16 +108,7 @@ export function SwapCard() {
       ? 'refresh'
       : null;
   const requiresFreshQuote =
-    recoveryRequestedAt !== null &&
-    (quote.loading || quote.isStale);
-  const needsSlippageAcknowledgment =
-    requiresSlippageAcknowledgment(slippage) && !isHighSlippageAcknowledged;
-  const slippageAcknowledgmentKey = getSlippageAcknowledgmentKey({
-    amount: fromAmount,
-    fromToken,
-    slippage,
-    toToken,
-  });
+    recoveryRequestedAt !== null && (quote.loading || quote.isStale);
 
   // Connection status indicator
   const { isOnline } = useOnlineStatus();
@@ -125,34 +118,61 @@ export function SwapCard() {
     isOnline,
   });
 
+  const parsedAmount = useMemo(() => {
+    const val = parseFloat(fromAmount);
+    return Number.isFinite(val) && val > 0 ? val : undefined;
+  }, [fromAmount]);
+
+  const quoteRefreshRequestKey = useMemo(
+    () => `${fromToken}|${toToken}|${parsedAmount ?? ''}|sell`,
+    [fromToken, toToken, parsedAmount],
+  );
+
+  const quoteRefreshAnnouncements = useQuoteRefreshAnnouncements({
+    canAnnounce:
+      parsedAmount !== undefined &&
+      Boolean(fromToken) &&
+      Boolean(toToken) &&
+      isOnline,
+    loading: quote.loading,
+    error: quote.error,
+    isRecovering: quote.isRecovering,
+    hasPendingRetry: quote.hasPendingRetry,
+    lastQuotedAtMs: quote.lastQuotedAtMs,
+    requestKey: quoteRefreshRequestKey,
+    rateSummary: formattedRate,
+    t,
+  });
+
   const optimistic = useOptimisticSwap({
     rollbackTarget: {
       setFromToken,
       setToToken,
       setFromAmount,
       setSlippage,
-      setSelectedRoute: (id) => setSelectedRoute(id ? { id, venue: '', expectedAmount: '' } : null),
+      setSelectedRoute: (id) =>
+        setSelectedRoute(id ? { id, venue: '', expectedAmount: '' } : null),
       refreshQuote: quote.refresh,
     },
   });
 
   // Mock balance
-  const fromBalance = "100.00";
+  const fromBalance = '100.00';
   const fromSymbol = fromToken === 'native' ? 'XLM' : fromToken.split(':')[0];
   const toSymbol = toToken === 'native' ? 'XLM' : toToken.split(':')[0];
 
   const buttonState = useMemo<SwapButtonState>(() => {
-    if (optimistic.submitLock) return "executing";
-    if (!isConnected) return "no_wallet";
-    if (!fromAmount || parseFloat(fromAmount) === 0) return "no_amount";
-    if (quote.error) return "error";
-    if (requiresFreshQuote) return "refreshing_quote";
-    if (parseFloat(fromAmount) > parseFloat(fromBalance)) return "insufficient_balance";
-    if (needsSlippageAcknowledgment) return "slippage_ack_required";
-    if (quote.priceImpact > 10) return "high_impact_warning";
-    if (quote.loading) return "refreshing_quote";
-    if (quote.isStale) return "error";
-    return "ready";
+    if (optimistic.submitLock) return 'executing';
+    if (!isConnected) return 'no_wallet';
+    if (!fromAmount || parseFloat(fromAmount) === 0) return 'no_amount';
+    if (quote.error) return 'error';
+    if (requiresFreshQuote) return 'refreshing_quote';
+    if (parseFloat(fromAmount) > parseFloat(fromBalance))
+      return 'insufficient_balance';
+    if (quote.priceImpact > 10) return 'high_impact_warning';
+    if (quote.loading) return 'refreshing_quote';
+    if (quote.isStale) return 'error';
+    return 'ready';
   }, [
     fromAmount,
     fromBalance,
@@ -163,7 +183,6 @@ export function SwapCard() {
     quote.loading,
     quote.priceImpact,
     requiresFreshQuote,
-    needsSlippageAcknowledgment,
   ]);
 
   useEffect(() => {
@@ -256,7 +275,18 @@ export function SwapCard() {
       walletAddress: 'mock_wallet_address',
       snapshot: snap,
     });
-  }, [fromToken, toToken, fromAmount, slippage, selectedRoute, toAmount, formattedRate, quote, toSymbol, optimistic]);
+  }, [
+    fromToken,
+    toToken,
+    fromAmount,
+    slippage,
+    selectedRoute,
+    toAmount,
+    formattedRate,
+    quote,
+    toSymbol,
+    optimistic,
+  ]);
 
   const handleSwap = useCallback(() => {
     if (quote.priceImpact > 5) {
@@ -270,15 +300,18 @@ export function SwapCard() {
     setFromAmount(fromBalance);
   }, [fromBalance, setFromAmount]);
 
-  const handlePresetSelect = useCallback((percentage: number) => {
-    const balanceNum = parseFloat(fromBalance);
-    if (isNaN(balanceNum) || balanceNum === 0) return;
-    
-    const amount = balanceNum * percentage;
-    // Round to 7 decimals to respect asset precision
-    const rounded = Math.floor(amount * 10000000) / 10000000;
-    setFromAmount(rounded.toString());
-  }, [fromBalance, setFromAmount]);
+  const handlePresetSelect = useCallback(
+    (percentage: number) => {
+      const balanceNum = parseFloat(fromBalance);
+      if (isNaN(balanceNum) || balanceNum === 0) return;
+
+      const amount = balanceNum * percentage;
+      // Round to 7 decimals to respect asset precision
+      const rounded = Math.floor(amount * 10000000) / 10000000;
+      setFromAmount(rounded.toString());
+    },
+    [fromBalance, setFromAmount]
+  );
 
   const handleSwitchTokens = useCallback(() => {
     setSelectedRoute(null);
@@ -286,42 +319,42 @@ export function SwapCard() {
   }, [switchTokens]);
 
   useEffect(() => {
-    setIsHighSlippageAcknowledged(false);
-  }, [slippageAcknowledgmentKey]);
-
-  useEffect(() => {
     const onKeydown = (event: KeyboardEvent) => {
       const target = event.target as HTMLElement | null;
       const isEditable = target
-        ? target.tagName === "INPUT" ||
-          target.tagName === "TEXTAREA" ||
+        ? target.tagName === 'INPUT' ||
+          target.tagName === 'TEXTAREA' ||
           target.isContentEditable
         : false;
 
-      if (event.key === "?" && !isEditable) {
+      if (event.key === '?' && !isEditable) {
         event.preventDefault();
         lastFocusedElementRef.current = document.activeElement as HTMLElement;
         setShortcutHelpOpen(true);
       }
 
-      if (event.key.toLowerCase() === "r" && event.altKey) {
+      if (event.key.toLowerCase() === 'r' && event.altKey) {
         event.preventDefault();
         quote.refresh();
       }
 
-      if (event.key === "1" && event.altKey) {
+      if (event.key === '1' && event.altKey) {
         event.preventDefault();
-        document.querySelectorAll<HTMLInputElement>('input[placeholder="0.00"]')[0]?.focus();
+        document
+          .querySelectorAll<HTMLInputElement>('input[placeholder="0.00"]')[0]
+          ?.focus();
       }
 
-      if (event.key === "2" && event.altKey) {
+      if (event.key === '2' && event.altKey) {
         event.preventDefault();
-        document.querySelectorAll<HTMLInputElement>('input[placeholder="0.00"]')[1]?.focus();
+        document
+          .querySelectorAll<HTMLInputElement>('input[placeholder="0.00"]')[1]
+          ?.focus();
       }
     };
 
-    window.addEventListener("keydown", onKeydown);
-    return () => window.removeEventListener("keydown", onKeydown);
+    window.addEventListener('keydown', onKeydown);
+    return () => window.removeEventListener('keydown', onKeydown);
   }, [quote]);
 
   const handleShortcutOpenChange = useCallback((open: boolean) => {
@@ -331,48 +364,69 @@ export function SwapCard() {
     }
   }, []);
 
-  const handleExport = useCallback((format: "json" | "csv") => {
-    const payload: QuoteExportPayload = {
-      exportedAt: new Date().toISOString(),
-      market: {
-        fromAsset: fromSymbol,
-        toAsset: toSymbol,
-        fromAmount,
-        expectedToAmount: toAmount,
-      },
-      pricing: {
-        rate: formattedRate,
-        priceImpactPct: quote.priceImpact.toFixed(2),
-        minimumReceived: `${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`,
-        networkFee: quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM',
-      },
-      route: {
-        selectedVenue: selectedRoute?.venue ?? "auto",
-        routeSummary:
-          selectedRoute?.hops?.map((hop) => `${hop.fromAsset}->${hop.toAsset}`).join(" | ") ??
-          "best-route",
-      },
-    };
-    const serialized = format === "json"
-      ? JSON.stringify(payload, null, 2)
-      : quoteExportToCsv(payload);
-    const blob = new Blob([serialized], {
-      type: format === "json" ? "application/json" : "text/csv;charset=utf-8",
-    });
-    const url = URL.createObjectURL(blob);
-    const anchor = document.createElement("a");
-    anchor.href = url;
-    anchor.download = `stellarroute-quote-summary.${format}`;
-    anchor.click();
-    URL.revokeObjectURL(url);
-    toast.success(t("swap.quote.exportSuccess", { format: format.toUpperCase() }));
-  }, [formattedRate, fromAmount, fromSymbol, quote.fee, quote.priceImpact, selectedRoute, slippage, t, toAmount, toSymbol]);
+  const handleExport = useCallback(
+    (format: 'json' | 'csv') => {
+      const payload: QuoteExportPayload = {
+        exportedAt: new Date().toISOString(),
+        market: {
+          fromAsset: fromSymbol,
+          toAsset: toSymbol,
+          fromAmount,
+          expectedToAmount: toAmount,
+        },
+        pricing: {
+          rate: formattedRate,
+          priceImpactPct: quote.priceImpact.toFixed(2),
+          minimumReceived: `${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`,
+          networkFee: quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM',
+        },
+        route: {
+          selectedVenue: selectedRoute?.venue ?? 'auto',
+          routeSummary:
+            selectedRoute?.hops
+              ?.map((hop) => `${hop.fromAsset}->${hop.toAsset}`)
+              .join(' | ') ?? 'best-route',
+        },
+      };
+      const serialized =
+        format === 'json'
+          ? JSON.stringify(payload, null, 2)
+          : quoteExportToCsv(payload);
+      const blob = new Blob([serialized], {
+        type: format === 'json' ? 'application/json' : 'text/csv;charset=utf-8',
+      });
+      const url = URL.createObjectURL(blob);
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.download = `stellarroute-quote-summary.${format}`;
+      anchor.click();
+      URL.revokeObjectURL(url);
+      toast.success(
+        t('swap.quote.exportSuccess', { format: format.toUpperCase() })
+      );
+    },
+    [
+      formattedRate,
+      fromAmount,
+      fromSymbol,
+      quote.fee,
+      quote.priceImpact,
+      selectedRoute,
+      slippage,
+      t,
+      toAmount,
+      toSymbol,
+    ]
+  );
 
   return (
-    <div data-testid="swap-card" className="w-full max-w-[480px] mx-auto perspective-1000">
+    <div
+      data-testid="swap-card"
+      className="w-full max-w-[480px] mx-auto perspective-1000"
+    >
       {/* Network Mismatch Banner */}
       <NetworkMismatchBanner className="mb-4" />
-      
+
       {/* Shared Quote Stale Warning */}
       {isSharedQuoteStale && refreshSharedQuote && (
         <div className="mb-4 p-3 rounded-xl border border-amber-500/50 bg-amber-500/10">
@@ -389,34 +443,39 @@ export function SwapCard() {
           </Button>
         </div>
       )}
-      
-      <Card className={cn(
-        "relative overflow-hidden border-border/40 bg-background/60 backdrop-blur-xl shadow-2xl rounded-[32px] transition-all duration-500 hover:shadow-primary/5",
-        isCompact && "rounded-2xl"
-      )}>
+
+      <Card
+        className={cn(
+          'relative overflow-hidden border-border/40 bg-background/60 backdrop-blur-xl shadow-2xl rounded-[32px] transition-all duration-500 hover:shadow-primary/5',
+          isCompact && 'rounded-2xl'
+        )}
+      >
         {/* Animated Background Gradients */}
         <div className="absolute -top-24 -left-24 w-48 h-48 bg-primary/10 rounded-full blur-3xl animate-pulse" />
         <div className="absolute -bottom-24 -right-24 w-48 h-48 bg-blue-500/10 rounded-full blur-3xl animate-pulse delay-700" />
-        
-        <CardContent className={cn(
-          "space-y-4",
-          isCompact ? "p-4" : "p-6"
-        )}>
+
+        <CardContent className={cn('space-y-4', isCompact ? 'p-4' : 'p-6')}>
+          <QuoteRefreshLiveRegion {...quoteRefreshAnnouncements} />
           {/* Header */}
           <div className="flex items-center justify-between mb-2">
-            <h2 className={cn(
-              "font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/60 bg-clip-text text-transparent",
-              isCompact ? "text-lg" : "text-xl"
-            )}>
+            <h2
+              className={cn(
+                'font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/60 bg-clip-text text-transparent',
+                isCompact ? 'text-lg' : 'text-xl'
+              )}
+            >
               Swap
             </h2>
             <div className="flex items-center gap-1">
-              <QuoteStreamStatusIndicator status={streamStatus} mode={streamMode} />
+              <QuoteStreamStatusIndicator
+                status={streamStatus}
+                mode={streamMode}
+              />
               <Button
                 variant="ghost"
                 size="icon"
                 onClick={toggleCompact}
-                aria-label={isCompact ? "Expand layout" : "Compact layout"}
+                aria-label={isCompact ? 'Expand layout' : 'Compact layout'}
                 className="h-9 w-9 rounded-xl hover:bg-muted/80"
               >
                 {isCompact ? (
@@ -431,41 +490,39 @@ export function SwapCard() {
                 deadline={deadline}
                 onDeadlineChange={setDeadline}
                 onReset={() => {
-      reset();
-      setSelectedRoute(null);
-    }}
+                  reset();
+                  setSelectedRoute(null);
+                }}
               />
-              <Button 
-                variant="ghost" 
-                size="icon" 
-                onClick={() => quote.refresh()} 
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => quote.refresh()}
                 disabled={quote.loading}
-                aria-label={t("swap.card.refreshQuote")}
+                aria-label={t('swap.card.refreshQuote')}
                 className="h-9 w-9 rounded-xl hover:bg-muted/80"
               >
-                <RefreshCw className={cn("h-4.5 w-4.5 text-muted-foreground", quote.loading && "animate-spin")} />
+                <RefreshCw
+                  className={cn(
+                    'h-4.5 w-4.5 text-muted-foreground',
+                    quote.loading && 'animate-spin'
+                  )}
+                />
               </Button>
             </div>
           </div>
 
-          <SwapPresetTemplates 
-            onSelect={(base, quote) => {
-              setFromToken(base);
-              setToToken(quote);
-            }}
-            selectedBase={fromToken}
-            selectedQuote={toToken}
-          />
-
           {/* Pay Section */}
-          <div className={cn("space-y-2 group", isCompact && "space-y-1")}>
-            <div className={cn(
-              "bg-muted/30 hover:bg-muted/40 transition-colors rounded-2xl border border-border/20 focus-within:border-primary/30 focus-within:ring-4 focus-within:ring-primary/5",
-              isCompact ? "p-3 rounded-xl" : "p-4"
-            )}>
+          <div className={cn('space-y-2 group', isCompact && 'space-y-1')}>
+            <div
+              className={cn(
+                'bg-muted/30 hover:bg-muted/40 transition-colors rounded-2xl border border-border/20 focus-within:border-primary/30 focus-within:ring-4 focus-within:ring-primary/5',
+                isCompact ? 'p-3 rounded-xl' : 'p-4'
+              )}
+            >
               <div className="flex justify-between items-start mb-1">
                 <AmountInput
-                  label={t("swap.pair.youPay")}
+                  label={t('swap.pair.youPay')}
                   value={fromAmount}
                   onChange={setFromAmount}
                   onMax={handleMax}
@@ -480,16 +537,6 @@ export function SwapCard() {
                   className="mt-6"
                 />
               </div>
-              {isConnected && (
-                <PriceImpactHeatmapSlider
-                  fromToken={fromToken}
-                  toToken={toToken}
-                  balance={parseFloat(fromBalance)}
-                  currentAmount={fromAmount}
-                  onChangeAmount={setFromAmount}
-                  disabled={quote.loading}
-                />
-              )}
             </div>
           </div>
 
@@ -506,14 +553,16 @@ export function SwapCard() {
           </div>
 
           {/* Receive Section */}
-          <div className={cn("space-y-2", isCompact && "space-y-1")}>
-            <div className={cn(
-              "bg-muted/30 rounded-2xl border border-border/20",
-              isCompact ? "p-3 rounded-xl" : "p-4"
-            )}>
+          <div className={cn('space-y-2', isCompact && 'space-y-1')}>
+            <div
+              className={cn(
+                'bg-muted/30 rounded-2xl border border-border/20',
+                isCompact ? 'p-3 rounded-xl' : 'p-4'
+              )}
+            >
               <div className="flex justify-between items-start mb-1">
                 <AmountInput
-                  label={t("swap.pair.youReceive")}
+                  label={t('swap.pair.youReceive')}
                   value={selectedRoute?.expectedAmount ?? toAmount}
                   readOnly
                   placeholder="0.00"
@@ -531,23 +580,22 @@ export function SwapCard() {
 
           {/* Info Panels (Conditional) */}
           {parseFloat(fromAmount) > 0 && (
-            <div className={cn(
-              "space-y-3 animate-in fade-in slide-in-from-bottom-2 duration-500",
-              isCompact ? "space-y-2 pt-1" : "pt-2"
-            )}>
+            <div
+              className={cn(
+                'space-y-3 animate-in fade-in slide-in-from-bottom-2 duration-500',
+                isCompact ? 'space-y-2 pt-1' : 'pt-2'
+              )}
+            >
               <PriceInfoPanel
                 rate={formattedRate}
                 priceImpact={quote.priceImpact}
                 minReceived={`${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`}
-                networkFee={quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM'}
+                networkFee={
+                  quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM'
+                }
                 isLoading={quote.loading}
-                onExportJson={() => handleExport("json")}
-                onExportCsv={() => handleExport("csv")}
-              />
-              <SlippageRiskNotice
-                slippage={slippage}
-                acknowledged={isHighSlippageAcknowledged}
-                onAcknowledgedChange={setIsHighSlippageAcknowledged}
+                onExportJson={() => handleExport('json')}
+                onExportCsv={() => handleExport('csv')}
               />
               <RouteDisplay
                 amountOut={selectedRoute?.expectedAmount ?? toAmount}
@@ -575,7 +623,7 @@ export function SwapCard() {
               data-testid="stale-indicator"
               className="text-xs text-amber-500 font-medium"
             >
-              {t("swap.card.outdated")}
+              {t('swap.card.outdated')}
             </span>
           )}
           {quote.isRecovering && (
@@ -585,10 +633,13 @@ export function SwapCard() {
             >
               <span className="text-xs text-blue-500 font-medium">
                 {quote.hasPendingRetry
-                  ? t("swap.card.recoveringQuoteCountdown", {
-                      seconds: Math.max(1, Math.ceil(quote.pendingRetryRemainingMs / 1000)),
+                  ? t('swap.card.recoveringQuoteCountdown', {
+                      seconds: Math.max(
+                        1,
+                        Math.ceil(quote.pendingRetryRemainingMs / 1000)
+                      ),
                     })
-                  : t("swap.card.recoveringQuote")}
+                  : t('swap.card.recoveringQuote')}
               </span>
               {quote.hasPendingRetry && (
                 <Button
@@ -598,7 +649,7 @@ export function SwapCard() {
                   onClick={quote.cancelRetry}
                   className="h-7 rounded-lg px-2 text-[11px] font-semibold text-blue-600 hover:bg-blue-500/10 hover:text-blue-700"
                 >
-                  {t("swap.card.cancelRetry")}
+                  {t('swap.card.cancelRetry')}
                 </Button>
               )}
             </div>
@@ -609,7 +660,7 @@ export function SwapCard() {
               data-testid="recovery-refresh-indicator"
               className="text-xs font-medium text-primary"
             >
-              {t("swap.card.sessionRestored")}
+              {t('swap.card.sessionRestored')}
             </span>
           )}
 
@@ -658,20 +709,35 @@ export function SwapCard() {
 
       {/* Footer Info */}
       <p className="text-center text-[10px] text-muted-foreground/60 mt-4 px-8 uppercase tracking-widest font-bold">
-        {t("swap.card.poweredBy")}
+        {t('swap.card.poweredBy')}
       </p>
 
       <Dialog open={shortcutHelpOpen} onOpenChange={handleShortcutOpenChange}>
         <DialogContent>
           <DialogHeader>
-            <DialogTitle>{t("swap.shortcuts.title")}</DialogTitle>
+            <DialogTitle>{t('swap.shortcuts.title')}</DialogTitle>
           </DialogHeader>
           <ul className="space-y-3 text-sm">
-            <li className="flex justify-between"><span>{t("swap.shortcuts.openHelp")}</span><kbd className="font-mono">?</kbd></li>
-            <li className="flex justify-between"><span>{t("swap.shortcuts.closeHelp")}</span><kbd className="font-mono">Esc</kbd></li>
-            <li className="flex justify-between"><span>{t("swap.shortcuts.refreshQuote")}</span><kbd className="font-mono">Alt+R</kbd></li>
-            <li className="flex justify-between"><span>{t("swap.shortcuts.focusPayAmount")}</span><kbd className="font-mono">Alt+1</kbd></li>
-            <li className="flex justify-between"><span>{t("swap.shortcuts.focusReceiveAmount")}</span><kbd className="font-mono">Alt+2</kbd></li>
+            <li className="flex justify-between">
+              <span>{t('swap.shortcuts.openHelp')}</span>
+              <kbd className="font-mono">?</kbd>
+            </li>
+            <li className="flex justify-between">
+              <span>{t('swap.shortcuts.closeHelp')}</span>
+              <kbd className="font-mono">Esc</kbd>
+            </li>
+            <li className="flex justify-between">
+              <span>{t('swap.shortcuts.refreshQuote')}</span>
+              <kbd className="font-mono">Alt+R</kbd>
+            </li>
+            <li className="flex justify-between">
+              <span>{t('swap.shortcuts.focusPayAmount')}</span>
+              <kbd className="font-mono">Alt+1</kbd>
+            </li>
+            <li className="flex justify-between">
+              <span>{t('swap.shortcuts.focusReceiveAmount')}</span>
+              <kbd className="font-mono">Alt+2</kbd>
+            </li>
           </ul>
         </DialogContent>
       </Dialog>

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -20,6 +20,8 @@ import { useQuoteRefreshAnnouncements } from '@/hooks/useQuoteRefreshAnnouncemen
 import { useOptimisticSwap } from '@/hooks/useOptimisticSwap';
 import type { PreSubmitSnapshot } from '@/types/transaction';
 import { useSwapState } from '@/hooks/useSwapState';
+import { useOptionalTradingPair } from '@/contexts/TradingPairContext';
+import { useExpertSettings } from '@/hooks/useExpertSettings';
 import {
   SESSION_RECOVERY_THRESHOLD_MS,
   type TradeFormSnapshot,
@@ -45,6 +47,8 @@ import {
 export function SwapCard() {
   const { t } = useSwapI18n();
   const { isCompact, toggleCompact } = useCompactMode();
+  const tradingPairContext = useOptionalTradingPair();
+  
   // Wrap useSearchParams in try-catch for SSR
   let parseParams: ReturnType<typeof useShareableQuote>['parseParams'] | null =
     null;
@@ -84,6 +88,44 @@ export function SwapCard() {
     snapshotCurrent,
     reset,
   } = useSwapState();
+
+  // Initialize from URL parameters on mount
+  useEffect(() => {
+    if (!parseParams) return;
+    
+    const urlParams = parseParams();
+    if (!urlParams) return;
+
+    // Apply URL parameters to form state
+    if (urlParams.from && urlParams.from !== fromToken) {
+      setFromToken(urlParams.from);
+    }
+    if (urlParams.to && urlParams.to !== toToken) {
+      setToToken(urlParams.to);
+    }
+    if (urlParams.amount && urlParams.amount !== fromAmount) {
+      setFromAmount(urlParams.amount);
+    }
+    if (urlParams.slippage && parseFloat(urlParams.slippage) !== slippage) {
+      setSlippage(parseFloat(urlParams.slippage));
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [parseParams]); // Only run on mount when parseParams becomes available
+
+  // Update trading pair context when tokens change
+  useEffect(() => {
+    if (tradingPairContext && fromToken && toToken) {
+      tradingPairContext.setTradingPair(fromToken, toToken);
+    }
+  }, [fromToken, toToken, tradingPairContext]);
+  const {
+    expertMode,
+    bypassConfirmation,
+    extendedRouteDetails,
+    updateExpertMode,
+    updateBypassConfirmation,
+    updateExtendedRouteDetails,
+  } = useExpertSettings();
 
   const [isConnected, setIsConnected] = useState(false);
   const [isConfirmModalOpen, setIsConfirmModalOpen] = useState(false);
@@ -155,6 +197,28 @@ export function SwapCard() {
       refreshQuote: quote.refresh,
     },
   });
+
+  // Handle background transaction toasts when bypassConfirmation is enabled
+  useEffect(() => {
+    if (!bypassConfirmation || !isModalOpen) return;
+
+    if (optimistic.status === 'pending') {
+      toast.loading('Signing transaction...', { id: 'swap-toast' });
+    } else if (optimistic.status === 'submitted') {
+      toast.loading('Transaction submitted, awaiting confirmation...', { id: 'swap-toast' });
+    } else if (optimistic.status === 'confirmed') {
+      toast.success('Swap confirmed successfully!', { id: 'swap-toast' });
+      setIsModalOpen(false);
+      reset();
+      setSelectedRoute(null);
+    } else if (optimistic.status === 'failed') {
+      toast.error(optimistic.errorMessage || 'Swap failed. Please try again.', { id: 'swap-toast' });
+      setIsModalOpen(false);
+    } else if (optimistic.status === 'dropped') {
+      toast.error('Transaction timed out.', { id: 'swap-toast' });
+      setIsModalOpen(false);
+    }
+  }, [optimistic.status, optimistic.errorMessage, bypassConfirmation, isModalOpen, reset, setSelectedRoute]);
 
   // Mock balance
   const fromBalance = '100.00';
@@ -447,7 +511,8 @@ export function SwapCard() {
       <Card
         className={cn(
           'relative overflow-hidden border-border/40 bg-background/60 backdrop-blur-xl shadow-2xl rounded-[32px] transition-all duration-500 hover:shadow-primary/5',
-          isCompact && 'rounded-2xl'
+          isCompact && 'rounded-2xl',
+          expertMode && 'border-amber-500/30 hover:shadow-amber-500/10 shadow-amber-500/5'
         )}
       >
         {/* Animated Background Gradients */}
@@ -458,14 +523,21 @@ export function SwapCard() {
           <QuoteRefreshLiveRegion {...quoteRefreshAnnouncements} />
           {/* Header */}
           <div className="flex items-center justify-between mb-2">
-            <h2
-              className={cn(
-                'font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/60 bg-clip-text text-transparent',
-                isCompact ? 'text-lg' : 'text-xl'
+            <div className="flex items-center gap-1.5">
+              <h2
+                className={cn(
+                  'font-bold tracking-tight bg-gradient-to-br from-foreground to-foreground/60 bg-clip-text text-transparent',
+                  isCompact ? 'text-lg' : 'text-xl'
+                )}
+              >
+                Swap
+              </h2>
+              {expertMode && (
+                <span className="text-[10px] font-bold uppercase tracking-wider text-amber-500 bg-amber-500/10 px-2 py-0.5 rounded-full border border-amber-500/20 animate-pulse">
+                  Expert
+                </span>
               )}
-            >
-              Swap
-            </h2>
+            </div>
             <div className="flex items-center gap-1">
               <QuoteStreamStatusIndicator
                 status={streamStatus}
@@ -489,6 +561,12 @@ export function SwapCard() {
                 onSlippageChange={setSlippage}
                 deadline={deadline}
                 onDeadlineChange={setDeadline}
+                expertMode={expertMode}
+                bypassConfirmation={bypassConfirmation}
+                extendedRouteDetails={extendedRouteDetails}
+                onExpertModeChange={updateExpertMode}
+                onBypassConfirmationChange={updateBypassConfirmation}
+                onExtendedRouteDetailsChange={updateExtendedRouteDetails}
                 onReset={() => {
                   reset();
                   setSelectedRoute(null);
@@ -601,6 +679,7 @@ export function SwapCard() {
                 amountOut={selectedRoute?.expectedAmount ?? toAmount}
                 isLoading={quote.loading}
                 onSelect={setSelectedRoute}
+                extendedRouteDetails={extendedRouteDetails}
               />
               {/* Share Quote Button */}
               <div className="flex justify-end">
@@ -697,6 +776,37 @@ export function SwapCard() {
         toAmount={toAmount}
         toSymbol={toSymbol}
       />
+
+      {!bypassConfirmation && (
+        <TransactionConfirmationModal
+          isOpen={isModalOpen}
+          status={optimistic.status}
+          txHash={optimistic.txHash}
+          errorMessage={optimistic.errorMessage}
+          tradeParams={optimistic.tradeParams}
+          onConfirm={() => {}}
+          onCancel={() => {
+            optimistic.cancel();
+            setIsModalOpen(false);
+          }}
+          onTryAgain={() => {
+            optimistic.tryAgain();
+          }}
+          onResubmit={() => {
+            optimistic.resubmit();
+          }}
+          onDismiss={() => {
+            optimistic.dismiss();
+            setIsModalOpen(false);
+          }}
+          onDone={() => {
+            optimistic.dismiss();
+            setIsModalOpen(false);
+            reset();
+            setSelectedRoute(null);
+          }}
+        />
+      )}
 
       <SessionRecoveryModal
         isOpen={recoveryReason !== null}

--- a/frontend/docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md
+++ b/frontend/docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md
@@ -1,0 +1,75 @@
+# Quote Refresh Screen Reader Testing
+
+Manual verification notes for issue #513 — live region announcements during quote refresh.
+
+## Scope
+
+- `SwapCard` (`/swap`) — primary swap UI
+- `DemoSwap` (demo page using `useQuoteRefresh`) — debounced amount entry
+
+Announcements are rendered by `QuoteRefreshLiveRegion` and driven by `useQuoteRefreshAnnouncements`.
+
+## Prerequisites
+
+1. Start the frontend: `cd frontend && npm run dev`
+2. Use a screen reader:
+   - **Windows**: NVDA (free) or JAWS
+   - **macOS**: VoiceOver (`Cmd + F5`)
+3. Ensure the quote API is reachable (or use mocked/demo data as documented for local dev)
+
+## Expected behavior
+
+| Scenario | Region | Priority | Expected announcement |
+| --- | --- | --- | --- |
+| Quote fetch succeeds (manual refresh, auto-refresh, or debounced amount) | `role="status"` | polite | “Quote updated.” or “Quote updated. {rate}” |
+| Hard failure (4xx, offline, retries exhausted) | `role="alert"` | assertive | “Quote refresh failed. {message}” |
+| Transient failure while auto-retry is pending | — | — | **No** announcement until retries finish |
+| Rapid amount edits during debounce | — | — | **One** success announcement per completed quote, not per keystroke |
+
+Focus must remain on the control the user is editing (amount field, refresh button, etc.).
+
+## Test steps
+
+### 1. Polite success on manual refresh
+
+1. Open `/swap` and connect wallet (or use demo with valid pair/amount).
+2. Enter a valid pay amount and wait for the initial quote.
+3. Tab to **Refresh quote** and activate it.
+4. **Pass**: Screen reader announces a polite “Quote updated…” message; focus stays on the refresh control.
+
+### 2. Polite success after debounced typing
+
+1. Focus the pay amount field.
+2. Type `1`, then quickly append `0` and `0` (e.g. `100`) without pausing long between keys.
+3. **Pass**: After debounce settles and the request completes, exactly **one** polite quote-updated announcement is heard (not three).
+
+### 3. Assertive hard failure
+
+1. Stop the API or force an invalid amount that returns a non-retryable 400.
+2. Trigger a quote refresh.
+3. **Pass**: Assertive “Quote refresh failed…” is announced; no duplicate failure spam on subsequent renders.
+
+### 4. No announcement during transient retry
+
+1. Simulate a transient 503/429 that auto-retries (or use integration test mocks).
+2. **Pass**: No assertive failure during the retry window; polite success after recovery if the retry succeeds.
+
+### 5. Offline
+
+1. Disable network in devtools.
+2. Attempt to refresh the quote.
+3. **Pass**: Assertive failure mentioning offline/reconnect guidance.
+
+## Automated coverage
+
+```bash
+cd frontend
+npm test -- lib/quote-refresh-announcements.test.ts hooks/useQuoteRefreshAnnouncements.test.ts components/swap/QuoteRefreshLiveRegion.test.tsx
+```
+
+## Sign-off checklist
+
+- [ ] Polite announcement on successful refresh
+- [ ] Assertive announcement on hard failure
+- [ ] No duplicate announcements during debounce
+- [ ] Focus never moves to the live region

--- a/frontend/hooks/useQuote.ts
+++ b/frontend/hooks/useQuote.ts
@@ -28,8 +28,6 @@ export interface QuoteResult {
   refresh: (opts?: { force?: boolean }) => void;
   data: import('@/types').PriceQuote | undefined;
   lastQuotedAtMs: number | null;
-  expiresAtMs?: number;
-  ttlSeconds?: number;
 }
 
 /**
@@ -49,6 +47,7 @@ export function useQuote({ fromToken, toToken, amount, type = 'sell' }: UseQuote
     pendingRetryRemainingMs,
     cancelRetry,
     refresh,
+    lastQuotedAtMs,
   } = useQuoteRefresh(
     fromToken,
     toToken,
@@ -114,8 +113,6 @@ export function useQuote({ fromToken, toToken, amount, type = 'sell' }: UseQuote
     cancelRetry,
     refresh,
     data,
-    lastQuotedAtMs: data ? (data.timestamp ?? Date.now()) : null,
-    expiresAtMs: data?.expires_at,
-    ttlSeconds: data?.ttl_seconds,
+    lastQuotedAtMs,
   };
 }

--- a/frontend/hooks/useQuoteRefreshAnnouncements.test.ts
+++ b/frontend/hooks/useQuoteRefreshAnnouncements.test.ts
@@ -1,0 +1,178 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { useQuoteRefreshAnnouncements } from './useQuoteRefreshAnnouncements';
+import { createSwapTranslator } from '@/lib/swap-i18n';
+
+const { t } = createSwapTranslator('en-US');
+
+describe('useQuoteRefreshAnnouncements', () => {
+  it('emits a polite message after a successful refresh', async () => {
+    const { result, rerender } = renderHook(
+      (props) => useQuoteRefreshAnnouncements(props),
+      {
+        initialProps: {
+          canAnnounce: true,
+          loading: true,
+          error: null,
+          isRecovering: false,
+          hasPendingRetry: false,
+          lastQuotedAtMs: null,
+          requestKey: 'native|USDC|100|sell',
+          rateSummary: '1 XLM = 0.12 USDC',
+          t,
+        },
+      },
+    );
+
+    expect(result.current.politeMessage).toBeNull();
+
+    rerender({
+      canAnnounce: true,
+      loading: false,
+      error: null,
+      isRecovering: false,
+      hasPendingRetry: false,
+      lastQuotedAtMs: 1_700_000_000_000,
+      requestKey: 'native|USDC|100|sell',
+      rateSummary: '1 XLM = 0.12 USDC',
+      t,
+    });
+
+    await waitFor(() => {
+      expect(result.current.politeMessage).toBe(
+        'Quote updated. 1 XLM = 0.12 USDC',
+      );
+      expect(result.current.assertiveMessage).toBeNull();
+    });
+  });
+
+  it('does not duplicate success announcements for the same quote timestamp', async () => {
+    const { result, rerender } = renderHook(
+      (props) => useQuoteRefreshAnnouncements(props),
+      {
+        initialProps: {
+          canAnnounce: true,
+          loading: false,
+          error: null,
+          isRecovering: false,
+          hasPendingRetry: false,
+          lastQuotedAtMs: 42,
+          requestKey: 'native|USDC|100|sell',
+          rateSummary: '1 XLM = 0.12 USDC',
+          t,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.politeMessage).toContain('Quote updated');
+    });
+
+    const firstMessage = result.current.politeMessage;
+    rerender({
+      canAnnounce: true,
+      loading: true,
+      error: null,
+      isRecovering: false,
+      hasPendingRetry: false,
+      lastQuotedAtMs: 42,
+      requestKey: 'native|USDC|100|sell',
+      rateSummary: '1 XLM = 0.12 USDC',
+      t,
+    });
+
+    rerender({
+      canAnnounce: true,
+      loading: false,
+      error: null,
+      isRecovering: false,
+      hasPendingRetry: false,
+      lastQuotedAtMs: 42,
+      requestKey: 'native|USDC|100|sell',
+      rateSummary: '1 XLM = 0.12 USDC',
+      t,
+    });
+
+    expect(result.current.politeMessage).toBe(firstMessage);
+  });
+
+  it('emits an assertive message on hard failures only', async () => {
+    const { result, rerender } = renderHook(
+      (props) => useQuoteRefreshAnnouncements(props),
+      {
+        initialProps: {
+          canAnnounce: true,
+          loading: false,
+          error: new Error('Invalid amount'),
+          isRecovering: true,
+          hasPendingRetry: true,
+          lastQuotedAtMs: null,
+          requestKey: 'native|USDC|100|sell',
+          t,
+        },
+      },
+    );
+
+    expect(result.current.assertiveMessage).toBeNull();
+
+    rerender({
+      canAnnounce: true,
+      loading: false,
+      error: new Error('Invalid amount'),
+      isRecovering: false,
+      hasPendingRetry: false,
+      lastQuotedAtMs: null,
+      requestKey: 'native|USDC|100|sell',
+      t,
+    });
+
+    await waitFor(() => {
+      expect(result.current.assertiveMessage).toBe(
+        'Quote refresh failed. Invalid amount',
+      );
+      expect(result.current.politeMessage).toBeNull();
+    });
+  });
+
+  it('resets dedupe when the request key changes during debounce', async () => {
+    const { result, rerender } = renderHook(
+      (props) => useQuoteRefreshAnnouncements(props),
+      {
+        initialProps: {
+          canAnnounce: true,
+          loading: false,
+          error: null,
+          isRecovering: false,
+          hasPendingRetry: false,
+          lastQuotedAtMs: 10,
+          requestKey: 'native|USDC|100|sell',
+          rateSummary: '1 XLM = 0.10 USDC',
+          t,
+        },
+      },
+    );
+
+    await waitFor(() => {
+      expect(result.current.politeMessage).toContain('Quote updated');
+    });
+
+    rerender({
+      canAnnounce: true,
+      loading: false,
+      error: null,
+      isRecovering: false,
+      hasPendingRetry: false,
+      lastQuotedAtMs: 20,
+      requestKey: 'native|USDC|200|sell',
+      rateSummary: '1 XLM = 0.20 USDC',
+      t,
+    });
+
+    await waitFor(() => {
+      expect(result.current.politeMessage).toBe(
+        'Quote updated. 1 XLM = 0.20 USDC',
+      );
+    });
+  });
+});

--- a/frontend/hooks/useQuoteRefreshAnnouncements.ts
+++ b/frontend/hooks/useQuoteRefreshAnnouncements.ts
@@ -1,0 +1,120 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+import {
+  getQuoteRefreshErrorKey,
+  shouldAnnounceQuoteRefreshFailure,
+  shouldAnnounceQuoteRefreshSuccess,
+  type QuoteRefreshAnnouncementState,
+} from '@/lib/quote-refresh-announcements';
+import type { SwapTranslationKey } from '@/lib/swap-i18n';
+
+export interface UseQuoteRefreshAnnouncementsInput
+  extends QuoteRefreshAnnouncementState {
+  /** Changes when quote request inputs change; resets dedupe tracking. */
+  requestKey: string;
+  /** Human-readable rate summary for polite success announcements. */
+  rateSummary?: string;
+  t: (
+    key: SwapTranslationKey,
+    variables?: Record<string, string | number>,
+  ) => string;
+}
+
+export interface QuoteRefreshAnnouncements {
+  politeMessage: string | null;
+  assertiveMessage: string | null;
+}
+
+/**
+ * Derives aria-live announcement text from quote refresh state.
+ * Suppresses duplicate announcements during debounce and transient retries.
+ */
+export function useQuoteRefreshAnnouncements(
+  input: UseQuoteRefreshAnnouncementsInput,
+): QuoteRefreshAnnouncements {
+  const {
+    canAnnounce,
+    loading,
+    error,
+    isRecovering,
+    hasPendingRetry,
+    lastQuotedAtMs,
+    requestKey,
+    rateSummary,
+    t,
+  } = input;
+
+  const [politeMessage, setPoliteMessage] = useState<string | null>(null);
+  const [assertiveMessage, setAssertiveMessage] = useState<string | null>(null);
+  const lastAnnouncedSuccessAtMs = useRef<number | null>(null);
+  const lastAnnouncedErrorKey = useRef<string | null>(null);
+
+  useEffect(() => {
+    lastAnnouncedSuccessAtMs.current = null;
+    lastAnnouncedErrorKey.current = null;
+    setPoliteMessage(null);
+    setAssertiveMessage(null);
+  }, [requestKey]);
+
+  useEffect(() => {
+    const state: QuoteRefreshAnnouncementState = {
+      canAnnounce,
+      loading,
+      error,
+      isRecovering,
+      hasPendingRetry,
+      lastQuotedAtMs,
+    };
+
+    if (
+      shouldAnnounceQuoteRefreshSuccess(
+        state,
+        lastAnnouncedSuccessAtMs.current,
+      )
+    ) {
+      lastAnnouncedSuccessAtMs.current = lastQuotedAtMs;
+      lastAnnouncedErrorKey.current = null;
+      setAssertiveMessage(null);
+      setPoliteMessage(
+        rateSummary?.trim()
+          ? t('swap.a11y.quoteRefreshed', { rate: rateSummary.trim() })
+          : t('swap.a11y.quoteRefreshedGeneric'),
+      );
+      return;
+    }
+
+    if (!error) {
+      return;
+    }
+
+    const errorKey = getQuoteRefreshErrorKey(error);
+    if (
+      !shouldAnnounceQuoteRefreshFailure(
+        state,
+        lastAnnouncedErrorKey.current,
+        errorKey,
+      )
+    ) {
+      return;
+    }
+
+    lastAnnouncedErrorKey.current = errorKey;
+    setPoliteMessage(null);
+    setAssertiveMessage(
+      t('swap.a11y.quoteRefreshFailed', { message: error.message }),
+    );
+  }, [
+    canAnnounce,
+    loading,
+    error,
+    isRecovering,
+    hasPendingRetry,
+    lastQuotedAtMs,
+    rateSummary,
+    t,
+  ]);
+
+  return { politeMessage, assertiveMessage };
+}

--- a/frontend/lib/quote-refresh-announcements.test.ts
+++ b/frontend/lib/quote-refresh-announcements.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  isHardQuoteRefreshFailure,
+  shouldAnnounceQuoteRefreshFailure,
+  shouldAnnounceQuoteRefreshSuccess,
+} from './quote-refresh-announcements';
+
+describe('quote-refresh-announcements', () => {
+  const baseState = {
+    canAnnounce: true,
+    loading: false,
+    error: null,
+    isRecovering: false,
+    hasPendingRetry: false,
+    lastQuotedAtMs: 1_000,
+  };
+
+  it('detects hard failures after retries stop', () => {
+    expect(
+      isHardQuoteRefreshFailure({
+        loading: false,
+        error: new Error('boom'),
+        isRecovering: false,
+        hasPendingRetry: false,
+      }),
+    ).toBe(true);
+  });
+
+  it('does not treat transient retries as hard failures', () => {
+    expect(
+      isHardQuoteRefreshFailure({
+        loading: false,
+        error: new Error('boom'),
+        isRecovering: true,
+        hasPendingRetry: true,
+      }),
+    ).toBe(false);
+  });
+
+  it('announces success only once per completed quote timestamp', () => {
+    expect(
+      shouldAnnounceQuoteRefreshSuccess(baseState, null),
+    ).toBe(true);
+    expect(
+      shouldAnnounceQuoteRefreshSuccess(baseState, baseState.lastQuotedAtMs),
+    ).toBe(false);
+  });
+
+  it('skips success announcements while loading', () => {
+    expect(
+      shouldAnnounceQuoteRefreshSuccess(
+        { ...baseState, loading: true },
+        null,
+      ),
+    ).toBe(false);
+  });
+
+  it('announces hard failures once per error message', () => {
+    const error = new Error('Invalid amount');
+    const state = {
+      ...baseState,
+      lastQuotedAtMs: null,
+      error,
+    };
+
+    expect(
+      shouldAnnounceQuoteRefreshFailure(state, null, error.message),
+    ).toBe(true);
+    expect(
+      shouldAnnounceQuoteRefreshFailure(state, error.message, error.message),
+    ).toBe(false);
+  });
+});

--- a/frontend/lib/quote-refresh-announcements.ts
+++ b/frontend/lib/quote-refresh-announcements.ts
@@ -1,0 +1,58 @@
+/**
+ * Screen reader announcement helpers for quote refresh outcomes.
+ */
+
+export type QuoteRefreshAnnouncementKind = 'success' | 'hard_failure';
+
+export interface QuoteRefreshAnnouncementState {
+  /** When false, suppress all announcements (invalid or missing inputs). */
+  canAnnounce: boolean;
+  loading: boolean;
+  error: Error | null;
+  isRecovering: boolean;
+  hasPendingRetry: boolean;
+  lastQuotedAtMs: number | null;
+}
+
+export function isHardQuoteRefreshFailure(
+  state: Pick<
+    QuoteRefreshAnnouncementState,
+    'loading' | 'error' | 'isRecovering' | 'hasPendingRetry'
+  >,
+): boolean {
+  return (
+    state.error !== null &&
+    !state.loading &&
+    !state.isRecovering &&
+    !state.hasPendingRetry
+  );
+}
+
+export function shouldAnnounceQuoteRefreshSuccess(
+  state: QuoteRefreshAnnouncementState,
+  lastAnnouncedSuccessAtMs: number | null,
+): boolean {
+  return (
+    state.canAnnounce &&
+    !state.loading &&
+    state.error === null &&
+    state.lastQuotedAtMs !== null &&
+    state.lastQuotedAtMs !== lastAnnouncedSuccessAtMs
+  );
+}
+
+export function shouldAnnounceQuoteRefreshFailure(
+  state: QuoteRefreshAnnouncementState,
+  lastAnnouncedErrorKey: string | null,
+  errorKey: string,
+): boolean {
+  return (
+    state.canAnnounce &&
+    isHardQuoteRefreshFailure(state) &&
+    errorKey !== lastAnnouncedErrorKey
+  );
+}
+
+export function getQuoteRefreshErrorKey(error: Error): string {
+  return error.message;
+}

--- a/frontend/lib/swap-i18n.ts
+++ b/frontend/lib/swap-i18n.ts
@@ -1,19 +1,3 @@
-/**
- * StellarRoute i18n module
- *
- * ## Adding a new locale
- *
- * 1. Add your locale code (e.g. "fr-FR") to the `SupportedSwapLocale` union type.
- * 2. Add a `SWAP_LOCALE_ALIASES` entry mapping the full `Locale` to your
- *    supported locale code.
- * 3. Add a full `SwapTranslations` record for every `SwapTranslationKey` in
- *    the `SWAP_TRANSLATIONS` dictionary.
- * 4. If your locale uses a different number format, ensure
- *    `SUPPORTED_LOCALES` in `lib/formatting.ts` includes a display name.
- * 5. Add a test in `swap-i18n.test.ts` that verifies your locale resolves
- *    correctly and returns the expected translated strings.
- */
-
 import { useOptionalSettings } from "@/components/providers/settings-provider";
 import {
   DEFAULT_LOCALE,
@@ -25,9 +9,9 @@ const SETTINGS_STORAGE_KEY = "stellar_route_settings";
 
 export const SWAP_FALLBACK_LOCALE: Locale = DEFAULT_LOCALE;
 
-type SupportedSwapLocale = "en-US" | "es-ES" | "zh-CN";
+type SupportedSwapLocale = "en-US" | "zh-CN";
 
-type SwapTranslationKey =
+export type SwapTranslationKey =
   | "swap.card.title"
   | "swap.card.offlineBanner"
   | "swap.card.clearForm"
@@ -114,16 +98,9 @@ type SwapTranslationKey =
   | "swap.shortcuts.focusPayAmount"
   | "swap.shortcuts.focusReceiveAmount"
   | "swap.shortcuts.refreshQuote"
-  | "swap.shortcuts.flipPair"
-  | "swap.shortcuts.maxAmount"
-  | "common.appName"
-  | "common.nav.history"
-  | "common.nav.swap"
-  | "common.nav.orderbook"
-  | "common.nav.settings"
-  | "common.error.generic"
-  | "common.error.network"
-  | "common.error.timeout";
+  | "swap.a11y.quoteRefreshed"
+  | "swap.a11y.quoteRefreshedGeneric"
+  | "swap.a11y.quoteRefreshFailed";
 
 type SwapTranslations = Record<SwapTranslationKey, string>;
 
@@ -135,16 +112,6 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.card.clearForm": "Clear form",
     "swap.card.offlineQuoteError": "You are offline. Reconnect to refresh quote.",
     "swap.card.retryQuote": "Retry quote",
-    "swap.shortcuts.flipPair": "Flip pay/receive pair",
-    "swap.shortcuts.maxAmount": "Set max pay amount",
-    "common.appName": "StellarRoute",
-    "common.nav.history": "History",
-    "common.nav.swap": "Swap",
-    "common.nav.orderbook": "Orderbook",
-    "common.nav.settings": "Settings",
-    "common.error.generic": "Something went wrong. Please try again.",
-    "common.error.network": "Network error. Check your connection.",
-    "common.error.timeout": "Request timed out. Please try again.",
     "swap.pair.youPay": "You Pay",
     "swap.pair.youReceive": "You Receive",
     "swap.pair.amountPlaceholder": "0.00",
@@ -236,115 +203,9 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.shortcuts.focusPayAmount": "Focus pay amount",
     "swap.shortcuts.focusReceiveAmount": "Focus receive amount",
     "swap.shortcuts.refreshQuote": "Refresh quote",
-  },
-  "es-ES": {
-    "swap.card.title": "Intercambiar",
-    "swap.card.offlineBanner":
-      "Estás desconectado. La actualización de cotizaciones y el envío de intercambios se pausarán hasta que se restaure la conexión.",
-    "swap.card.clearForm": "Limpiar formulario",
-    "swap.card.offlineQuoteError": "Estás desconectado. Reconéctate para actualizar la cotización.",
-    "swap.card.retryQuote": "Reintentar cotización",
-    "swap.shortcuts.flipPair": "Intercambiar par de pago/recepción",
-    "swap.shortcuts.maxAmount": "Establecer cantidad máxima de pago",
-    "common.appName": "StellarRoute",
-    "common.nav.history": "Historial",
-    "common.nav.swap": "Intercambiar",
-    "common.nav.orderbook": "Libro de órdenes",
-    "common.nav.settings": "Ajustes",
-    "common.error.generic": "Algo salió mal. Inténtalo de nuevo.",
-    "common.error.network": "Error de red. Verifica tu conexión.",
-    "common.error.timeout": "La solicitud expiró. Inténtalo de nuevo.",
-    "swap.pair.youPay": "Tú pagas",
-    "swap.pair.youReceive": "Tú recibes",
-    "swap.pair.amountPlaceholder": "0.00",
-    "swap.pair.payAmountAriaLabel": "Cantidad a pagar",
-    "swap.pair.receiveAmountAriaLabel": "Cantidad a recibir",
-    "swap.pair.selectPayTokenAriaLabel": "Seleccionar token para pagar",
-    "swap.pair.selectReceiveTokenAriaLabel": "Seleccionar token para recibir",
-    "swap.pair.swapTokensAriaLabel": "Intercambiar tokens de pago y recepción",
-    "swap.pair.balance": "Saldo: {amount}",
-    "swap.quote.rate": "Tasa",
-    "swap.quote.networkFee": "Comisión de red",
-    "swap.quote.priceImpact": "Impacto en el precio",
-    "swap.quote.minimumReceived": "Mínimo a recibir",
-    "swap.quote.exchangeRateTooltip":
-      "Tasa de mercado actual para este par de trading, incluido el enrutamiento de ruta.",
-    "swap.quote.minimumReceivedTooltip":
-      "La transacción se revertirá si hay un movimiento de precio desfavorable grande antes de que se confirme.",
-    "swap.quote.networkFeeTooltip":
-      "Costo estimado para ejecutar esta transacción en la red Stellar.",
-    "swap.quote.exportJson": "Exportar JSON",
-    "swap.quote.exportCsv": "Exportar CSV",
-    "swap.quote.exportSuccess": "Resumen de cotización exportado como {format}",
-    "swap.settings.buttonLabel": "Ajustes",
-    "swap.settings.menuTitle": "Ajustes de transacción",
-    "swap.settings.slippageTolerance": "Tolerancia de deslizamiento",
-    "swap.simulation.errorTitle": "Error de simulación",
-    "swap.simulation.emptyState": "Introduce una cantidad para ver la simulación",
-    "swap.simulation.title": "Simulación de intercambio",
-    "swap.simulation.slippageBadge": "{value}% deslizamiento",
-    "swap.simulation.highImpact": "Alto impacto",
-    "swap.simulation.expectedOutput": "Salida esperada",
-    "swap.simulation.minReceived": "Mínimo recibido",
-    "swap.simulation.fromSlippage": "-{amount} por deslizamiento",
-    "swap.simulation.effectiveRate": "Tasa efectiva",
-    "swap.simulation.priceImpact": "Impacto en el precio",
-    "swap.simulation.highImpactTitle": "Alto impacto en el precio:",
-    "swap.simulation.highImpactBody":
-      "Esta operación puede afectar significativamente el precio del mercado. Considera dividirla en órdenes más pequeñas.",
-    "swap.route.title": "Mejor ruta",
-    "swap.route.optimal": "Óptimo",
-    "swap.route.showDetails": "Mostrar detalles de la ruta",
-    "swap.route.expectedAmount": "{amount} esperado",
-    "swap.route.expectedShort": "{amount} esp.",
-    "swap.route.alternativeRoutes": "Rutas alternativas",
-    "swap.route.poolLabel": "Pool AQUA",
-    "swap.route.altVenue": "SDEX",
-    "swap.fees.unavailableTitle": "Estimación de comisiones",
-    "swap.fees.unavailableBody":
-      "Las estimaciones de comisiones no están disponibles actualmente. Inténtalo de nuevo más tarde.",
-    "swap.fees.title": "Desglose de comisiones",
-    "swap.fees.protocolSection": "Comisiones de protocolo",
-    "swap.fees.networkSection": "Costos de red",
-    "swap.fees.total": "Comisiones totales",
-    "swap.fees.netOutput": "Salida neta",
-    "swap.fees.routerFee.name": "Comisión de enrutador",
-    "swap.fees.routerFee.description":
-      "Comisión por usar el agregador StellarRoute",
-    "swap.fees.poolFee.name": "Comisión del pool",
-    "swap.fees.poolFee.description":
-      "Comisión del proveedor de liquidez para el pool AQUA",
-    "swap.fees.baseFee.name": "Comisión base",
-    "swap.fees.baseFee.description":
-      "Comisión base de transacción de la red Stellar",
-    "swap.fees.operationFee.name": "Comisión de operación",
-    "swap.fees.operationFee.description":
-      "Comisión por operaciones de pago de ruta",
-    "swap.cta.reviewSwap": "Revisar intercambio",
-    "swap.cta.offline": "Desconectado",
-    "swap.cta.selectTokens": "Seleccionar tokens",
-    "swap.cta.enterAmount": "Introducir cantidad",
-    "swap.cta.invalidSlippage": "Deslizamiento no válido",
-    "swap.cta.loadingQuote": "Cargando cotización...",
-    "swap.cta.connectWallet": "Conectar billetera",
-    "swap.cta.insufficientBalance": "Saldo insuficiente",
-    "swap.cta.swapAnyway": "Intercambiar de todos modos",
-    "swap.cta.swapping": "Intercambiando...",
-    "swap.cta.errorFetchingQuote": "Error al obtener cotización",
-    "swap.card.refreshQuote": "Actualizar cotización",
-    "swap.card.outdated": "Cotización desactualizada — actualiza para obtener el precio más reciente",
-    "swap.card.recoveringQuote": "Reintentando cotización...",
-    "swap.card.recoveringQuoteCountdown": "Reintentando cotización en {seconds}s...",
-    "swap.card.cancelRetry": "Cancelar reintento",
-    "swap.card.sessionRestored":
-      "Sesión restaurada — obteniendo una cotización nueva antes de intercambiar",
-    "swap.card.poweredBy": "Desarrollado por StellarRoute Aggregator",
-    "swap.shortcuts.title": "Atajos de teclado",
-    "swap.shortcuts.openHelp": "Abrir ayuda de atajos",
-    "swap.shortcuts.closeHelp": "Cerrar modal",
-    "swap.shortcuts.focusPayAmount": "Enfocar cantidad de pago",
-    "swap.shortcuts.focusReceiveAmount": "Enfocar cantidad a recibir",
-    "swap.shortcuts.refreshQuote": "Actualizar cotización",
+    "swap.a11y.quoteRefreshed": "Quote updated. {rate}",
+    "swap.a11y.quoteRefreshedGeneric": "Quote updated.",
+    "swap.a11y.quoteRefreshFailed": "Quote refresh failed. {message}",
   },
   "zh-CN": {
     "swap.card.title": "兑换",
@@ -353,16 +214,6 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.card.clearForm": "清空表单",
     "swap.card.offlineQuoteError": "你当前处于离线状态。恢复网络后再刷新报价。",
     "swap.card.retryQuote": "重试报价",
-    "swap.shortcuts.flipPair": "交换支付/接收代币对",
-    "swap.shortcuts.maxAmount": "设置最大支付金额",
-    "common.appName": "StellarRoute",
-    "common.nav.history": "历史",
-    "common.nav.swap": "兑换",
-    "common.nav.orderbook": "订单簿",
-    "common.nav.settings": "设置",
-    "common.error.generic": "出了点问题。请重试。",
-    "common.error.network": "网络错误。检查你的连接。",
-    "common.error.timeout": "请求超时。请重试。",
     "swap.pair.youPay": "你支付",
     "swap.pair.youReceive": "你收到",
     "swap.pair.amountPlaceholder": "0.00",
@@ -446,6 +297,9 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.shortcuts.focusPayAmount": "聚焦支付数量",
     "swap.shortcuts.focusReceiveAmount": "聚焦接收数量",
     "swap.shortcuts.refreshQuote": "刷新报价",
+    "swap.a11y.quoteRefreshed": "报价已更新。{rate}",
+    "swap.a11y.quoteRefreshedGeneric": "报价已更新。",
+    "swap.a11y.quoteRefreshFailed": "报价刷新失败。{message}",
   },
 };
 
@@ -454,7 +308,7 @@ const SWAP_LOCALE_ALIASES: Record<Locale, SupportedSwapLocale> = {
   "en-GB": "en-US",
   "de-DE": "en-US",
   "fr-FR": "en-US",
-  "es-ES": "es-ES",
+  "es-ES": "en-US",
   "ja-JP": "en-US",
   "zh-CN": "zh-CN",
 };


### PR DESCRIPTION
## Summary

- Add `useQuoteRefreshAnnouncements` and `QuoteRefreshLiveRegion` to announce quote refresh outcomes via screen-reader-only `aria-live` regions without moving focus.
- Polite announcements fire on successful quote completion; assertive announcements fire on hard failures after retries are exhausted.
- Deduplicate announcements per request context so debounced amount edits do not spam the live region.
- Wire into `SwapCard` and `DemoSwap`; add unit tests and manual screen reader test notes in `frontend/docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md`.

Closes #513

## Test plan

- [x] `npm test` for announcement helpers, hook, and live region component
- [x] `npm run build` in `frontend`
- [ ] Manual NVDA/VoiceOver pass using `frontend/docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md`