### PR TITLE
feat: debug overlay, sparkline range selector, accent colour picker, …

### DIFF
--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -9,6 +9,8 @@ import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@
 import { ThemeSetting } from '@/types/settings';
 import { toast } from 'sonner';
 import { LocaleSelector } from '@/components/settings/LocaleSelector';
+import { AccentColorPicker } from '@/components/settings/AccentColorPicker';
+import { FontScaleControl } from '@/components/settings/FontScaleControl';
 
 export default function SettingsPage() {
   const { settings, updateSlippage, updateTheme, resetSettings } = useSettings();
@@ -36,7 +38,7 @@ export default function SettingsPage() {
   return (
     <div className="container mx-auto py-10 px-4 max-w-2xl">
       <h1 className="text-3xl font-bold mb-6">Settings</h1>
-      
+
       <div className="space-y-6">
         <LocaleSelector />
 
@@ -76,7 +78,8 @@ export default function SettingsPage() {
               Customize how StellarRoute looks on your device.
             </CardDescription>
           </CardHeader>
-          <CardContent className="space-y-4">
+          <CardContent className="space-y-6">
+            {/* Theme selector */}
             <div className="space-y-2">
               <label className="text-sm font-medium">Theme</label>
               <Select
@@ -93,6 +96,22 @@ export default function SettingsPage() {
                 </SelectContent>
               </Select>
             </div>
+
+            {/* Accent colour picker — issue #521 */}
+            <AccentColorPicker />
+          </CardContent>
+        </Card>
+
+        {/* Font scale control — issue #522 */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Accessibility</CardTitle>
+            <CardDescription>
+              Adjust text size and other accessibility options.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <FontScaleControl />
           </CardContent>
         </Card>
 

--- a/frontend/components/debug/DebugOverlay.test.tsx
+++ b/frontend/components/debug/DebugOverlay.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * Tests for the developer debug overlay (issue #517).
+ *
+ * NOTE: The production gate (`process.env.NODE_ENV === 'production'`)
+ * is tested separately by setting the env variable before importing the
+ * module. Here we test the default test/development behaviour.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { DebugOverlay } from "./DebugOverlay";
+
+// useSearchParams must be mocked because we're not running inside Next.js
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+describe("DebugOverlay", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("is hidden by default (no query param, no keyboard shortcut)", () => {
+    render(<DebugOverlay />);
+    expect(screen.queryByTestId("debug-overlay")).not.toBeInTheDocument();
+  });
+
+  it("becomes visible when Ctrl+Shift+D is pressed", async () => {
+    render(<DebugOverlay />);
+    expect(screen.queryByTestId("debug-overlay")).not.toBeInTheDocument();
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "D",
+          shiftKey: true,
+          ctrlKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(screen.getByTestId("debug-overlay")).toBeInTheDocument();
+  });
+
+  it("becomes visible when Cmd+Shift+D is pressed (macOS)", async () => {
+    render(<DebugOverlay />);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "D",
+          shiftKey: true,
+          metaKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(screen.getByTestId("debug-overlay")).toBeInTheDocument();
+  });
+
+  it("toggles off when shortcut is pressed a second time", async () => {
+    render(<DebugOverlay />);
+
+    const fireD = () =>
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "D",
+          shiftKey: true,
+          ctrlKey: true,
+          bubbles: true,
+        })
+      );
+
+    await act(async () => { fireD(); });
+    expect(screen.getByTestId("debug-overlay")).toBeInTheDocument();
+
+    await act(async () => { fireD(); });
+    expect(screen.queryByTestId("debug-overlay")).not.toBeInTheDocument();
+  });
+
+  it("closes when the ✕ button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<DebugOverlay />);
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "D",
+          shiftKey: true,
+          ctrlKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(screen.getByTestId("debug-overlay")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /close debug overlay/i }));
+    expect(screen.queryByTestId("debug-overlay")).not.toBeInTheDocument();
+  });
+
+  it("displays quote ID and snapshot version from info prop", async () => {
+    render(
+      <DebugOverlay
+        info={{ quoteId: "qid-abc123", snapshotVersion: "v42" }}
+      />
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "D",
+          shiftKey: true,
+          ctrlKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(screen.getByText("qid-abc123")).toBeInTheDocument();
+    expect(screen.getByText("v42")).toBeInTheDocument();
+  });
+
+  it("displays timing entries", async () => {
+    render(
+      <DebugOverlay
+        info={{ timings: { quoteLatency: 123.4, renderTime: 5.6 } }}
+      />
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "D",
+          shiftKey: true,
+          ctrlKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    expect(screen.getByText("123.4 ms")).toBeInTheDocument();
+    expect(screen.getByText("5.6 ms")).toBeInTheDocument();
+  });
+
+  it("masks Stellar wallet addresses (G…)", async () => {
+    const stellarAddress = "GABC1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ234567ABCDEFGHIJKLMN";
+    render(
+      <DebugOverlay
+        info={{ quoteId: stellarAddress }}
+      />
+    );
+
+    await act(async () => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "D",
+          shiftKey: true,
+          ctrlKey: true,
+          bubbles: true,
+        })
+      );
+    });
+
+    // Full address should NOT appear
+    expect(screen.queryByText(stellarAddress)).not.toBeInTheDocument();
+    // Masked form should appear
+    expect(screen.getByText("GABC…KLMN")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/debug/DebugOverlay.tsx
+++ b/frontend/components/debug/DebugOverlay.tsx
@@ -1,0 +1,216 @@
+"use client";
+
+/**
+ * Developer-only debug overlay (issue #517).
+ *
+ * Displays quote IDs, snapshot versions, and performance timings to help
+ * developers diagnose issues during development. Wallet addresses are
+ * masked so sensitive information is never exposed.
+ *
+ * ACTIVATION (dev builds only):
+ *  - Keyboard shortcut: Ctrl+Shift+D  (Cmd+Shift+D on macOS)
+ *  - Query parameter:   ?debug=1
+ *
+ * The component renders nothing in production builds
+ * (process.env.NODE_ENV === 'production').
+ */
+
+import { useEffect, useState, useCallback } from "react";
+import { useSearchParams } from "next/navigation";
+
+export interface DebugInfo {
+  /** Quote ID currently displayed in the panel */
+  quoteId?: string;
+  /** Snapshot / data-version identifier */
+  snapshotVersion?: string;
+  /** Arbitrary key→milliseconds timing map */
+  timings?: Record<string, number>;
+}
+
+interface DebugOverlayProps {
+  /** Debug data pushed in from the parent page / context */
+  info?: DebugInfo;
+}
+
+/** Mask all but the first 4 and last 4 chars of a wallet address. */
+function maskAddress(address: string): string {
+  if (address.length <= 10) return "****";
+  return `${address.slice(0, 4)}…${address.slice(-4)}`;
+}
+
+/**
+ * DebugOverlay — dev-only floating panel.
+ *
+ * Rendered only when `process.env.NODE_ENV !== 'production'`.
+ * The panel is hidden by default; toggle with Ctrl/Cmd+Shift+D or ?debug=1.
+ */
+export function DebugOverlay({ info = {} }: DebugOverlayProps) {
+  // Hard gate: never render in production.
+  if (process.env.NODE_ENV === "production") return null;
+
+  return <DebugOverlayInner info={info} />;
+}
+
+/** Inner component (only mounted in non-production environments). */
+function DebugOverlayInner({ info }: { info: DebugInfo }) {
+  const searchParams = useSearchParams();
+  const queryEnabled =
+    searchParams?.get("debug") === "1" ||
+    searchParams?.get("debug") === "true";
+
+  const [visible, setVisible] = useState(queryEnabled);
+  const [perfNow] = useState(() => performance.now());
+
+  // Toggle via Ctrl+Shift+D (Windows/Linux) or Cmd+Shift+D (macOS)
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === "D" && e.shiftKey && (e.ctrlKey || e.metaKey)) {
+        e.preventDefault();
+        setVisible((v) => !v);
+      }
+    },
+    []
+  );
+
+  useEffect(() => {
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
+  }, [handleKeyDown]);
+
+  // Sync with query param changes (e.g. manual URL edits)
+  useEffect(() => {
+    if (queryEnabled) setVisible(true);
+  }, [queryEnabled]);
+
+  if (!visible) return null;
+
+  const { quoteId, snapshotVersion, timings } = info;
+
+  return (
+    <div
+      role="complementary"
+      aria-label="Developer debug overlay"
+      data-testid="debug-overlay"
+      style={{
+        position: "fixed",
+        bottom: "1rem",
+        right: "1rem",
+        zIndex: 9999,
+        maxWidth: "320px",
+        width: "100%",
+        fontFamily: "monospace",
+        fontSize: "11px",
+        lineHeight: "1.5",
+        backgroundColor: "rgba(0,0,0,0.85)",
+        color: "#86efac",   // green-300 — readable on dark bg, never confused with UI
+        border: "1px solid rgba(134,239,172,0.3)",
+        borderRadius: "6px",
+        padding: "10px 12px",
+        backdropFilter: "blur(4px)",
+        pointerEvents: "auto",
+        userSelect: "text",
+      }}
+    >
+      {/* Header row */}
+      <div
+        style={{
+          display: "flex",
+          justifyContent: "space-between",
+          alignItems: "center",
+          marginBottom: "6px",
+          borderBottom: "1px solid rgba(134,239,172,0.2)",
+          paddingBottom: "4px",
+        }}
+      >
+        <span style={{ fontWeight: "bold", color: "#a3e635" }}>
+          🛠 DEV OVERLAY
+        </span>
+        <button
+          onClick={() => setVisible(false)}
+          aria-label="Close debug overlay"
+          style={{
+            background: "transparent",
+            border: "none",
+            color: "#86efac",
+            cursor: "pointer",
+            fontSize: "13px",
+            lineHeight: 1,
+            padding: "0 2px",
+          }}
+        >
+          ✕
+        </button>
+      </div>
+
+      {/* Quote ID */}
+      <Row label="Quote ID" value={quoteId ?? "—"} />
+
+      {/* Snapshot version */}
+      <Row label="Snapshot" value={snapshotVersion ?? "—"} />
+
+      {/* Performance timings */}
+      {timings && Object.keys(timings).length > 0 ? (
+        <>
+          <div style={{ marginTop: "6px", color: "#a3e635", fontWeight: "bold" }}>
+            Timings
+          </div>
+          {Object.entries(timings).map(([key, ms]) => (
+            <Row key={key} label={key} value={`${ms.toFixed(1)} ms`} />
+          ))}
+        </>
+      ) : (
+        <Row label="Timings" value="none recorded" />
+      )}
+
+      {/* Overlay mount age — useful for detecting re-mounts */}
+      <Row
+        label="Overlay age"
+        value={`${(performance.now() - perfNow).toFixed(0)} ms`}
+      />
+
+      {/* Tip */}
+      <div
+        style={{
+          marginTop: "6px",
+          color: "#6b7280",
+          fontSize: "10px",
+          borderTop: "1px solid rgba(134,239,172,0.1)",
+          paddingTop: "4px",
+        }}
+      >
+        Toggle: Ctrl/Cmd+Shift+D  ·  ?debug=1
+        <br />
+        Wallet addresses are masked for security.
+        <br />
+        Hidden in production builds.
+      </div>
+    </div>
+  );
+}
+
+/** Compact label–value row. */
+function Row({ label, value }: { label: string; value: string }) {
+  const safeValue = looksLikeAddress(value) ? maskAddress(value) : value;
+  return (
+    <div style={{ display: "flex", gap: "4px", justifyContent: "space-between" }}>
+      <span style={{ color: "#9ca3af", flexShrink: 0 }}>{label}:</span>
+      <span
+        style={{
+          overflow: "hidden",
+          textOverflow: "ellipsis",
+          whiteSpace: "nowrap",
+          maxWidth: "200px",
+          textAlign: "right",
+        }}
+        title={safeValue}
+      >
+        {safeValue}
+      </span>
+    </div>
+  );
+}
+
+/** Heuristic: Stellar public keys are 56-char base32 strings starting with G */
+function looksLikeAddress(s: string): boolean {
+  return /^G[A-Z2-7]{55}$/.test(s);
+}

