### PR TITLE
[#464] [design] Trader-facing error copy and tone style guide

### DIFF
--- a/crates/api/benches/cache_invalidation_load.rs
+++ b/crates/api/benches/cache_invalidation_load.rs
@@ -8,7 +8,6 @@
  *   - Liquidity updates arriving at 50/sec
  *   - Measures: invalidation latency, stale read rate, memory usage
  */
-
 use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use std::collections::HashSet;
 
@@ -53,11 +52,7 @@ fn invalidate_full_clear(cache: &mut SimpleCacheStore, _updated_pair: &str, cach
 }
 
 // Strategy 2: Pair-level invalidation (basic)
-fn invalidate_pair_level(
-    cache: &mut SimpleCacheStore,
-    updated_pair: &str,
-    pairs_per_quote: usize,
-) {
+fn invalidate_pair_level(cache: &mut SimpleCacheStore, updated_pair: &str, pairs_per_quote: usize) {
     // Simulate deleting only quotes/routes for this pair
     for i in 0..pairs_per_quote * 2 {
         let key = format!("{}:route:{}", updated_pair, i);
@@ -128,7 +123,11 @@ fn benchmark_invalidation_strategies(c: &mut Criterion) {
             for i in 0..total_cache_entries {
                 cache_clone.set(format!("key_{}", i), "val".to_string());
             }
-            invalidate_full_clear(black_box(&mut cache_clone), "pair_5000", total_cache_entries);
+            invalidate_full_clear(
+                black_box(&mut cache_clone),
+                "pair_5000",
+                total_cache_entries,
+            );
             assert_eq!(cache_clone.size(), 0);
         });
     });
@@ -140,11 +139,7 @@ fn benchmark_invalidation_strategies(c: &mut Criterion) {
             for i in 0..total_cache_entries {
                 cache_clone.set(format!("key_{}", i), "val".to_string());
             }
-            invalidate_pair_level(
-                black_box(&mut cache_clone),
-                "pair_5000",
-                quotes_per_pair,
-            );
+            invalidate_pair_level(black_box(&mut cache_clone), "pair_5000", quotes_per_pair);
             // Should have deleted ~20 entries (10 quotes + 10 routes)
             assert!(cache_clone.size() > total_cache_entries - 30);
         });
