### PR TITLE
[#473] [backend] Sparse field selection for quote API responses

### DIFF
--- a/crates/api/src/middleware/validation.rs
+++ b/crates/api/src/middleware/validation.rs
@@ -50,6 +50,7 @@ where
             .map_err(|(code, message)| match code.as_str() {
                 "invalid_amount" => ApiError::InvalidAmount(message),
                 "invalid_slippage" => ApiError::InvalidSlippage(message),
+                "invalid_fields" => ApiError::BadRequest(message),
                 _ => ApiError::Validation(message),
             })?;
 

--- a/crates/api/src/models/request.rs
+++ b/crates/api/src/models/request.rs
@@ -8,6 +8,28 @@ pub const DEFAULT_SLIPPAGE_BPS: u32 = 50;
 /// Maximum slippage tolerance in basis points (100.00%)
 pub const MAX_SLIPPAGE_BPS: u32 = 10_000;
 
+/// Allowed top-level fields for sparse quote response selection.
+pub const ALLOWED_QUOTE_FIELDS: &[&str] = &[
+    "base_asset",
+    "quote_asset",
+    "amount",
+    "price",
+    "total",
+    "quote_type",
+    "degraded",
+    "path",
+    "timestamp",
+    "expires_at",
+    "source_timestamp",
+    "ttl_seconds",
+    "rationale",
+    "price_impact",
+    "exclusion_diagnostics",
+    "data_freshness",
+    "midpoint",
+    "spread_bps",
+];
+
 /// Query parameters for quote endpoint
 #[derive(Debug, Deserialize, Clone)]
 pub struct QuoteParams {
@@ -20,6 +42,8 @@ pub struct QuoteParams {
     pub quote_type: QuoteType,
     /// Explain the route selection with decision diagnostics
     pub explain: Option<bool>,
+    /// Comma-separated list of quote response fields to include
+    pub fields: Option<String>,
 }
 
 /// Request item for batch quotes
@@ -93,6 +117,17 @@ pub struct RoutesParams {
 }
 
 impl QuoteParams {
+    /// Parse and normalize sparse field selections from `fields` query parameter.
+    pub fn selected_fields(&self) -> Option<Vec<String>> {
+        self.fields.as_ref().map(|raw| {
+            raw.split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(|s| s.to_string())
+                .collect()
+        })
+    }
+
     /// Get the slippage tolerance in basis points, applying default if omitted
     pub fn slippage_bps(&self) -> u32 {
         self.slippage_bps.unwrap_or(DEFAULT_SLIPPAGE_BPS)
@@ -123,6 +158,32 @@ impl QuoteParams {
                     MAX_SLIPPAGE_BPS
                 ),
             ));
+        }
+
+        if let Some(selected) = self.selected_fields() {
+            if selected.is_empty() {
+                return Err((
+                    "invalid_fields".to_string(),
+                    "fields must include at least one field name".to_string(),
+                ));
+            }
+
+            let unknown: Vec<String> = selected
+                .iter()
+                .filter(|field| !ALLOWED_QUOTE_FIELDS.contains(&field.as_str()))
+                .cloned()
+                .collect();
+
+            if !unknown.is_empty() {
+                return Err((
+                    "invalid_fields".to_string(),
+                    format!(
+                        "Unknown field(s): {}. Allowed fields: {}",
+                        unknown.join(", "),
+                        ALLOWED_QUOTE_FIELDS.join(", ")
+                    ),
+                ));
+            }
         }
 
         Ok(())
@@ -221,6 +282,34 @@ mod tests {
     }
 
     #[test]
+    fn validate_accepts_known_sparse_fields() {
+        let params = QuoteParams {
+            amount: None,
+            slippage_bps: None,
+            quote_type: QuoteType::Sell,
+            explain: None,
+            fields: Some("price,total,path".to_string()),
+        };
+
+        assert!(params.validate().is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_unknown_sparse_fields() {
+        let params = QuoteParams {
+            amount: None,
+            slippage_bps: None,
+            quote_type: QuoteType::Sell,
+            explain: None,
+            fields: Some("price,foo_field,total".to_string()),
+        };
+
+        let err = params.validate().expect_err("must reject unknown fields");
+        assert_eq!(err.0, "invalid_fields");
+        assert!(err.1.contains("foo_field"));
+    }
+
+    #[test]
     fn test_parse_code_only() {
         let asset = AssetPath::parse("USDC").unwrap();
         assert_eq!(asset.asset_code, "USDC");
@@ -246,6 +335,7 @@ mod tests {
             slippage_bps: None,
             quote_type: QuoteType::Sell,
             explain: None,
+            fields: None,
         };
         assert_eq!(params.slippage_bps(), DEFAULT_SLIPPAGE_BPS);
         assert!(params.validate().is_ok());
@@ -258,6 +348,7 @@ mod tests {
             slippage_bps: Some(100),
             quote_type: QuoteType::Sell,
             explain: None,
+            fields: None,
         };
         assert_eq!(params.slippage_bps(), 100);
         assert!(params.validate().is_ok());
@@ -270,6 +361,7 @@ mod tests {
             slippage_bps: Some(MAX_SLIPPAGE_BPS),
             quote_type: QuoteType::Sell,
             explain: None,
+            fields: None,
         };
         assert_eq!(params.slippage_bps(), MAX_SLIPPAGE_BPS);
         assert!(params.validate().is_ok());
@@ -282,6 +374,7 @@ mod tests {
             slippage_bps: Some(MAX_SLIPPAGE_BPS + 1),
             quote_type: QuoteType::Sell,
             explain: None,
+            fields: None,
         };
         let result = params.validate();
         assert!(result.is_err());
@@ -295,6 +388,7 @@ mod tests {
             slippage_bps: None,
             quote_type: QuoteType::Sell,
             explain: None,
+            fields: None,
         };
         let result = params.validate();
         assert!(result.is_err());
@@ -308,6 +402,7 @@ mod tests {
             slippage_bps: None,
             quote_type: QuoteType::Sell,
             explain: None,
+            fields: None,
         };
         let result = params.validate();
         assert!(result.is_err());

--- a/crates/api/src/routes/idempotent_quote.rs
+++ b/crates/api/src/routes/idempotent_quote.rs
@@ -123,8 +123,8 @@ pub async fn post_quote(
         };
         if let Ok(cached_bytes) = state.idempotency_ledger.lookup(&identity).await {
             debug!("Idempotency cache hit for key: {}", key);
-            let quote_resp: crate::models::QuoteResponse =
-                serde_json::from_slice(&cached_bytes).map_err(|e| {
+            let quote_resp: crate::models::QuoteResponse = serde_json::from_slice(&cached_bytes)
+                .map_err(|e| {
                     ApiError::Internal(Arc::new(anyhow::anyhow!(
                         "Failed to deserialise cached quote: {e}"
                     )))
@@ -145,6 +145,7 @@ pub async fn post_quote(
         slippage_bps: body.slippage_bps,
         quote_type: body.quote_type.unwrap_or(QuoteType::Sell),
         explain: None,
+        fields: None,
     };
 
     // ── 4. Run quote pipeline ─────────────────────────────────────────────

--- a/crates/api/src/routes/quote.rs
+++ b/crates/api/src/routes/quote.rs
@@ -10,7 +10,8 @@
 //!
 //! Request logs and decision stages include matching `request_id` values.
 
-use axum::{extract::State, Json};
+use axum::{extract::State, response::IntoResponse, Json};
+use serde_json::{Map, Value};
 use sqlx::Row;
 use std::sync::Arc;
 use tokio::time::timeout;
@@ -51,6 +52,7 @@ use crate::{
         ("amount" = Option<String>, Query, description = "Amount to trade (default: 1)"),
         ("slippage_bps" = Option<u32>, Query, description = "Slippage tolerance in basis points (default: 50)"),
         ("quote_type" = Option<String>, Query, description = "Type of quote: 'sell' or 'buy' (default: sell)"),
+        ("fields" = Option<String>, Query, description = "Optional comma-separated top-level quote fields to include (e.g., 'price,total,path'). Unknown fields return 400."),
     ),
     responses(
         (status = 200, description = "Price quote", body = QuoteResponse),
@@ -103,7 +105,7 @@ pub async fn get_quote(
     headers: axum::http::HeaderMap,
     request_id: RequestId,
     request: crate::middleware::validation::ValidatedQuoteRequest,
-) -> Result<Json<crate::models::ApiResponse<QuoteResponse>>> {
+) -> Result<axum::response::Response> {
     let ValidatedQuoteRequest {
         base: base_asset,
         quote: quote_asset,
@@ -119,6 +121,7 @@ pub async fn get_quote(
         .map(|s| s.eq_ignore_ascii_case("true"))
         .unwrap_or(false);
     let explain = explain_header || params.explain.unwrap_or(false);
+    let selected_fields = params.selected_fields();
 
     let start_time = std::time::Instant::now();
 
@@ -142,7 +145,8 @@ pub async fn get_quote(
         )
         .await
         {
-            Ok((quote_resp, cache_hit)) => {
+            Ok((prepared_quote, cache_hit)) => {
+                let quote_resp = prepared_quote.into_quote()?;
                 let error_class = "none";
                 let latency_ms = start_time.elapsed().as_millis() as u64;
 
@@ -184,8 +188,15 @@ pub async fn get_quote(
                     audit_exclusions,
                 );
 
+                if let Some(fields) = &selected_fields {
+                    let sparse_data = build_sparse_quote_data(&quote_resp, fields)?;
+                    let envelope =
+                        crate::models::ApiResponse::new(sparse_data, request_id.to_string());
+                    return Ok(Json(envelope).into_response());
+                }
+
                 let envelope = crate::models::ApiResponse::new(quote_resp, request_id.to_string());
-                Ok(Json(envelope))
+                Ok(Json(envelope).into_response())
             }
             Err(e) => {
                 let (error_class, audit_outcome) = match &e {
@@ -421,6 +432,7 @@ pub async fn get_batch_quotes(
                         .quote_type
                         .unwrap_or(crate::models::request::QuoteType::Sell),
                     explain: None,
+                    fields: None,
                 };
 
                 let base_asset = match AssetPath::parse(&item.base) {
@@ -449,7 +461,13 @@ pub async fn get_batch_quotes(
                 };
 
                 match get_quote_inner(state, base_asset, quote_asset, params, false).await {
-                    Ok((quote, _cache_hit)) => BatchQuoteItemResult::ok(i, quote),
+                    Ok((quote, _cache_hit)) => match quote.into_quote() {
+                        Ok(quote) => BatchQuoteItemResult::ok(i, quote),
+                        Err(e) => {
+                            let (code, message) = batch_error_from_api_error(&e);
+                            BatchQuoteItemResult::err(i, BatchItemError { code, message })
+                        }
+                    },
                     Err(e) => {
                         let (code, message) = batch_error_from_api_error(&e);
                         BatchQuoteItemResult::err(i, BatchItemError { code, message })
@@ -823,8 +841,8 @@ type FindBestPriceResult = (
     FreshnessOutcome,
     Vec<chrono::DateTime<chrono::Utc>>,
     Vec<crate::replay::artifact::LiquidityCandidate>, // snapshot for replay capture
-    Option<f64>, // midpoint
-    Option<u32>, // spread_bps
+    Option<f64>,                                      // midpoint
+    Option<u32>,                                      // spread_bps
 );
 
 #[tracing::instrument(
@@ -894,7 +912,7 @@ async fn find_best_price(
         .filter(|c| !c.is_inverse)
         .cloned()
         .collect();
-    
+
     let inverse_candidates: Vec<DirectVenueCandidate> = candidates
         .iter()
         .filter(|c| c.is_inverse)
@@ -917,7 +935,7 @@ async fn find_best_price(
         .filter(|c| c.price > 0.0)
         .map(|c| c.price)
         .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    
+
     let best_bid = inverse_candidates
         .iter()
         .filter(|c| c.price > 0.0)
@@ -1309,7 +1327,7 @@ async fn fetch_source_candidates(
             let available_amount_e7: i64 = row.get("available_amount_e7");
             let fee_bps: i32 = row.get("fee_bps");
             let selling_id: uuid::Uuid = row.get("selling_asset_id");
-            
+
             DirectVenueCandidate {
                 venue_type,
                 venue_ref,
@@ -1466,6 +1484,26 @@ fn build_audit_exclusions(quote: &QuoteResponse) -> Vec<AuditExclusion> {
                 .collect()
         })
         .unwrap_or_default()
+}
+
+fn build_sparse_quote_data(quote: &QuoteResponse, selected_fields: &[String]) -> Result<Value> {
+    let serialized = serde_json::to_value(quote)
+        .map_err(|e| ApiError::Internal(Arc::new(anyhow::anyhow!(e))))?;
+
+    let data_obj = serialized.as_object().ok_or_else(|| {
+        ApiError::Internal(Arc::new(anyhow::anyhow!(
+            "quote payload did not serialize to an object"
+        )))
+    })?;
+
+    let mut sparse = Map::new();
+    for field in selected_fields {
+        if let Some(value) = data_obj.get(field) {
+            sparse.insert(field.clone(), value.clone());
+        }
+    }
+
+    Ok(Value::Object(sparse))
 }
 
 #[cfg(test)]
@@ -1757,6 +1795,80 @@ mod tests {
         assert_eq!(data_freshness.fresh_count, 1);
         assert_eq!(data_freshness.max_staleness_secs, 300);
     }
+
+    fn sample_quote_response() -> QuoteResponse {
+        QuoteResponse {
+            base_asset: AssetInfo::native(),
+            quote_asset: AssetInfo::credit("USDC".to_string(), Some("GISSUER".to_string())),
+            amount: "100.0000000".to_string(),
+            price: "1.0500000".to_string(),
+            total: "105.0000000".to_string(),
+            quote_type: "sell".to_string(),
+            degraded: false,
+            path: vec![],
+            timestamp: 1_700_000_000_000,
+            expires_at: Some(1_700_000_030_000),
+            source_timestamp: Some(1_700_000_000_000),
+            ttl_seconds: Some(30),
+            rationale: None,
+            price_impact: Some("0.10".to_string()),
+            exclusion_diagnostics: None,
+            data_freshness: None,
+            midpoint: Some("1.0450000".to_string()),
+            spread_bps: Some(15),
+        }
+    }
+
+    #[test]
+    fn sparse_fields_common_price_combo() {
+        let quote = sample_quote_response();
+        let fields = vec![
+            "price".to_string(),
+            "total".to_string(),
+            "timestamp".to_string(),
+        ];
+
+        let sparse = build_sparse_quote_data(&quote, &fields).expect("sparse payload");
+        let obj = sparse.as_object().expect("object");
+
+        assert_eq!(obj.len(), 3);
+        assert!(obj.contains_key("price"));
+        assert!(obj.contains_key("total"));
+        assert!(obj.contains_key("timestamp"));
+    }
+
+    #[test]
+    fn sparse_fields_common_asset_combo() {
+        let quote = sample_quote_response();
+        let fields = vec![
+            "base_asset".to_string(),
+            "quote_asset".to_string(),
+            "path".to_string(),
+        ];
+
+        let sparse = build_sparse_quote_data(&quote, &fields).expect("sparse payload");
+        let obj = sparse.as_object().expect("object");
+
+        assert_eq!(obj.len(), 3);
+        assert!(obj.contains_key("base_asset"));
+        assert!(obj.contains_key("quote_asset"));
+        assert!(obj.contains_key("path"));
+    }
+
+    #[test]
+    fn sparse_fields_omits_unselected_values() {
+        let quote = sample_quote_response();
+        let fields = vec!["price".to_string()];
+
+        let sparse = build_sparse_quote_data(&quote, &fields).expect("sparse payload");
+        let obj = sparse.as_object().expect("object");
+
+        assert_eq!(obj.len(), 1);
+        assert!(obj.contains_key("price"));
+        assert!(!obj.contains_key("total"));
+        assert!(!obj.contains_key("base_asset"));
+    }
+
     #[tokio::test]
     async fn test_parallel_execution_latency() {
         use std::time::{Duration, Instant};

--- a/crates/api/tests/conformance.rs
+++ b/crates/api/tests/conformance.rs
@@ -1,3 +1,4 @@
+use stellarroute_api::models::request::{QuoteParams, QuoteType};
 use stellarroute_api::models::response::QuoteResponse;
 
 #[test]
@@ -80,4 +81,46 @@ fn test_quote_response_missing_fields_fail() {
         result.is_err(),
         "Should have failed due to missing required fields"
     );
+}
+
+#[test]
+fn test_sparse_fields_conformance_common_combinations() {
+    let combos = [
+        "price,total,timestamp",
+        "base_asset,quote_asset,path",
+        "amount,quote_type,expires_at",
+    ];
+
+    for combo in combos {
+        let params = QuoteParams {
+            amount: None,
+            slippage_bps: None,
+            quote_type: QuoteType::Sell,
+            explain: None,
+            fields: Some(combo.to_string()),
+        };
+
+        assert!(
+            params.validate().is_ok(),
+            "expected valid field combo: {}",
+            combo
+        );
+    }
+}
+
+#[test]
+fn test_sparse_fields_conformance_rejects_unknown() {
+    let params = QuoteParams {
+        amount: None,
+        slippage_bps: None,
+        quote_type: QuoteType::Sell,
+        explain: None,
+        fields: Some("price,unknown_field,total".to_string()),
+    };
+
+    let err = params
+        .validate()
+        .expect_err("unknown sparse field should fail");
+    assert_eq!(err.0, "invalid_fields");
+    assert!(err.1.contains("unknown_field"));
 }


### PR DESCRIPTION
## Summary\n- add ields query parameter support to quote request parsing/validation and document it in OpenAPI route metadata\n- validate sparse field names against an explicit allow-list and return HTTP 400 with a helpful unknown-fields message\n- preserve existing full quote response behavior when ields is omitted\n- add conformance coverage for common valid field combinations and unknown field rejection\n\n## Validation\n- cargo fmt -p stellarroute-api\n- cargo check -p stellarroute-api --lib *(fails due pre-existing unrelated compile errors in crates/api such as duplicate fields in graph.rs and existing tuple/borrow issues in quote.rs and ordering.rs)*\n\n Closes #473