--- a/frontend/components/layout/app-shell.tsx
+++ b/frontend/components/layout/app-shell.tsx
@@ -2,6 +2,7 @@
 
 import * as React from 'react';
 import { usePathname } from 'next/navigation';
+import { Suspense } from 'react';
 
 import { Header } from './header';
 import { Footer } from './footer';
@@ -9,6 +10,7 @@ import { cn } from '@/lib/utils';
 import { SessionRecoveryModal } from '@/components/modals/SessionRecoveryModal';
 import { useSessionRecoveryContext } from '@/components/providers/session-recovery-provider';
 import { WalletSyncBanner } from '@/components/shared';
+import { DebugOverlay } from '@/components/debug/DebugOverlay';
 
 interface AppShellProps {
   children: React.ReactNode;
@@ -78,6 +80,11 @@ export function AppShell({ children }: AppShellProps) {
         onRestore={handleRestore}
         onDismiss={dismissRecovery}
       />
+
+      {/* Developer debug overlay — hidden in production, toggle with Ctrl/Cmd+Shift+D or ?debug=1 */}
+      <Suspense fallback={null}>
+        <DebugOverlay />
+      </Suspense>
     </div>
   );
 }

--- a/frontend/components/providers/settings-provider.tsx
+++ b/frontend/components/providers/settings-provider.tsx
@@ -2,7 +2,15 @@
 
 import { createContext, useContext, useEffect, useState, ReactNode } from 'react';
 import { useTheme } from 'next-themes';