@@ -152,9 +147,7 @@ fn benchmark_invalidation_strategies(c: &mut Criterion) {
 
     // Benchmark 3: Hierarchical graph invalidation
     // Simulate a pair that affects 50 dependent pairs (realistic for multi-hop routes)
-    let affected_pairs: Vec<String> = (0..50)
-        .map(|i| format!("pair_{}", 5000 + i))
-        .collect();
+    let affected_pairs: Vec<String> = (0..50).map(|i| format!("pair_{}", 5000 + i)).collect();
 
     group.bench_function("hierarchical_50_dependent_pairs", |b| {
         b.iter(|| {
@@ -171,14 +164,16 @@ fn benchmark_invalidation_strategies(c: &mut Criterion) {
             // Should delete: 20 (direct) + 50*20 (dependent) = 1020 entries
             let expected_deletions = 20 + (50 * 20);
             let remaining = cache_clone.size();
-            assert!(remaining < total_cache_entries && remaining > (total_cache_entries - expected_deletions - 100));
+            assert!(
+                remaining < total_cache_entries
+                    && remaining > (total_cache_entries - expected_deletions - 100)
+            );
         });
     });
 
     // Benchmark 4: Hierarchical with larger dependency tree
-    let large_affected_pairs: Vec<String> = (0..500)
-        .map(|i| format!("pair_{}", 5000 + i))
-        .collect();
+    let large_affected_pairs: Vec<String> =
+        (0..500).map(|i| format!("pair_{}", 5000 + i)).collect();
 
     group.bench_function("hierarchical_500_dependent_pairs", |b| {
         b.iter(|| {

--- a/crates/api/src/budget.rs
+++ b/crates/api/src/budget.rs
@@ -3,10 +3,10 @@
 //! This module implements per-stage timing budgets for the quote pipeline
 //! to prevent runaway latency and protect SLOs.
 
+use prometheus::{register_histogram_vec, register_int_counter_vec, HistogramVec, IntCounterVec};
+use serde::{Deserialize, Serialize};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
-use serde::{Deserialize, Serialize};
-use prometheus::{IntCounterVec, HistogramVec, register_int_counter_vec, register_histogram_vec};
 
 lazy_static::lazy_static! {
     /// Counter for budget overrun events by stage

--- a/crates/api/src/cache/invalidation_graph.rs
+++ b/crates/api/src/cache/invalidation_graph.rs
@@ -10,7 +10,6 @@
  *     and parent pairs that use (A,B) as intermediate
  *   - Fallback: if graph insertion fails, fall back to full cache clear
  */
-
 use dashmap::DashMap;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
@@ -60,10 +59,7 @@ pub enum CacheKey {
         route_hash: String,
     },
     /// Orderbook cache key: pair
-    Orderbook {
-        base: String,
-        quote: String,
-    },
+    Orderbook { base: String, quote: String },
 }
 
 impl CacheKey {
@@ -77,7 +73,11 @@ impl CacheKey {
 
     pub fn to_string(&self) -> String {
         match self {
-            CacheKey::Quote { base, quote, amount } => {
+            CacheKey::Quote {
+                base,
+                quote,
+                amount,
+            } => {
                 format!("quote:{}:{}:{}", base, quote, amount)
             }
             CacheKey::Route {
@@ -233,16 +233,8 @@ impl PairInvalidationGraph {
         GraphSize {
             pair_quote_entries: self.pair_to_quotes.len(),
             pair_route_entries: self.pair_to_routes.len(),
-            total_quote_keys: self
-                .pair_to_quotes
-                .iter()
-                .map(|r| r.value().len())
-                .sum(),
-            total_route_keys: self
-                .pair_to_routes
-                .iter()
-                .map(|r| r.value().len())
-                .sum(),
+            total_quote_keys: self.pair_to_quotes.iter().map(|r| r.value().len()).sum(),
+            total_route_keys: self.pair_to_routes.iter().map(|r| r.value().len()).sum(),
             dependency_edges: self.pair_to_children.len(),
         }
     }

--- a/crates/api/src/reconciliation.rs
+++ b/crates/api/src/reconciliation.rs
@@ -212,7 +212,10 @@ impl ReconciliationJob {
     }
 
     /// Check a single cached quote against live computation
-    async fn check_single_quote(&self, sample: &CachedQuoteSample) -> Result<Option<ReconciliationResult>> {
+    async fn check_single_quote(
+        &self,
+        sample: &CachedQuoteSample,
+    ) -> Result<Option<ReconciliationResult>> {
         // This would:
         // 1. Parse the cached quote
         // 2. Compute a fresh quote for the same parameters
@@ -257,9 +260,7 @@ impl ReconciliationJob {
             } else {
                 "low"
             };
-            DRIFT_DETECTIONS
-                .with_label_values(&[severity])
-                .inc();
+            DRIFT_DETECTIONS.with_label_values(&[severity]).inc();
             DRIFT_MAGNITUDE
                 .with_label_values(&[&result.pair])
                 .set(result.drift_pct);

--- a/crates/api/src/routes/idempotent_quote.rs
+++ b/crates/api/src/routes/idempotent_quote.rs
@@ -123,8 +123,8 @@ pub async fn post_quote(
         };
         if let Ok(cached_bytes) = state.idempotency_ledger.lookup(&identity).await {
             debug!("Idempotency cache hit for key: {}", key);
-            let quote_resp: crate::models::QuoteResponse =
-                serde_json::from_slice(&cached_bytes).map_err(|e| {
+            let quote_resp: crate::models::QuoteResponse = serde_json::from_slice(&cached_bytes)
+                .map_err(|e| {
                     ApiError::Internal(Arc::new(anyhow::anyhow!(
                         "Failed to deserialise cached quote: {e}"
                     )))

--- a/crates/api/src/routes/metrics.rs
+++ b/crates/api/src/routes/metrics.rs
@@ -100,10 +100,7 @@ impl PoolStats {
 )]
 pub async fn pool_stats(State(state): State<Arc<AppState>>) -> Json<PoolStatsResponse> {
     let primary = PoolStats::from_pool(state.db.write_pool());
-    let replica = state
-        .db
-        .replica_pool()
-        .map(PoolStats::from_pool);
+    let replica = state.db.replica_pool().map(PoolStats::from_pool);
 
     Json(PoolStatsResponse { primary, replica })
 }

--- a/crates/api/src/serialization.rs
+++ b/crates/api/src/serialization.rs
@@ -29,9 +29,7 @@ pub trait DeterministicSerialize: Serialize + for<'de> Deserialize<'de> + Sized 
                 }
                 Value::Object(sorted.into_iter().collect())
             }
-            Value::Array(arr) => {
-                Value::Array(arr.into_iter().map(Self::normalize_value).collect())
-            }
+            Value::Array(arr) => Value::Array(arr.into_iter().map(Self::normalize_value).collect()),
             Value::Number(n) => {
                 if let Some(f) = n.as_f64() {
                     if f.is_nan() || f.is_infinite() {

--- a/crates/api/src/simulation.rs
+++ b/crates/api/src/simulation.rs
@@ -195,10 +195,7 @@ impl SorobanSimulator {
             "params": { "transaction": transaction_xdr }
         });
 
-        debug!(
-            "Calling simulateTransaction on {}",
-            self.config.rpc_url
-        );
+        debug!("Calling simulateTransaction on {}", self.config.rpc_url);
 
         let resp = self
             .http
@@ -212,8 +209,7 @@ impl SorobanSimulator {
             return Err(format!("HTTP {}", resp.status()));
         }
 
-        let payload: SimulateTransactionResponse =
-            resp.json().await.map_err(|e| e.to_string())?;
+        let payload: SimulateTransactionResponse = resp.json().await.map_err(|e| e.to_string())?;
 
         if let Some(err) = payload.error {
             return Ok(SimulationResult {
@@ -377,10 +373,7 @@ mod tests {
 
         let result = sim.simulate("AAAA_XDR").await;
         assert!(!result.simulated);
-        assert_eq!(
-            result.failure_reason.as_deref(),
-            Some("timeout")
-        );
+        assert_eq!(result.failure_reason.as_deref(), Some("timeout"));
     }
 
     #[tokio::test]

--- a/crates/api/tests/budget_enforcement_test.rs
+++ b/crates/api/tests/budget_enforcement_test.rs
@@ -100,7 +100,10 @@ fn budget_tracker_aggregates_multiple_stages() {
     let summary = tracker.finish();
 
     assert_eq!(summary.stage_results.len(), 3);
-    assert!(!summary.has_overruns(), "All stages should be within budget");
+    assert!(
+        !summary.has_overruns(),
+        "All stages should be within budget"
+    );
 }
 
 #[test]
@@ -125,7 +128,9 @@ fn budget_tracker_detects_overruns() {
 
     assert!(summary.has_overruns(), "Should detect overruns");
     assert!(
-        summary.overbudget_stages.contains(&PipelineStage::FetchCandidates),
+        summary
+            .overbudget_stages
+            .contains(&PipelineStage::FetchCandidates),
         "FetchCandidates should be over budget"
     );
 }

--- a/crates/api/tests/deterministic_serialization_test.rs
+++ b/crates/api/tests/deterministic_serialization_test.rs
@@ -4,9 +4,9 @@
 //! so clients and tests can compare outputs reliably.
 
 use stellarroute_api::serialization::{
-    DeterministicSerialize, NormalizedAnomaly, NormalizedExclusion, NormalizedHop,
-    NormalizedPolicy, NormalizedAlternative, NormalizedRouteDiagnostics,
-    NormalizedRouteMetrics, NormalizedSwapPath,
+    DeterministicSerialize, NormalizedAlternative, NormalizedAnomaly, NormalizedExclusion,
+    NormalizedHop, NormalizedPolicy, NormalizedRouteDiagnostics, NormalizedRouteMetrics,
+    NormalizedSwapPath,
 };
 
 fn make_sample_diagnostics() -> NormalizedRouteDiagnostics {
@@ -112,7 +112,9 @@ fn field_ordering_is_deterministic() {
     let json_str = String::from_utf8(json.clone()).expect("valid utf8");
 
     // Verify that fields appear in sorted order
-    let selected_path_pos = json_str.find("\"selected_path\"").expect("selected_path field");
+    let selected_path_pos = json_str
+        .find("\"selected_path\"")
+        .expect("selected_path field");
     let metrics_pos = json_str.find("\"metrics\"").expect("metrics field");
     let policy_pos = json_str.find("\"policy\"").expect("policy field");
 
@@ -145,7 +147,10 @@ fn normalization_handles_nan_and_infinity() {
     assert!(obj["valid_number"].is_number(), "valid numbers preserved");
     assert!(obj["nan_value"].is_null(), "NaN becomes null");
     assert!(obj["infinity_value"].is_null(), "infinity becomes null");
-    assert!(obj["neg_infinity"].is_null(), "negative infinity becomes null");
+    assert!(
+        obj["neg_infinity"].is_null(),
+        "negative infinity becomes null"
+    );
 }
 
 #[test]

--- a/crates/api/tests/reconciliation_test.rs
+++ b/crates/api/tests/reconciliation_test.rs
@@ -10,7 +10,10 @@ use stellarroute_api::reconciliation::{
 #[test]
 fn calculate_drift_handles_equal_prices() {
     let drift = calculate_drift(100.0, 100.0);
-    assert!((drift - 0.0).abs() < 0.001, "Equal prices should have zero drift");
+    assert!(
+        (drift - 0.0).abs() < 0.001,
+        "Equal prices should have zero drift"
+    );
 }
 
 #[test]
@@ -40,7 +43,10 @@ fn calculate_drift_handles_both_zero() {
 #[test]
 fn calculate_drift_handles_negative_drift() {
     let drift = calculate_drift(100.0, 99.0);
-    assert!((drift - 1.0).abs() < 0.001, "Should calculate 1% drift for price decrease");
+    assert!(
+        (drift - 1.0).abs() < 0.001,
+        "Should calculate 1% drift for price decrease"
+    );
 }
 
 #[test]
@@ -93,7 +99,10 @@ fn reconciliation_action_equality() {
         ReconciliationAction::CacheInvalidated,
         ReconciliationAction::CacheInvalidated
     );
-    assert_ne!(ReconciliationAction::None, ReconciliationAction::AlertTriggered);
+    assert_ne!(
+        ReconciliationAction::None,
+        ReconciliationAction::AlertTriggered
+    );
 }
 
 #[test]

--- a/crates/routing/benches/hybrid_optimizer_benchmarks.rs
+++ b/crates/routing/benches/hybrid_optimizer_benchmarks.rs
@@ -264,11 +264,9 @@ fn bench_scorer_throughput(c: &mut Criterion) {
     let registry = ScorerRegistry::new();
     for (name, scorer) in registry.iter() {
         let scorer_name = name.to_string();
-        group.bench_with_input(
-            BenchmarkId::new("score", &scorer_name),
-            &input,
-            |b, inp| b.iter(|| black_box(scorer.score(black_box(inp)))),
-        );
+        group.bench_with_input(BenchmarkId::new("score", &scorer_name), &input, |b, inp| {
+            b.iter(|| black_box(scorer.score(black_box(inp))))
+        });
     }
 
     // Also benchmark via registry (includes clamping overhead)

--- a/crates/routing/src/amm_fallback.rs
+++ b/crates/routing/src/amm_fallback.rs
@@ -144,7 +144,12 @@ impl TieredAmmFallback {
 
         if !live.is_empty() {
             let dropped = candidates.len() - live.len();
-            tracing::debug!(tier = "live_amm", kept = live.len(), dropped, "fallback resolved");
+            tracing::debug!(
+                tier = "live_amm",
+                kept = live.len(),
+                dropped,
+                "fallback resolved"
+            );
             return Ok(FallbackResult {
                 tier: AmmFallbackTier::LiveAmm,
                 edges: live,
@@ -156,9 +161,7 @@ impl TieredAmmFallback {
         // Tier 1 – cached AMM (AMM edges beyond live threshold but within max_cache_age)
         let cached: Vec<LiquidityEdge> = candidates
             .iter()
-            .filter(|c| {
-                c.edge.venue_type == "amm" && c.data_age < self.config.max_cache_age
-            })
+            .filter(|c| c.edge.venue_type == "amm" && c.data_age < self.config.max_cache_age)
             .map(|c| c.edge.clone())
             .collect();
 
@@ -204,7 +207,10 @@ impl TieredAmmFallback {
         }
 
         // Tier 3 – nothing viable
-        tracing::error!(tier = "empty", "all fallback tiers exhausted; no viable edges");
+        tracing::error!(
+            tier = "empty",
+            "all fallback tiers exhausted; no viable edges"
+        );
         Err(FallbackError::NoViableEdges)
     }
 }
@@ -300,7 +306,10 @@ mod tests {
             data_age: Duration::from_secs(9999),
         }];
         // SDEX-only fallback won't help since there are no SDEX edges.
-        assert!(matches!(strategy.resolve(&candidates), Err(FallbackError::NoViableEdges)));
+        assert!(matches!(
+            strategy.resolve(&candidates),
+            Err(FallbackError::NoViableEdges)
+        ));
     }
 
     #[test]
@@ -320,7 +329,10 @@ mod tests {
                 data_age: Duration::from_secs(5),
             },
         ];
-        assert!(matches!(strategy.resolve(&candidates), Err(FallbackError::NoViableEdges)));
+        assert!(matches!(
+            strategy.resolve(&candidates),
+            Err(FallbackError::NoViableEdges)
+        ));
     }
 
     #[test]
@@ -366,6 +378,9 @@ mod tests {
     #[test]
     fn test_empty_candidates_returns_error() {
         let strategy = default_strategy();
-        assert!(matches!(strategy.resolve(&[]), Err(FallbackError::NoViableEdges)));
+        assert!(matches!(
+            strategy.resolve(&[]),
+            Err(FallbackError::NoViableEdges)
+        ));
     }
 }

--- a/crates/routing/src/bin/fixture_gen.rs
+++ b/crates/routing/src/bin/fixture_gen.rs
@@ -160,12 +160,11 @@ fn output_json(builder: &FixtureBuilder, name: &str, output: Option<PathBuf>) ->
         }).collect::<Vec<_>>(),
     });
 
-    let content = serde_json::to_string_pretty(&fixture)
-        .context("failed to serialize fixture to JSON")?;
+    let content =
+        serde_json::to_string_pretty(&fixture).context("failed to serialize fixture to JSON")?;
 
     if let Some(path) = output {
-        fs::write(&path, content)
-            .context(format!("failed to write JSON fixture to {:?}", path))?;
+        fs::write(&path, content).context(format!("failed to write JSON fixture to {:?}", path))?;
         println!("✓ JSON fixture written to {}", path.display());
     } else {
         println!("{}", content);

--- a/crates/routing/src/execution_quality.rs
+++ b/crates/routing/src/execution_quality.rs
@@ -37,7 +37,10 @@ pub struct WeightBounds {
 
 impl Default for WeightBounds {
     fn default() -> Self {
-        Self { min: 0.1, max: 0.95 }
+        Self {
+            min: 0.1,
+            max: 0.95,
+        }
     }
 }
 
@@ -139,20 +142,23 @@ impl ExecutionQualityTracker {
         let alpha = self.config.ema_alpha;
 
         let mut guard = self.state.write().expect("weight state lock poisoned");
-        let entry = guard.entry(obs.source.clone()).or_insert_with(|| SourceState {
-            source: obs.source.clone(),
-            quality_ema: self.config.default_weight,
-            error_rate_ema: 0.0,
-            weight: self.config.default_weight,
-            observation_count: 0,
-        });
+        let entry = guard
+            .entry(obs.source.clone())
+            .or_insert_with(|| SourceState {
+                source: obs.source.clone(),
+                quality_ema: self.config.default_weight,
+                error_rate_ema: 0.0,
+                weight: self.config.default_weight,
+                observation_count: 0,
+            });
 
         let prev_weight = entry.weight;
         entry.quality_ema = alpha * quality_score + (1.0 - alpha) * entry.quality_ema;
         entry.error_rate_ema = alpha * error_signal + (1.0 - alpha) * entry.error_rate_ema;
         entry.observation_count += 1;
 
-        let raw_weight = entry.quality_ema * (1.0 - self.config.error_penalty * entry.error_rate_ema);
+        let raw_weight =
+            entry.quality_ema * (1.0 - self.config.error_penalty * entry.error_rate_ema);
         entry.weight = raw_weight.clamp(self.config.bounds.min, self.config.bounds.max);
 
         info!(
@@ -217,7 +223,10 @@ mod tests {
         ExecutionQualityTracker::new(QualityTrackerConfig {
             ema_alpha: 0.5,
             default_weight: 0.5,
-            bounds: WeightBounds { min: 0.1, max: 0.95 },
+            bounds: WeightBounds {
+                min: 0.1,
+                max: 0.95,
+            },
             error_penalty: 0.5,
         })
     }
@@ -239,7 +248,10 @@ mod tests {
             });
         }
         let w = tracker.weight_for("amm");
-        assert!(w > 0.5, "weight should increase with consistent high quality; got {w}");
+        assert!(
+            w > 0.5,
+            "weight should increase with consistent high quality; got {w}"
+        );
         assert!(w <= 0.95, "weight must not exceed max bound; got {w}");
     }
 
@@ -265,7 +277,10 @@ mod tests {
             });
         }
         let w_after = tracker.weight_for("sdex");
-        assert!(w_after < w_before, "errors should reduce weight; before={w_before}, after={w_after}");
+        assert!(
+            w_after < w_before,
+            "errors should reduce weight; before={w_before}, after={w_after}"
+        );
     }
 
     #[test]
@@ -367,7 +382,13 @@ mod tests {
         let dynamic_sdex = tracker.weight_for("sdex");
 
         // Dynamic weights should diverge from static
-        assert!(dynamic_amm > static_amm, "dynamic amm weight should exceed static after good performance");
-        assert!(dynamic_sdex < static_sdex, "dynamic sdex weight should fall below static after poor performance");
+        assert!(
+            dynamic_amm > static_amm,
+            "dynamic amm weight should exceed static after good performance"
+        );
+        assert!(
+            dynamic_sdex < static_sdex,
+            "dynamic sdex weight should fall below static after poor performance"
+        );
     }
 }

--- a/crates/routing/src/lib.rs
+++ b/crates/routing/src/lib.rs
@@ -26,10 +26,14 @@ pub mod snapshot;
 
 pub use adaptive_routing::{AdaptiveError, AdaptivePolicy, AdaptiveRouter, QualityMetrics};
 pub use adaptive_timeout::{TimeoutConfig, TimeoutController};
+pub use amm_fallback::{AmmFallbackConfig, AmmFallbackTier, FallbackResult, TieredAmmFallback};
 pub use canary::{CanaryConfig, CanaryEvaluation, CanaryEvaluator};
 pub use compaction::{CompactedEdge, CompactedGraph};
 pub use consensus::{
     ConsensusDiagnostics, ConsensusEngine, ConsensusError, ConsensusPolicy, RouteCandidate,
+};
+pub use execution_quality::{
+    ExecutionQualityTracker, QualityObservation, QualityTrackerConfig, SourceState, WeightBounds,
 };
 pub use impact::{AmmQuoteCalculator, OrderbookImpactCalculator};
 pub use optimizer::{
@@ -37,18 +41,14 @@ pub use optimizer::{
 };
 pub use pathfinder::{LiquidityEdge, Pathfinder, PathfinderConfig, SwapPath};
 pub use policy::RoutingPolicy;
+pub use regression::{
+    BaselineStore, BenchmarkFixture, RegressionReport, RegressionRunner, RegressionRunnerConfig,
+    RouteRegressionEntry,
+};
 pub use risk::{AssetRiskLimit, ExclusionReason, RiskLimitConfig, RiskValidator, RouteExclusion};
 pub use scorer::{
     BenchmarkHarness, BenchmarkReport, DefaultScorer, FeeMinimizingScorer, OutputMaximizingScorer,
     RouteScorer, ScorerInput, ScorerOutput, ScorerRegistry, ScorerResult,
-};
-pub use amm_fallback::{AmmFallbackConfig, AmmFallbackTier, FallbackResult, TieredAmmFallback};
-pub use execution_quality::{
-    ExecutionQualityTracker, QualityObservation, QualityTrackerConfig, SourceState, WeightBounds,
-};
-pub use regression::{
-    BaselineStore, BenchmarkFixture, RegressionReport, RegressionRunner, RegressionRunnerConfig,
-    RouteRegressionEntry,
 };
 pub use snapshot::{
     SnapshotId, SnapshotIsolationError, SnapshotIsolationMetrics, SnapshotIsolationValidator,

--- a/crates/routing/src/optimizer.rs
+++ b/crates/routing/src/optimizer.rs
@@ -566,7 +566,10 @@ mod tests {
     fn test_set_scorer_delegates_to_registry() {
         let mut optimizer = HybridOptimizer::default();
         assert!(optimizer.set_scorer("fee_minimizing").is_ok());
-        assert_eq!(optimizer.scorer_registry.active_scorer_name(), "fee_minimizing");
+        assert_eq!(
+            optimizer.scorer_registry.active_scorer_name(),
+            "fee_minimizing"
+        );
         assert!(optimizer.set_scorer("nonexistent").is_err());
     }
 
@@ -574,8 +577,12 @@ mod tests {
     fn test_with_scorer_registry_constructor() {
         let mut registry = ScorerRegistry::new();
         registry.set_active("output_maximizing").unwrap();
-        let optimizer = HybridOptimizer::with_scorer_registry(PathfinderConfig::default(), registry);
-        assert_eq!(optimizer.scorer_registry.active_scorer_name(), "output_maximizing");
+        let optimizer =
+            HybridOptimizer::with_scorer_registry(PathfinderConfig::default(), registry);
+        assert_eq!(
+            optimizer.scorer_registry.active_scorer_name(),
+            "output_maximizing"
+        );
     }
 
     #[test]

--- a/crates/routing/src/regression.rs
+++ b/crates/routing/src/regression.rs
@@ -32,9 +32,9 @@
 use crate::pathfinder::{LiquidityEdge, Pathfinder, PathfinderConfig};
 use crate::policy::RoutingPolicy;
 use crate::scorer::{BenchmarkHarness, ScorerRegistry};
+use rand::Rng;
 use rand::SeedableRng;
 use rand_chacha::ChaCha8Rng;
-use rand::Rng;
 use serde::{Deserialize, Serialize};
 use std::time::Instant;
 
@@ -62,9 +62,7 @@ impl BenchmarkFixture {
     /// seed and graph parameters.
     pub fn generate_edges(&self) -> Vec<LiquidityEdge> {
         let mut rng = ChaCha8Rng::seed_from_u64(self.seed);
-        let assets: Vec<String> = (0..self.graph_size)
-            .map(|i| format!("ASSET_{i}"))
-            .collect();
+        let assets: Vec<String> = (0..self.graph_size).map(|i| format!("ASSET_{i}")).collect();
 
         // Always include direct and indirect paths between from/to
         let mut edges = vec![
@@ -189,7 +187,11 @@ impl BaselineStore {
 
     /// Upsert a baseline entry.
     pub fn set(&mut self, entry: RouteRegressionEntry) {
-        if let Some(existing) = self.entries.iter_mut().find(|e| e.fixture_name == entry.fixture_name) {
+        if let Some(existing) = self
+            .entries
+            .iter_mut()
+            .find(|e| e.fixture_name == entry.fixture_name)
+        {
             *existing = entry;
         } else {
             self.entries.push(entry);
@@ -365,8 +367,13 @@ impl RegressionRunner {
             latencies.push(latency);
 
             if !paths.is_empty() {
-                let report = BenchmarkHarness::run(&paths, &edges, fixture.amount_in, &self.scorer_registry);
-                if let Some(top) = report.scorer_results.iter().find(|r| r.scorer_name == "default") {
+                let report =
+                    BenchmarkHarness::run(&paths, &edges, fixture.amount_in, &self.scorer_registry);
+                if let Some(top) = report
+                    .scorer_results
+                    .iter()
+                    .find(|r| r.scorer_name == "default")
+                {
                     if let Some((_, out)) = top.ranked_paths.first() {
                         best_score = best_score.max(out.score);
                     }
@@ -379,8 +386,8 @@ impl RegressionRunner {
 
         let baseline_entry = baseline.and_then(|b| b.get(&fixture.name));
         let score_delta = baseline_entry.map(|b| best_score - b.baseline_score);
-        let latency_delta = baseline_entry
-            .map(|b| median_latency as i64 - b.baseline_latency_us as i64);
+        let latency_delta =
+            baseline_entry.map(|b| median_latency as i64 - b.baseline_latency_us as i64);
 
         let (passed, failure_reason) = self.evaluate(best_score, median_latency, baseline_entry);
 
@@ -477,8 +484,14 @@ mod tests {
 
     #[test]
     fn test_different_seeds_produce_different_edges() {
-        let f1 = BenchmarkFixture { seed: 1, ..simple_fixture() };
-        let f2 = BenchmarkFixture { seed: 2, ..simple_fixture() };
+        let f1 = BenchmarkFixture {
+            seed: 1,
+            ..simple_fixture()
+        };
+        let f2 = BenchmarkFixture {
+            seed: 2,
+            ..simple_fixture()
+        };
         let e1 = f1.generate_edges();
         let e2 = f2.generate_edges();
         // At minimum the liquidity values should differ
@@ -525,7 +538,10 @@ mod tests {
         let fixtures = vec![simple_fixture()];
         let baseline = runner.build_baseline(&fixtures);
         let report = runner.run(&fixtures, Some(&baseline));
-        assert!(report.passed, "identical baseline should not trigger regression");
+        assert!(
+            report.passed,
+            "identical baseline should not trigger regression"
+        );
     }
 
     #[test]
@@ -544,7 +560,10 @@ mod tests {
             baseline_latency_us: 1,
         });
         let report = runner.run(&fixtures, Some(&baseline));
-        assert!(!report.passed, "should detect score regression vs inflated baseline");
+        assert!(
+            !report.passed,
+            "should detect score regression vs inflated baseline"
+        );
         assert_eq!(report.failed, 1);
     }
 

--- a/crates/routing/src/scorer.rs
+++ b/crates/routing/src/scorer.rs
@@ -121,9 +121,16 @@ impl ScorerRegistry {
             active: "default".to_string(),
         };
         // Register built-ins (these are infallible — names are unique)
-        registry.scorers.insert("default".to_string(), Box::new(DefaultScorer));
-        registry.scorers.insert("fee_minimizing".to_string(), Box::new(FeeMinimizingScorer));
-        registry.scorers.insert("output_maximizing".to_string(), Box::new(OutputMaximizingScorer));
+        registry
+            .scorers
+            .insert("default".to_string(), Box::new(DefaultScorer));
+        registry
+            .scorers
+            .insert("fee_minimizing".to_string(), Box::new(FeeMinimizingScorer));
+        registry.scorers.insert(
+            "output_maximizing".to_string(),
+            Box::new(OutputMaximizingScorer),
+        );
 
         // Read ROUTING_SCORER env var
         if let Ok(name) = std::env::var("ROUTING_SCORER") {
@@ -141,9 +148,15 @@ impl ScorerRegistry {
     }
 
     /// Register a scorer under a unique name.
-    pub fn register(&mut self, name: &str, scorer: Box<dyn RouteScorer>) -> crate::error::Result<()> {
+    pub fn register(
+        &mut self,
+        name: &str,
+        scorer: Box<dyn RouteScorer>,
+    ) -> crate::error::Result<()> {
         if self.scorers.contains_key(name) {
-            return Err(crate::error::RoutingError::DuplicateScorer(name.to_string()));
+            return Err(crate::error::RoutingError::DuplicateScorer(
+                name.to_string(),
+            ));
         }
         self.scorers.insert(name.to_string(), scorer);
         Ok(())
@@ -171,7 +184,10 @@ impl ScorerRegistry {
     /// Score a route using the currently active scorer.
     /// Clamps the result to [0.0, 1.0] and emits tracing::warn! if clamping occurs.
     pub fn score(&self, input: &ScorerInput) -> ScorerOutput {
-        let scorer = self.scorers.get(&self.active).expect("active scorer must be registered");
+        let scorer = self
+            .scorers
+            .get(&self.active)
+            .expect("active scorer must be registered");
         let mut output = scorer.score(input);
         let raw = output.score;
         // f64::clamp handles NaN by returning the lower bound (0.0)
@@ -272,7 +288,11 @@ impl BenchmarkHarness {
                 .collect();
 
             // Sort descending by score
-            ranked.sort_by(|a, b| b.1.score.partial_cmp(&a.1.score).unwrap_or(std::cmp::Ordering::Equal));
+            ranked.sort_by(|a, b| {
+                b.1.score
+                    .partial_cmp(&a.1.score)
+                    .unwrap_or(std::cmp::Ordering::Equal)
+            });
 
             scorer_results.push(ScorerResult {
                 scorer_name: scorer_name.to_string(),
@@ -286,9 +306,9 @@ impl BenchmarkHarness {
             false
         } else {
             let first_top = scorer_results[0].ranked_paths.first().map(|(p, _)| &p.hops);
-            scorer_results[1..].iter().any(|r| {
-                r.ranked_paths.first().map(|(p, _)| &p.hops) != first_top
-            })
+            scorer_results[1..]
+                .iter()
+                .any(|r| r.ranked_paths.first().map(|(p, _)| &p.hops) != first_top)
         };
 
         BenchmarkReport {
@@ -509,11 +529,16 @@ mod tests {
         struct OutOfRangeScorer;
         impl RouteScorer for OutOfRangeScorer {
             fn score(&self, _input: &ScorerInput) -> ScorerOutput {
-                ScorerOutput { score: 1.5, diagnostics: None }
+                ScorerOutput {
+                    score: 1.5,
+                    diagnostics: None,
+                }
             }
         }
         let mut registry = ScorerRegistry::new();
-        registry.register("out_of_range", Box::new(OutOfRangeScorer)).unwrap();
+        registry
+            .register("out_of_range", Box::new(OutOfRangeScorer))
+            .unwrap();
         registry.set_active("out_of_range").unwrap();
 
         let policy = OptimizerPolicy::default();

--- a/crates/routing/src/snapshot.rs
+++ b/crates/routing/src/snapshot.rs
@@ -156,17 +156,17 @@ impl SnapshotIsolationValidator {
     ///
     /// Returns `Err(SnapshotIsolationError::MixedSnapshots)` if any hop
     /// deviates from the snapshot of the first hop.
-    pub fn validate_hops(
-        &self,
-        hops: &[ValidatedHop],
-    ) -> Result<(), SnapshotIsolationError> {
+    pub fn validate_hops(&self, hops: &[ValidatedHop]) -> Result<(), SnapshotIsolationError> {
         self.metrics
             .inner
             .total_validations
             .fetch_add(1, Ordering::Relaxed);
 
         if hops.is_empty() {
-            self.metrics.inner.empty_paths.fetch_add(1, Ordering::Relaxed);
+            self.metrics
+                .inner
+                .empty_paths
+                .fetch_add(1, Ordering::Relaxed);
             if self.config.strict {
                 return Err(SnapshotIsolationError::EmptyPath);
             }
@@ -176,7 +176,10 @@ impl SnapshotIsolationValidator {
         let baseline = hops[0].snapshot_id;
         for (idx, hop) in hops.iter().enumerate().skip(1) {
             if hop.snapshot_id != baseline {
-                self.metrics.inner.violations.fetch_add(1, Ordering::Relaxed);
+                self.metrics
+                    .inner
+                    .violations
+                    .fetch_add(1, Ordering::Relaxed);
                 tracing::warn!(
                     hop_index = idx,
                     expected = %baseline,
@@ -332,7 +335,11 @@ mod tests {
             venue_ref: "pool_z".to_string(),
         };
         let json = serde_json::to_string(&err).expect("should serialize");
-        assert!(json.contains("mixed_snapshots") || json.contains("MixedSnapshots") || json.contains("hop_index"));
+        assert!(
+            json.contains("mixed_snapshots")
+                || json.contains("MixedSnapshots")
+                || json.contains("hop_index")
+        );
     }
 
     #[test]
@@ -354,6 +361,9 @@ mod tests {
                 destination_asset: "BTC".into(),
             },
         ];
-        assert!(v.validate_hops(&hops).is_err(), "concurrent-update mixed snapshot must be rejected");
+        assert!(
+            v.validate_hops(&hops).is_err(),
+            "concurrent-update mixed snapshot must be rejected"
+        );
     }
 }

--- a/frontend/components/DemoSwap.tsx
+++ b/frontend/components/DemoSwap.tsx
@@ -26,6 +26,7 @@ import {
   maxDecimalsForSellAsset,
   parseSellAmount,
 } from "@/lib/amount-input";
+import { getTraderErrorCopy } from "@/lib/api/trader-error-copy";
 
 import { QUOTE_AUTO_REFRESH_INTERVAL_MS } from "@/lib/quote-stale";
 
@@ -177,6 +178,7 @@ export function DemoSwap() {
 
   const receivePreview =
     quote && parseResult.status === "ok" ? quote.total : "—";
+  const quoteErrorCopy = quoteError ? getTraderErrorCopy(quoteError) : null;
 
   return (
     <Card className="p-6 max-w-lg mx-auto shadow-lg mt-8 border-primary/20 bg-background/50 backdrop-blur-sm">
@@ -284,7 +286,7 @@ export function DemoSwap() {
             </div>
             {quoteError && numericForQuote !== undefined && (
               <p className="text-xs text-destructive mt-1">
-                Quote failed: {quoteError.message}
+                {quoteErrorCopy?.headline}. {quoteErrorCopy?.recoveryAction}
               </p>
             )}
           </div>

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -36,6 +36,7 @@ import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useSwapI18n } from '@/lib/swap-i18n';
 import { quoteExportToCsv, type QuoteExportPayload } from '@/lib/quote-export';
+import { toTraderErrorLine, getTraderErrorCopy } from '@/lib/api/trader-error-copy';
 import { Maximize2, Minimize2 } from 'lucide-react';
 import {
   Dialog,
@@ -232,6 +233,10 @@ export function SwapCard() {
     quote.priceImpact,
     requiresFreshQuote,
   ]);
+
+  const quoteErrorLine = quote.error
+    ? toTraderErrorLine(getTraderErrorCopy(quote.error))
+    : null;
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -766,7 +771,7 @@ export function SwapCard() {
               'text-center text-xs font-medium text-destructive',
               !prefersReducedMotion && 'animate-pulse'
             )}>
-              {quote.error.message}
+              {quoteErrorLine}
             </p>
           )}
         </CardContent>

--- a/frontend/docs/trader-error-copy-style-guide.md
+++ b/frontend/docs/trader-error-copy-style-guide.md
@@ -1,0 +1,137 @@
+# Trader-Facing Error Copy and Tone Style Guide
+
+Issue: #464  
+Linked frontend mapping work: #310
+
+## Objective
+Create consistent, trader-facing error copy for quote, wallet, and network failures.
+
+## Voice and Tone Principles
+- Be direct and calm: describe what happened without blame.
+- Focus on next action: every message should include a recovery step.
+- Stay specific: mention the affected task (quote refresh, wallet confirmation, pair selection).
+- Keep confidence: avoid catastrophic language and avoid exposing backend internals.
+- Keep it short: headline first, explanation second, recovery action third.
+
+## Message Pattern (Required)
+Every trader-facing error should follow this structure:
+- Headline: short state statement.
+- Explanation: one sentence with context.
+- Recovery action: explicit next step.
+
+Template:
+- Headline: What happened now.
+- Explanation: Why this blocked the action.
+- Recovery action: What the trader can do next.
+
+## Tone Rules
+- Use neutral wording: "could not", "not available", "temporarily limited".
+- Do not use blame wording: "you entered wrong", "invalid user", "you failed".
+- Do not use panic wording: "fatal", "catastrophic", "critical failure".
+- Use action verbs in CTAs: "Refresh quote", "Reconnect wallet", "Adjust trade size".
+
+## Canonical Error Mapping (Frontend)
+The shared copy mapping is centralized in:
+- frontend/lib/api/trader-error-copy.ts
+
+The mapper accepts `StellarRouteApiError` codes from:
+- frontend/lib/api/client.ts
+
+Mapped API codes:
+- validation_error
+- invalid_asset
+- no_route
+- stale_market_data
+- rate_limit_exceeded
+- overloaded
+- bad_request
+- unauthorized
+- not_found
+- internal_error
+- network_error
+- unknown_error (safe fallback)
+
+## Example Library (12+)
+These examples are canonical samples for design review and QA.
+
+1. validation_error
+- Headline: Check your trade details
+- Explanation: One or more inputs are outside the allowed format or range.
+- Recovery action: Update the amount or pair, then refresh the quote.
+
+2. invalid_asset
+- Headline: This asset pair is not available right now
+- Explanation: The selected asset format or issuer could not be matched.
+- Recovery action: Choose a supported asset pair and try again.
+
+3. no_route
+- Headline: No executable route found
+- Explanation: Current liquidity cannot complete this trade at the requested size.
+- Recovery action: Try a smaller amount or a different pair.
+
+4. stale_market_data
+- Headline: Market data is still updating
+- Explanation: Fresh pricing is not available yet for this route.
+- Recovery action: Wait a moment and refresh to fetch a current quote.
+
+5. rate_limit_exceeded
+- Headline: Quote refresh is temporarily limited
+- Explanation: Too many quote requests were sent in a short window.
+- Recovery action: Wait briefly before refreshing again.
+
+6. overloaded
+- Headline: Quote service is handling high traffic
+- Explanation: Routing services are taking longer than normal to respond.
+- Recovery action: Retry in a moment to request a fresh quote.
+
+7. bad_request
+- Headline: We could not process this request
+- Explanation: The quote request did not match the expected API format.
+- Recovery action: Refresh and try again with updated trade inputs.
+
+8. unauthorized
+- Headline: Session check required
+- Explanation: Your current request needs a valid session context.
+- Recovery action: Reconnect wallet or reload the page, then retry.
+
+9. not_found
+- Headline: Requested market data was not found
+- Explanation: The selected pair or route data is currently unavailable.
+- Recovery action: Pick another pair and request a new quote.
+
+10. internal_error
+- Headline: Quote service hit an internal issue
+- Explanation: The request reached the server but could not be completed safely.
+- Recovery action: Retry shortly while we stabilize the route response.
+
+11. network_error
+- Headline: Network connection interrupted
+- Explanation: The app could not reach routing services from this device.
+- Recovery action: Check your connection and refresh once online.
+
+12. wallet_rejected (inferred from generic wallet errors)
+- Headline: Wallet action was not completed
+- Explanation: The wallet did not confirm the request needed to continue.
+- Recovery action: Reopen your wallet, approve the request, and submit again.
+
+13. unknown_error
+- Headline: We could not refresh this quote
+- Explanation: Something unexpected happened while preparing your trade details.
+- Recovery action: Refresh the quote, then try again.
+
+## UI Integration Notes
+Current trader-facing usages now route through shared mapping in:
+- frontend/components/swap/SwapCard.tsx
+- frontend/components/DemoSwap.tsx
+
+Integration contract:
+- Convert raw errors to canonical copy using `getTraderErrorCopy(error)`.
+- Render the message as headline plus recovery action for compact UI blocks.
+- Keep CTA labels available for future buttonized recovery patterns.
+
+## QA Checklist
+- Message includes headline, explanation, and recovery action.
+- Copy avoids blame language.
+- Unknown errors use safe fallback text.
+- Quote and wallet failure surfaces use shared mapper, not raw `error.message`.
+- Recovery action is actionable and specific.

--- a/frontend/lib/api/trader-error-copy.test.ts
+++ b/frontend/lib/api/trader-error-copy.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import { StellarRouteApiError } from '@/lib/api/client';
+import {
+  getTraderErrorCopy,
+  toTraderErrorLine,
+} from '@/lib/api/trader-error-copy';
+
+describe('getTraderErrorCopy', () => {
+  it('maps known API error codes to trader-facing copy', () => {
+    const error = new StellarRouteApiError(422, 'no_route', 'No route available');
+
+    const copy = getTraderErrorCopy(error);
+
+    expect(copy.headline).toBe('No executable route found');
+    expect(copy.recoveryAction).toContain('smaller amount');
+  });
+
+  it('falls back to safe default for unknown API errors', () => {
+    const error = new StellarRouteApiError(
+      520,
+      'unknown_error',
+      'Unexpected upstream error',
+    );
+
+    const copy = getTraderErrorCopy(error);
+
+    expect(copy.headline).toBe('We could not refresh this quote');
+  });
+
+  it('infers wallet copy from generic wallet rejection errors', () => {
+    const copy = getTraderErrorCopy(new Error('Freighter rejected signature request'));
+
+    expect(copy.headline).toBe('Wallet action was not completed');
+    expect(copy.ctaLabel).toBe('Open wallet and retry');
+  });
+
+  it('infers network copy from transport failures', () => {
+    const copy = getTraderErrorCopy(new Error('Failed to fetch'));
+
+    expect(copy.headline).toBe('Network connection interrupted');
+  });
+
+  it('formats copy into a single display line', () => {
+    const copy = getTraderErrorCopy(
+      new StellarRouteApiError(400, 'validation_error', 'Invalid request'),
+    );
+
+    expect(toTraderErrorLine(copy)).toContain('Check your trade details.');
+  });
+});

--- a/frontend/lib/api/trader-error-copy.ts
+++ b/frontend/lib/api/trader-error-copy.ts
@@ -1,0 +1,147 @@
+import { StellarRouteApiError } from '@/lib/api/client';
+import type { ApiErrorCode } from '@/types';
+
+export interface TraderErrorCopy {
+  headline: string;
+  explanation: string;
+  recoveryAction: string;
+  ctaLabel: string;
+}
+
+const DEFAULT_COPY: TraderErrorCopy = {
+  headline: 'We could not refresh this quote',
+  explanation: 'Something unexpected happened while preparing your trade details.',
+  recoveryAction: 'Refresh the quote, then try again.',
+  ctaLabel: 'Refresh quote',
+};
+
+const API_ERROR_COPY: Record<ApiErrorCode, TraderErrorCopy> = {
+  validation_error: {
+    headline: 'Check your trade details',
+    explanation: 'One or more inputs are outside the allowed format or range.',
+    recoveryAction: 'Update the amount or pair, then refresh the quote.',
+    ctaLabel: 'Review trade inputs',
+  },
+  invalid_asset: {
+    headline: 'This asset pair is not available right now',
+    explanation: 'The selected asset format or issuer could not be matched.',
+    recoveryAction: 'Choose a supported asset pair and try again.',
+    ctaLabel: 'Select another pair',
+  },
+  no_route: {
+    headline: 'No executable route found',
+    explanation: 'Current liquidity cannot complete this trade at the requested size.',
+    recoveryAction: 'Try a smaller amount or a different pair.',
+    ctaLabel: 'Adjust trade size',
+  },
+  stale_market_data: {
+    headline: 'Market data is still updating',
+    explanation: 'Fresh pricing is not available yet for this route.',
+    recoveryAction: 'Wait a moment and refresh to fetch a current quote.',
+    ctaLabel: 'Refresh in a few seconds',
+  },
+  rate_limit_exceeded: {
+    headline: 'Quote refresh is temporarily limited',
+    explanation: 'Too many quote requests were sent in a short window.',
+    recoveryAction: 'Wait briefly before refreshing again.',
+    ctaLabel: 'Try again shortly',
+  },
+  overloaded: {
+    headline: 'Quote service is handling high traffic',
+    explanation: 'Routing services are taking longer than normal to respond.',
+    recoveryAction: 'Retry in a moment to request a fresh quote.',
+    ctaLabel: 'Retry quote',
+  },
+  bad_request: {
+    headline: 'We could not process this request',
+    explanation: 'The quote request did not match the expected API format.',
+    recoveryAction: 'Refresh and try again with updated trade inputs.',
+    ctaLabel: 'Refresh quote',
+  },
+  unauthorized: {
+    headline: 'Session check required',
+    explanation: 'Your current request needs a valid session context.',
+    recoveryAction: 'Reconnect wallet or reload the page, then retry.',
+    ctaLabel: 'Reconnect wallet',
+  },
+  not_found: {
+    headline: 'Requested market data was not found',
+    explanation: 'The selected pair or route data is currently unavailable.',
+    recoveryAction: 'Pick another pair and request a new quote.',
+    ctaLabel: 'Choose another pair',
+  },
+  internal_error: {
+    headline: 'Quote service hit an internal issue',
+    explanation: 'The request reached the server but could not be completed safely.',
+    recoveryAction: 'Retry shortly while we stabilize the route response.',
+    ctaLabel: 'Retry quote',
+  },
+  network_error: {
+    headline: 'Network connection interrupted',
+    explanation: 'The app could not reach routing services from this device.',
+    recoveryAction: 'Check your connection and refresh once online.',
+    ctaLabel: 'Reconnect and refresh',
+  },
+  unknown_error: DEFAULT_COPY,
+};
+
+function inferWalletError(errorMessage: string): TraderErrorCopy | null {
+  const text = errorMessage.toLowerCase();
+
+  if (
+    text.includes('wallet') ||
+    text.includes('freighter') ||
+    text.includes('xbull') ||
+    text.includes('rejected') ||
+    text.includes('denied') ||
+    text.includes('signature')
+  ) {
+    return {
+      headline: 'Wallet action was not completed',
+      explanation: 'The wallet did not confirm the request needed to continue.',
+      recoveryAction: 'Reopen your wallet, approve the request, and submit again.',
+      ctaLabel: 'Open wallet and retry',
+    };
+  }
+
+  return null;
+}
+
+function inferNetworkError(errorMessage: string): TraderErrorCopy | null {
+  const text = errorMessage.toLowerCase();
+
+  if (
+    text.includes('network') ||
+    text.includes('timeout') ||
+    text.includes('failed to fetch') ||
+    text.includes('offline')
+  ) {
+    return API_ERROR_COPY.network_error;
+  }
+
+  return null;
+}
+
+export function getTraderErrorCopy(error: unknown): TraderErrorCopy {
+  if (error instanceof StellarRouteApiError) {
+    return API_ERROR_COPY[error.code] ?? DEFAULT_COPY;
+  }
+
+  if (error instanceof Error) {
+    const walletCopy = inferWalletError(error.message);
+    if (walletCopy) {
+      return walletCopy;
+    }
+
+    const networkCopy = inferNetworkError(error.message);
+    if (networkCopy) {
+      return networkCopy;
+    }
+  }
+
+  return DEFAULT_COPY;
+}
+
+export function toTraderErrorLine(copy: TraderErrorCopy): string {
+  return `${copy.headline}. ${copy.explanation} ${copy.recoveryAction}`;
+}


### PR DESCRIPTION
Closes #464

## Summary
- add a trader-facing error tone style guide covering headline, explanation, and recovery action patterns
- add centralized shared frontend error copy mapping for API, wallet, and network failures
- wire swap error surfaces to shared mapping for consistent non-blaming copy
- add unit tests for mapped and fallback error behavior

## Validation
- static diagnostics: no TypeScript errors in changed files
- local frontend test/build blocked because local node toolchain binaries (itest, 
ext) are missing in this environment