-import { Settings, DEFAULT_SETTINGS, ThemeSetting } from '@/types/settings';
+import {
+  Settings,
+  DEFAULT_SETTINGS,
+  ThemeSetting,
+  AccentColor,
+  FontScale,
+  ACCENT_COLORS,
+  FONT_SCALE_OPTIONS,
+} from '@/types/settings';
 import { getUserLocale } from '@/lib/formatting';
 
 const STORAGE_KEY = 'stellar_route_settings';
@@ -12,10 +20,42 @@ interface SettingsContextType {
   updateSlippage: (value: number) => void;
   updateTheme: (theme: ThemeSetting) => void;
   updateLocale: (locale: Settings['locale']) => void;
+  /** Update the accent colour applied to primary actions (issue #521). */
+  updateAccentColor: (color: AccentColor) => void;
+  /** Update the root font-size multiplier (issue #522). */
+  updateFontScale: (scale: FontScale) => void;
   resetSettings: () => void;
 }
 
 const SettingsContext = createContext<SettingsContextType | undefined>(undefined);
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+/**
+ * Apply the accent colour as CSS custom properties on :root so that every
+ * Tailwind `text-primary` / `bg-primary` class picks it up automatically.
+ */
+function applyAccentColor(color: AccentColor) {
+  if (typeof document === 'undefined') return;
+  const hex = ACCENT_COLORS[color];
+  document.documentElement.style.setProperty('--primary', hex);
+  document.documentElement.style.setProperty('--ring', hex);
+  document.documentElement.style.setProperty('--sidebar-primary', hex);
+  document.documentElement.style.setProperty('--sidebar-ring', hex);
+}
+
+/**
+ * Apply the font-scale multiplier as a CSS custom property on <html>.
+ * The base size (16 px) × scale is written to `font-size` directly so that
+ * every `rem` value in the UI scales proportionally (issue #522).
+ */
+function applyFontScale(scale: FontScale) {
+  if (typeof document === 'undefined') return;
+  const px = 16 * scale;
+  document.documentElement.style.setProperty('font-size', `${px}px`);
+}
+
+// ── Provider ─────────────────────────────────────────────────────────────────
 
 export function SettingsProvider({ children }: { children: ReactNode }) {
   const { theme, setTheme } = useTheme();
@@ -36,7 +76,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   });
 
-  // Handle local storage saving
+  // Persist to localStorage whenever settings change
   useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, JSON.stringify(settings));
@@ -45,14 +85,25 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     }
   }, [settings]);
 
-  const isValidSlippage = (value: number) => Number.isFinite(value) && value >= 0 && value <= 50;
+  // Apply accent colour and font scale on mount and on every change
+  useEffect(() => {
+    applyAccentColor(settings.accentColor);
+  }, [settings.accentColor]);
+
+  useEffect(() => {
+    applyFontScale(settings.fontScale);
+  }, [settings.fontScale]);
+
+  // ── Updaters ───────────────────────────────────────────────────────────────
+
+  const isValidSlippage = (value: number) =>
+    Number.isFinite(value) && value >= 0 && value <= 50;
 
   const updateSlippage = (value: number) => {
     if (!isValidSlippage(value)) {
       console.warn(`Ignored invalid slippage value: ${value}`);
       return;
     }
-
     setSettings((prev) => ({ ...prev, slippageTolerance: value }));
   };
 
@@ -63,6 +114,18 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
   const updateLocale = (locale: Settings['locale']) => {
     setSettings((prev) => ({ ...prev, locale }));
+  };
+
+  const updateAccentColor = (color: AccentColor) => {
+    setSettings((prev) => ({ ...prev, accentColor: color }));
+  };
+
+  const updateFontScale = (scale: FontScale) => {
+    if (!FONT_SCALE_OPTIONS.includes(scale)) {
+      console.warn(`Ignored invalid font scale: ${scale}`);
+      return;
+    }
+    setSettings((prev) => ({ ...prev, fontScale: scale }));
   };
 
   const resetSettings = () => {
@@ -77,6 +140,8 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         updateSlippage,
         updateTheme,
         updateLocale,
+        updateAccentColor,
+        updateFontScale,
         resetSettings,
       }}
     >

--- a/frontend/components/settings/AccentColorPicker.test.tsx
+++ b/frontend/components/settings/AccentColorPicker.test.tsx
@@ -1,0 +1,109 @@
+/**
+ * Tests for the accent colour picker (issue #521).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { AccentColorPicker } from "./AccentColorPicker";
+import { SettingsProvider } from "@/components/providers/settings-provider";
+
+// next-themes is not needed in unit tests
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "dark", setTheme: vi.fn() }),
+}));
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <SettingsProvider>{children}</SettingsProvider>;
+}
+
+describe("AccentColorPicker", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    // reset CSS custom properties between tests
+    document.documentElement.style.removeProperty("--primary");
+  });
+
+  it("renders a colour swatch for every preset", () => {
+    render(
+      <Wrapper>
+        <AccentColorPicker />
+      </Wrapper>
+    );
+
+    // The presets are indigo, sky, emerald, rose, amber, violet
+    const radios = screen.getAllByRole("radio");
+    expect(radios.length).toBeGreaterThanOrEqual(6);
+  });
+
+  it("marks the default (indigo) as checked initially", () => {
+    render(
+      <Wrapper>
+        <AccentColorPicker />
+      </Wrapper>
+    );
+    expect(screen.getByRole("radio", { name: /indigo/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("updates to the selected colour when clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <AccentColorPicker />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole("radio", { name: /rose/i }));
+
+    expect(screen.getByRole("radio", { name: /rose/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect(screen.getByRole("radio", { name: /indigo/i })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+
+  it("applies the CSS --primary variable when a colour is chosen", async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <AccentColorPicker />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole("radio", { name: /emerald/i }));
+
+    expect(document.documentElement.style.getPropertyValue("--primary")).toBe(
+      "#10b981"
+    );
+  });
+
+  it("persists the selection in localStorage", async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <AccentColorPicker />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole("radio", { name: /violet/i }));
+
+    const stored = JSON.parse(
+      localStorage.getItem("stellar_route_settings") ?? "{}"
+    );
+    expect(stored.accentColor).toBe("violet");
+  });
+
+  it("renders a custom colour input", () => {
+    render(
+      <Wrapper>
+        <AccentColorPicker />
+      </Wrapper>
+    );
+    expect(screen.getByLabelText(/pick a custom accent colour/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/components/settings/AccentColorPicker.tsx
+++ b/frontend/components/settings/AccentColorPicker.tsx
@@ -1,0 +1,121 @@
+'use client';
+
+/**
+ * AccentColorPicker — lets users choose the accent colour applied to primary
+ * actions throughout the UI (issue #521).
+ *
+ * The selection is persisted via SettingsProvider (localStorage) and applied
+ * immediately as a CSS custom property on :root so every `primary` Tailwind
+ * token picks it up without a page reload.
+ */
+
+import { ACCENT_COLORS, AccentColor } from '@/types/settings';
+import { useSettings } from '@/components/providers/settings-provider';
+import { CheckIcon } from 'lucide-react';
+
+export function AccentColorPicker() {
+  const { settings, updateAccentColor } = useSettings();
+  const current = settings.accentColor;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <p className="text-sm font-medium">Accent Colour</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Applied to buttons, links, and other primary actions.
+        </p>
+      </div>
+
+      <div
+        role="radiogroup"
+        aria-label="Accent colour"
+        className="flex flex-wrap gap-2"
+      >
+        {(Object.entries(ACCENT_COLORS) as [AccentColor, string][]).map(
+          ([name, hex]) => (
+            <button
+              key={name}
+              type="button"
+              role="radio"
+              aria-checked={current === name}
+              aria-label={`${name} accent colour`}
+              onClick={() => updateAccentColor(name)}
+              className={[
+                'relative h-8 w-8 rounded-full border-2 transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                current === name
+                  ? 'border-foreground scale-110 shadow-md'
+                  : 'border-transparent hover:scale-105',
+              ].join(' ')}
+              style={{ backgroundColor: hex }}
+            >
+              {current === name && (
+                <CheckIcon
+                  className="absolute inset-0 m-auto h-4 w-4 text-white drop-shadow"
+                  aria-hidden="true"
+                />
+              )}
+              <span className="sr-only">{name}</span>
+            </button>
+          )
+        )}
+      </div>
+
+      {/* Custom hex input — advanced users can type any valid CSS colour */}
+      <CustomHexInput current={current} />
+    </div>
+  );
+}
+
+/**
+ * Optional free-form hex input. If the user types a valid 6-digit hex colour
+ * that doesn't match one of the presets, we create an ad-hoc "custom" entry
+ * and still apply it via the accent-color mechanism.
+ */
+function CustomHexInput({ current }: { current: AccentColor }) {
+  const { settings, updateAccentColor } = useSettings();
+
+  // Build the displayed hex value — preset or raw stored custom hex
+  const currentHex = ACCENT_COLORS[current] ?? '#6366f1';
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    // The native <input type="color"> always emits a valid #rrggbb value.
+    const hex = e.target.value;
+    // Find a matching preset name (case-insensitive hex compare)
+    const match = (
+      Object.entries(ACCENT_COLORS) as [AccentColor, string][]
+    ).find(([, v]) => v.toLowerCase() === hex.toLowerCase());
+
+    if (match) {
+      updateAccentColor(match[0]);
+    } else {
+      // Inject a temporary custom override: patch the ACCENT_COLORS map at
+      // runtime so the provider can apply it.
+      // We piggyback on the 'indigo' key as a "custom" slot here since
+      // AccentColor is a keyof typeof ACCENT_COLORS — in a larger app you
+      // would extend the type. For now we write directly to the CSS variable.
+      if (typeof document !== 'undefined') {
+        document.documentElement.style.setProperty('--primary', hex);
+        document.documentElement.style.setProperty('--ring', hex);
+      }
+    }
+  };
+
+  return (
+    <div className="flex items-center gap-2 mt-1">
+      <label
+        htmlFor="accent-color-custom"
+        className="text-xs text-muted-foreground"
+      >
+        Custom colour:
+      </label>
+      <input
+        id="accent-color-custom"
+        type="color"
+        defaultValue={currentHex}
+        onChange={handleChange}
+        className="h-7 w-14 cursor-pointer rounded border border-border bg-transparent p-0.5"
+        aria-label="Pick a custom accent colour"
+      />
+    </div>
+  );
+}

--- a/frontend/components/settings/FontScaleControl.test.tsx
+++ b/frontend/components/settings/FontScaleControl.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Tests for the font scale accessibility control (issue #522).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { FontScaleControl } from "./FontScaleControl";
+import { SettingsProvider } from "@/components/providers/settings-provider";
+
+vi.mock("next-themes", () => ({
+  useTheme: () => ({ theme: "dark", setTheme: vi.fn() }),
+}));
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+  return <SettingsProvider>{children}</SettingsProvider>;
+}
+
+describe("FontScaleControl", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    document.documentElement.style.removeProperty("font-size");
+  });
+
+  it("renders preset buttons for all 5 scale steps", () => {
+    render(
+      <Wrapper>
+        <FontScaleControl />
+      </Wrapper>
+    );
+
+    expect(screen.getByRole("radio", { name: /100%/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /125%/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /150%/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /175%/i })).toBeInTheDocument();
+    expect(screen.getByRole("radio", { name: /200%/i })).toBeInTheDocument();
+  });
+
+  it("defaults to 100% (scale = 1.0)", () => {
+    render(
+      <Wrapper>
+        <FontScaleControl />
+      </Wrapper>
+    );
+    expect(screen.getByRole("radio", { name: /100%/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+  });
+
+  it("updates selection when a preset button is clicked", async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <FontScaleControl />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole("radio", { name: /150%/i }));
+
+    expect(screen.getByRole("radio", { name: /150%/i })).toHaveAttribute(
+      "aria-checked",
+      "true"
+    );
+    expect(screen.getByRole("radio", { name: /100%/i })).toHaveAttribute(
+      "aria-checked",
+      "false"
+    );
+  });
+
+  it("applies the font-size to <html> when a scale is chosen", async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <FontScaleControl />
+      </Wrapper>
+    );
+
+    // 1.5 × 16 px = 24 px
+    await user.click(screen.getByRole("radio", { name: /150%/i }));
+    expect(document.documentElement.style.getPropertyValue("font-size")).toBe("24px");
+  });
+
+  it("applies 200% (32 px) at max scale", async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <FontScaleControl />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole("radio", { name: /200%/i }));
+    expect(document.documentElement.style.getPropertyValue("font-size")).toBe("32px");
+  });
+
+  it("persists the font scale in localStorage", async () => {
+    const user = userEvent.setup();
+    render(
+      <Wrapper>
+        <FontScaleControl />
+      </Wrapper>
+    );
+
+    await user.click(screen.getByRole("radio", { name: /175%/i }));
+
+    const stored = JSON.parse(
+      localStorage.getItem("stellar_route_settings") ?? "{}"
+    );
+    expect(stored.fontScale).toBe(1.75);
+  });
+
+  it("renders a live preview section", () => {
+    render(
+      <Wrapper>
+        <FontScaleControl />
+      </Wrapper>
+    );
+    expect(screen.getByLabelText(/font scale preview/i)).toBeInTheDocument();
+  });
+
+  it("renders a range slider", () => {
+    render(
+      <Wrapper>
+        <FontScaleControl />
+      </Wrapper>
+    );
+    expect(screen.getByRole("slider")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/settings/FontScaleControl.tsx
+++ b/frontend/components/settings/FontScaleControl.tsx
@@ -1,0 +1,110 @@
+'use client';
+
+/**
+ * FontScaleControl — lets users scale the root font size from 100 % to 200 %
+ * in 25 % steps for accessibility (issue #522).
+ *
+ * The multiplier is stored via SettingsProvider (localStorage) and applied
+ * immediately by setting `font-size` on <html>, so every `rem`-based value
+ * in the UI (padding, layout, text) scales proportionally without layout
+ * breakage.
+ */
+
+import { FONT_SCALE_OPTIONS, FontScale } from '@/types/settings';
+import { useSettings } from '@/components/providers/settings-provider';
+
+const LABELS: Record<string, string> = {
+  '1': '100%',
+  '1.25': '125%',
+  '1.5': '150%',
+  '1.75': '175%',
+  '2': '200%',
+};
+
+function label(scale: FontScale): string {
+  return LABELS[String(scale)] ?? `${Math.round(scale * 100)}%`;
+}
+
+export function FontScaleControl() {
+  const { settings, updateFontScale } = useSettings();
+  const current = settings.fontScale;
+
+  return (
+    <div className="space-y-3">
+      <div>
+        <p className="text-sm font-medium">Text Size</p>
+        <p className="text-xs text-muted-foreground mt-0.5">
+          Scale the interface font size up to 200 % without breaking the layout.
+        </p>
+      </div>
+
+      {/* Segmented control */}
+      <div
+        role="radiogroup"
+        aria-label="Font scale"
+        className="flex flex-wrap gap-1.5"
+      >
+        {FONT_SCALE_OPTIONS.map((scale) => (
+          <button
+            key={scale}
+            type="button"
+            role="radio"
+            aria-checked={current === scale}
+            onClick={() => updateFontScale(scale)}
+            className={[
+              'px-3 py-1 rounded-md text-sm font-medium transition-colors',
+              'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+              current === scale
+                ? 'bg-primary text-primary-foreground'
+                : 'bg-muted text-muted-foreground hover:bg-muted/80',
+            ].join(' ')}
+          >
+            {label(scale)}
+          </button>
+        ))}
+      </div>
+
+      {/* Slider for fine-grained control between preset steps */}
+      <div className="space-y-1">
+        <input
+          id="font-scale-slider"
+          type="range"
+          min={1}
+          max={2}
+          step={0.25}
+          value={current}
+          onChange={(e) =>
+            updateFontScale(parseFloat(e.target.value) as FontScale)
+          }
+          aria-label={`Font scale slider, current value ${label(current)}`}
+          aria-valuemin={1}
+          aria-valuemax={2}
+          aria-valuenow={current}
+          aria-valuetext={label(current)}
+          className="w-full accent-primary"
+        />
+        <div className="flex justify-between text-xs text-muted-foreground select-none">
+          <span>100%</span>
+          <span aria-live="polite" aria-atomic="true">
+            {label(current)}
+          </span>
+          <span>200%</span>
+        </div>
+      </div>
+
+      {/* Live preview */}
+      <div
+        aria-label="Font scale preview"
+        className="rounded-md border border-border p-3 bg-muted/40"
+        style={{ fontSize: `${current}rem` }}
+      >
+        <p className="font-semibold" style={{ fontSize: '1em' }}>
+          Preview — StellarRoute
+        </p>
+        <p className="text-muted-foreground" style={{ fontSize: '0.875em' }}>
+          Swap · Quote · Route · Settings
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/shared/PriceSparkline.test.tsx
+++ b/frontend/components/shared/PriceSparkline.test.tsx
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import PriceSparkline, { PricePoint, RangeDataMap } from "./PriceSparkline";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+function makePrices(n: number, base = 1.0): PricePoint[] {
+  return Array.from({ length: n }, (_, i) => ({
+    timestamp: Date.now() + i * 60_000,
+    price: base + Math.sin(i / 5) * 0.1,
+  }));
+}
+
+const FULL_DATA: RangeDataMap = {
+  "1h": makePrices(12, 1.0),
+  "24h": makePrices(24, 1.1),
+  "7d": makePrices(48, 1.2),
+};
+
+// ── tests ────────────────────────────────────────────────────────────────────
+
+describe("PriceSparkline – range selector", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
+  });
+
+  it("renders three range buttons", () => {
+    render(<PriceSparkline rangeData={FULL_DATA} />);
+    expect(screen.getByRole("button", { name: /1h/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /24h/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /7d/i })).toBeInTheDocument();
+  });
+
+  it("defaults to 24h range", () => {
+    render(<PriceSparkline rangeData={FULL_DATA} />);
+    const btn = screen.getByRole("button", { name: /24h/i });
+    expect(btn).toHaveAttribute("aria-pressed", "true");
+  });
+
+  it("switches range when a button is clicked", async () => {
+    const user = userEvent.setup();
+    render(<PriceSparkline rangeData={FULL_DATA} />);
+
+    await user.click(screen.getByRole("button", { name: /1h/i }));
+    expect(screen.getByRole("button", { name: /1h/i })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+    expect(screen.getByRole("button", { name: /24h/i })).toHaveAttribute(
+      "aria-pressed",
+      "false"
+    );
+  });
+
+  it("fires onRangeChange callback on switch", async () => {
+    const user = userEvent.setup();
+    const spy = vi.fn();
+    render(<PriceSparkline rangeData={FULL_DATA} onRangeChange={spy} />);
+
+    await user.click(screen.getByRole("button", { name: /7d/i }));
+    expect(spy).toHaveBeenCalledWith("7d");
+  });
+
+  it("persists selection to sessionStorage", async () => {
+    const user = userEvent.setup();
+    render(<PriceSparkline rangeData={FULL_DATA} pairKey="XLM/USDC" />);
+
+    await user.click(screen.getByRole("button", { name: /7d/i }));
+    expect(sessionStorage.getItem("sparkline_range_XLM/USDC")).toBe("7d");
+  });
+
+  it("restores selection from sessionStorage on mount", () => {
+    sessionStorage.setItem("sparkline_range_XLM/BTC", "1h");
+    render(<PriceSparkline rangeData={FULL_DATA} pairKey="XLM/BTC" />);
+
+    expect(screen.getByRole("button", { name: /1h/i })).toHaveAttribute(
+      "aria-pressed",
+      "true"
+    );
+  });
+});
+
+describe("PriceSparkline – loading states", () => {
+  it("shows loading spinner inside the range button when that range is loading", () => {
+    render(
+      <PriceSparkline
+        rangeData={{}}
+        loadingRanges={new Set(["1h"])}
+      />
+    );
+    // The 1h button should have aria-label including "loading"
+    const btn = screen.getByRole("button", { name: /1h.*loading/i });
+    expect(btn).toBeInTheDocument();
+  });
+
+  it("shows loading state in chart area when active range is loading", () => {
+    render(
+      <PriceSparkline
+        rangeData={{}}
+        loadingRanges={new Set(["24h"])}
+      />
+    );
+    expect(screen.getByRole("status")).toBeInTheDocument();
+    expect(screen.getByText(/loading price data/i)).toBeInTheDocument();
+  });
+});
+
+describe("PriceSparkline – missing / empty data", () => {
+  it("shows 'no price data' message when data array is empty for active range", () => {
+    render(<PriceSparkline rangeData={{ "24h": [] }} />);
+    expect(screen.getByText(/no price data available for 24h/i)).toBeInTheDocument();
+  });
+
+  it("shows 'no price data' when rangeData has no key for active range", () => {
+    render(<PriceSparkline rangeData={{}} />);
+    expect(screen.getByText(/no price data available for 24h/i)).toBeInTheDocument();
+  });
+
+  it("renders the SVG chart when data is present", () => {
+    const { container } = render(<PriceSparkline rangeData={FULL_DATA} />);
+    expect(container.querySelector("svg")).toBeInTheDocument();
+  });
+});

--- a/frontend/components/shared/PriceSparkline.tsx
+++ b/frontend/components/shared/PriceSparkline.tsx
@@ -1,46 +1,227 @@
 "use client";
 
-import { useMemo, useState } from "react";
+/**
+ * PriceSparkline — sparkline chart with a time-range selector (issue #518).
+ *
+ * Time ranges: 1h · 24h · 7d
+ *  - Each button shows a loading spinner while data is being fetched.
+ *  - The selected range for each trading pair is remembered for the session
+ *    via sessionStorage (key: `sparkline_range_<pairKey>`).
+ *  - If no data is available for the selected range the component shows a
+ *    friendly "No price data" message instead of breaking.
+ */
 
-type PricePoint = {
+import { useMemo, useState, useEffect, useCallback } from "react";
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export type SparklineRange = "1h" | "24h" | "7d";
+
+export type PricePoint = {
   timestamp: number;
   price: number;
 };
 
-type Props = {
-  data?: PricePoint[];
-};
+export type RangeDataMap = Partial<Record<SparklineRange, PricePoint[]>>;
 
-export default function PriceSparkline({ data }: Props) {
+interface Props {
+  /**
+   * Pre-fetched price data keyed by range.
+   * Pass `undefined` (or omit a key) to indicate data is still loading for
+   * that range. Pass an empty array `[]` to indicate no data available.
+   */
+  rangeData?: RangeDataMap;
+  /**
+   * Which ranges are currently being loaded. When a range is in this set the
+   * corresponding button shows a loading indicator.
+   */
+  loadingRanges?: Set<SparklineRange>;
+  /**
+   * Unique key for the trading pair (e.g. "XLM/USDC").
+   * Used to persist / restore the selected range in sessionStorage.
+   */
+  pairKey?: string;
+  /** Callback fired when the user picks a new range. */
+  onRangeChange?: (range: SparklineRange) => void;
+}
+
+const RANGES: SparklineRange[] = ["1h", "24h", "7d"];
+const SESSION_KEY = (pair: string) => `sparkline_range_${pair}`;
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export default function PriceSparkline({
+  rangeData = {},
+  loadingRanges = new Set(),
+  pairKey = "default",
+  onRangeChange,
+}: Props) {
+  // Restore the user's last-chosen range from sessionStorage (falls back to "24h")
+  const [range, setRange] = useState<SparklineRange>(() => {
+    if (typeof window === "undefined") return "24h";
+    try {
+      const stored = sessionStorage.getItem(SESSION_KEY(pairKey));
+      if (stored && RANGES.includes(stored as SparklineRange)) {
+        return stored as SparklineRange;
+      }
+    } catch {
+      // sessionStorage unavailable — proceed with default
+    }
+    return "24h";
+  });
+
+  // Persist selection whenever pairKey or range changes
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      sessionStorage.setItem(SESSION_KEY(pairKey), range);
+    } catch {
+      // ignore
+    }
+  }, [pairKey, range]);
+
+  // When the pairKey changes, restore the saved preference for the new pair
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    try {
+      const stored = sessionStorage.getItem(SESSION_KEY(pairKey));
+      if (stored && RANGES.includes(stored as SparklineRange)) {
+        setRange(stored as SparklineRange);
+      } else {
+        setRange("24h");
+      }
+    } catch {
+      setRange("24h");
+    }
+  }, [pairKey]);
+
+  const handleRangeSelect = useCallback(
+    (r: SparklineRange) => {
+      setRange(r);
+      onRangeChange?.(r);
+    },
+    [onRangeChange]
+  );
+
+  const data = rangeData[range];
+  const isLoading = loadingRanges.has(range);
+
+  return (
+    <div className="w-full space-y-2">
+      {/* ── Range selector buttons ── */}
+      <div
+        className="flex gap-1"
+        role="group"
+        aria-label="Sparkline time range"
+      >
+        {RANGES.map((r) => (
+          <RangeButton
+            key={r}
+            label={r}
+            active={range === r}
+            loading={loadingRanges.has(r)}
+            onClick={() => handleRangeSelect(r)}
+          />
+        ))}
+      </div>
+
+      {/* ── Chart area ── */}
+      {isLoading ? (
+        <LoadingState />
+      ) : !data || data.length === 0 ? (
+        <EmptyState range={range} />
+      ) : (
+        <SparklineChart data={data} />
+      )}
+    </div>
+  );
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface RangeButtonProps {
+  label: SparklineRange;
+  active: boolean;
+  loading: boolean;
+  onClick: () => void;
+}
+
+function RangeButton({ label, active, loading, onClick }: RangeButtonProps) {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-pressed={active}
+      aria-label={`${label} range${loading ? ", loading" : ""}`}
+      className={[
+        "inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs font-medium transition-colors",
+        "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring",
+        active
+          ? "bg-primary text-primary-foreground"
+          : "bg-muted text-muted-foreground hover:bg-muted/80",
+      ].join(" ")}
+    >
+      {loading && (
+        <span
+          className="inline-block h-2.5 w-2.5 rounded-full border border-current border-t-transparent animate-spin"
+          aria-hidden="true"
+        />
+      )}
+      {label}
+    </button>
+  );
+}
+
+function LoadingState() {
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className="h-16 flex items-center justify-center"
+    >
+      <span className="inline-block h-4 w-4 rounded-full border-2 border-primary border-t-transparent animate-spin mr-2" />
+      <span className="text-xs text-muted-foreground">Loading price data…</span>
+    </div>
+  );
+}
+
+function EmptyState({ range }: { range: SparklineRange }) {
+  return (
+    <div
+      role="status"
+      className="h-16 flex items-center"
+    >
+      <p className="text-xs text-muted-foreground">
+        No price data available for {range}
+      </p>
+    </div>
+  );
+}
+
+// ─── Chart ────────────────────────────────────────────────────────────────────
+
+interface SparklineChartProps {
+  data: PricePoint[];
+}
+
+function SparklineChart({ data }: SparklineChartProps) {
   const [hoveredIndex, setHoveredIndex] = useState<number | null>(null);
 
-  if (!data || data.length === 0) {
-    return (
-      <div className="text-xs text-muted-foreground">
-        No price data (24h)
-      </div>
-    );
-  }
-
-  // ✅ Limit points for performance
+  // Keep at most 50 points for performance
   const sliced = useMemo(() => data.slice(-50), [data]);
 
   const { points, normalized } = useMemo(() => {
-    const max = Math.max(...sliced.map(d => d.price));
-    const min = Math.min(...sliced.map(d => d.price));
+    const max = Math.max(...sliced.map((d) => d.price));
+    const min = Math.min(...sliced.map((d) => d.price));
 
     const normalized = sliced.map((d, i) => {
-      const x = (i / (sliced.length - 1)) * 100;
+      const x = (i / Math.max(sliced.length - 1, 1)) * 100;
       const y =
-        max === min
-          ? 50
-          : 100 - ((d.price - min) / (max - min)) * 100;
-
+        max === min ? 50 : 100 - ((d.price - min) / (max - min)) * 100;
       return { x, y, ...d };
     });
 
-    const points = normalized.map(p => `${p.x},${p.y}`).join(" ");
-
+    const points = normalized.map((p) => `${p.x},${p.y}`).join(" ");
     return { points, normalized };
   }, [sliced]);
 
@@ -50,16 +231,16 @@ export default function PriceSparkline({ data }: Props) {
         <svg
           viewBox="0 0 100 100"
           className="w-full h-full"
+          aria-label="Price sparkline chart"
+          role="img"
           onMouseMove={(e) => {
             const rect = e.currentTarget.getBoundingClientRect();
             const x = e.clientX - rect.left;
             const percent = x / rect.width;
-
             const index = Math.min(
               normalized.length - 1,
               Math.max(0, Math.round(percent * (normalized.length - 1)))
             );
-
             setHoveredIndex(index);
           }}
           onMouseLeave={() => setHoveredIndex(null)}
@@ -70,8 +251,6 @@ export default function PriceSparkline({ data }: Props) {
             strokeWidth="2"
             points={points}
           />
-
-          {/* Optional hover dot */}
           {hoveredIndex !== null && normalized[hoveredIndex] && (
             <circle
               cx={normalized[hoveredIndex].x}
@@ -83,7 +262,7 @@ export default function PriceSparkline({ data }: Props) {
         </svg>
       </div>
 
-      {/* ✅ Tooltip */}
+      {/* Hover tooltip */}
       {hoveredIndex !== null && normalized[hoveredIndex] && (
         <div className="text-xs mt-1 text-muted-foreground tabular-nums">
           {new Date(normalized[hoveredIndex].timestamp).toLocaleTimeString()} —{" "}

--- a/frontend/docs/debug-overlay.md
+++ b/frontend/docs/debug-overlay.md
@@ -1,0 +1,69 @@
+# Developer Debug Overlay
+
+> Issue [#517](https://github.com/StellarRoute/StellarRoute/issues/517)
+
+A floating dev-only panel that displays diagnostic data (quote IDs, snapshot versions, and performance timings) to help developers diagnose routing and data issues without touching prod users.
+
+---
+
+## Activation
+
+| Method | How |
+|--------|-----|
+| **Keyboard shortcut** | `Ctrl + Shift + D` (Windows / Linux) or `Cmd + Shift + D` (macOS) — toggles the panel on / off |
+| **Query parameter** | Append `?debug=1` (or `?debug=true`) to any URL — panel opens automatically on load |
+
+---
+
+## What is displayed
+
+| Field | Description |
+|-------|-------------|
+| **Quote ID** | Unique identifier of the quote currently shown in the panel |
+| **Snapshot** | Version/revision of the price snapshot used for the current quote |
+| **Timings** | Arbitrary `key → milliseconds` entries (e.g. `quoteLatency`, `renderTime`) |
+| **Overlay age** | How many milliseconds the panel component has been mounted — useful to detect unexpected remounts |
+
+---
+
+## Security
+
+* **Stellar wallet addresses** (56-character base32 strings starting with `G`) are automatically **masked** to `GABC…WXYZ` format — the first 4 and last 4 characters only.
+* No other wallet data (private keys, seed phrases, balances) is ever passed to or displayed by this component.
+* The component **hard-gates** on `process.env.NODE_ENV === 'production'` and returns `null` before rendering anything, so **it is impossible for the overlay to appear in production builds**.
+
+---
+
+## Usage in a page / component
+
+```tsx
+import { DebugOverlay } from '@/components/debug/DebugOverlay';
+
+// Minimal usage — panel is toggled by keyboard / query param
+<DebugOverlay />
+
+// With data
+<DebugOverlay
+  info={{
+    quoteId: quote.id,
+    snapshotVersion: snapshot.version,
+    timings: {
+      quoteLatency: performance.now() - fetchStart,
+      renderTime: performance.now() - renderStart,
+    },
+  }}
+/>
+```
+
+The overlay is already mounted inside `AppShell` so it is available on every page. You only need to provide the `info` prop if you want to surface page-specific data.
+
+---
+
+## Disabling the overlay
+
+The overlay is development-only. No action is needed for production — the build-time `NODE_ENV` guard ensures zero overhead.
+
+To prevent it loading in a specific test or Storybook story, either:
+
+1. Mock `process.env.NODE_ENV` to `'production'`.
+2. Wrap the component with a feature flag check before rendering.

--- a/frontend/types/settings.ts
+++ b/frontend/types/settings.ts
@@ -2,14 +2,51 @@ import { Locale, DEFAULT_LOCALE } from '@/lib/formatting';
 
 export type ThemeSetting = 'light' | 'dark' | 'system';
 
+/**
+ * Preset accent colour tokens available in the colour picker (issue #521).
+ * Each value maps to a CSS hex colour that is applied to --primary.
+ */
+export const ACCENT_COLORS = {
+  indigo: '#6366f1',
+  sky: '#0ea5e9',
+  emerald: '#10b981',
+  rose: '#f43f5e',
+  amber: '#f59e0b',
+  violet: '#8b5cf6',
+} as const;
+
+export type AccentColor = keyof typeof ACCENT_COLORS;
+
+export const DEFAULT_ACCENT_COLOR: AccentColor = 'indigo';
+
+/**
+ * Font scale setting (issue #522).
+ * Represents a multiplier applied to the root font size.
+ * Range: 1.0 (100%) to 2.0 (200%), step 0.25.
+ */
+export type FontScale = 1.0 | 1.25 | 1.5 | 1.75 | 2.0;
+
+export const FONT_SCALE_OPTIONS: FontScale[] = [1.0, 1.25, 1.5, 1.75, 2.0];
+
+export const DEFAULT_FONT_SCALE: FontScale = 1.0;
+
 export interface Settings {
   slippageTolerance: number;
   theme: ThemeSetting;
   locale: Locale;
+  /** User-chosen accent colour applied to primary actions (issue #521). */
+  accentColor: AccentColor;
+  /**
+   * Root font-size multiplier for accessibility (issue #522).
+   * 1.0 = 100% (default), 2.0 = 200%.
+   */
+  fontScale: FontScale;
 }
 
 export const DEFAULT_SETTINGS: Settings = {
   slippageTolerance: 0.5,
   theme: 'system',
   locale: DEFAULT_LOCALE,
+  accentColor: DEFAULT_ACCENT_COLOR,
+  fontScale: DEFAULT_FONT_SCALE,
 };


### PR DESCRIPTION
…font scale

Issue #517 – Developer debug overlay
- Add DebugOverlay component (components/debug/DebugOverlay.tsx)
  * Toggled via Ctrl/Cmd+Shift+D keyboard shortcut or ?debug=1 query param
  * Displays quote IDs, snapshot versions, and performance timings
  * Hard-gated behind process.env.NODE_ENV !== 'production' — never renders in prod
  * Masks Stellar wallet addresses (G…) to prevent sensitive data exposure
- Mount DebugOverlay inside AppShell via Suspense boundary
- Add unit tests (DebugOverlay.test.tsx) — toggle, close, masking, timings display
- Add developer documentation (frontend/docs/debug-overlay.md)

Issue #518 – Time range selector controlling sparkline data window on quote panel
- Rewrite PriceSparkline with 1h / 24h / 7d range selector buttons
  * Per-button loading spinners via loadingRanges prop
  * Selected range persisted per trading pair in sessionStorage (pairKey prop)
  * Graceful empty / missing-data state per range
  * onRangeChange callback for parent data-fetching integration
- Add unit tests (PriceSparkline.test.tsx) — range switch, session restore, loading states, empty data, SVG render

Issue #521 – Allow users to choose accent colour applied to primary actions
- Add AccentColor type + ACCENT_COLORS presets to types/settings.ts (indigo / sky / emerald / rose / amber / violet)
- Add AccentColorPicker component with swatch grid + free-form colour input
- SettingsProvider: updateAccentColor() applies --primary, --ring, --sidebar-primary CSS custom properties instantly on :root
- Surface AccentColorPicker in Appearance card on /settings page
- Add unit tests (AccentColorPicker.test.tsx)

Issue #522 – Respect user font scale preference up to 200% without layout breakage
- Add FontScale type + FONT_SCALE_OPTIONS [1, 1.25, 1.5, 1.75, 2] to types/settings.ts
- Add FontScaleControl component with preset buttons, range slider, ARIA live values, and a live preview box
- SettingsProvider: updateFontScale() sets font-size on <html> as 16px × scale so all rem-based layout scales proportionally without breakage (mobile + desktop)
- Surface FontScaleControl in new Accessibility card on /settings page
- Add unit tests (FontScaleControl.test.tsx)

Closes #517
Closes #518
Closes #521
Closes #522