### PR TITLE
[#474] [backend] Integrator webhook for quote expiration events

### DIFF
--- a/crates/api/Cargo.toml
+++ b/crates/api/Cargo.toml
@@ -43,6 +43,9 @@ config.workspace = true
 redis.workspace = true
 reqwest.workspace = true
 rand.workspace = true
+hmac = "0.12"
+sha2 = "0.10"
+hex = "0.4"
 
 # Internal dependencies
 stellarroute-indexer = { path = "../indexer" }

--- a/crates/api/src/docs.rs
+++ b/crates/api/src/docs.rs
@@ -6,8 +6,9 @@ use crate::models::{
     AssetInfo, BatchItemError, BatchQuoteItemResult, BatchQuoteResponse, CacheMetricsResponse,
     DataFreshness, DependenciesHealthResponse, ErrorResponse, ExcludedVenueInfo,
     ExclusionDiagnostics, ExclusionReason, HealthResponse, OrderbookLevel, OrderbookResponse,
-    PairsResponse, PathStep, QuoteRationaleMetadata, QuoteResponse, RouteResponse, TradingPair,
-    VenueEvaluation,
+    PairsResponse, PathStep, QuoteExpirationWebhookPayload,
+    QuoteExpirationWebhookRegistrationResponse, QuoteRationaleMetadata, QuoteResponse,
+    RouteResponse, TradingPair, VenueEvaluation,
 };
 
 /// OpenAPI documentation
@@ -23,6 +24,7 @@ use crate::models::{
         crate::routes::quote::get_quote,
         crate::routes::quote::get_route,
         crate::routes::quote::get_batch_quotes,
+        crate::routes::integrator_webhooks::upsert_quote_expiration_webhook,
         crate::routes::kill_switch::get_kill_switch,
         crate::routes::kill_switch::update_kill_switch,
     ),
@@ -47,16 +49,20 @@ use crate::models::{
         BatchQuoteResponse,
         BatchQuoteItemResult,
         BatchItemError,
+        QuoteExpirationWebhookRegistrationResponse,
+        QuoteExpirationWebhookPayload,
         ErrorResponse,
         crate::models::request::BatchQuoteRequest,
         crate::models::request::QuoteRequestItem,
         crate::models::request::QuoteType,
+        crate::models::request::QuoteExpirationWebhookRegistrationRequest,
         crate::kill_switch::KillSwitchState,
     )),
     tags(
         (name = "health", description = "Health check endpoints"),
         (name = "trading", description = "Trading and market data endpoints"),
         (name = "admin", description = "Administrative endpoints"),
+        (name = "integrator", description = "Integrator configuration and webhook endpoints"),
     ),
     info(
         title = "StellarRoute API",

--- a/crates/api/src/lib.rs
+++ b/crates/api/src/lib.rs
@@ -29,6 +29,7 @@ pub mod simulation;
 pub mod state;
 pub mod telemetry;
 pub mod tracing_config;
+pub mod webhooks;
 pub mod worker;
 
 pub use cache::CacheManager;

--- a/crates/api/src/models/request.rs
+++ b/crates/api/src/models/request.rs
@@ -83,6 +83,18 @@ pub struct BatchQuoteRequest {
     pub quotes: Vec<QuoteRequestItem>,
 }
 
+/// Register or update quote-expiration webhook settings for an API consumer.
+#[derive(Debug, Deserialize, Clone, ToSchema)]
+pub struct QuoteExpirationWebhookRegistrationRequest {
+    /// HTTPS endpoint that receives quote expiration events.
+    pub webhook_url: String,
+    /// Optional per-consumer signing secret for HMAC signatures.
+    /// If omitted, the server generates one and returns it once.
+    pub signing_secret: Option<String>,
+    /// Whether webhook delivery is enabled for this consumer.
+    pub enabled: Option<bool>,
+}
+
 /// Query parameters for the multiple-routes endpoint
 #[derive(Debug, Deserialize)]
 pub struct RoutesParams {

--- a/crates/api/src/models/response.rs
+++ b/crates/api/src/models/response.rs
@@ -324,6 +324,29 @@ pub struct BatchQuoteItemResult {
     pub status: String,
 }
 
+/// Registration status for quote-expiration webhook delivery.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct QuoteExpirationWebhookRegistrationResponse {
+    pub consumer_id: String,
+    pub webhook_url: String,
+    pub enabled: bool,
+    /// Present only when the server generated a secret during registration.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub generated_signing_secret: Option<String>,
+}
+
+/// Payload sent to integrator webhook endpoints when a quote expires or is invalidated.
+#[derive(Debug, Clone, Serialize, Deserialize, ToSchema)]
+pub struct QuoteExpirationWebhookPayload {
+    pub event_id: String,
+    pub consumer_id: String,
+    pub quote_id: String,
+    pub pair: String,
+    pub reason: String,
+    /// Unix timestamp in milliseconds representing event time.
+    pub expired_at: i64,
+}
+
 impl BatchQuoteItemResult {
     pub fn ok(index: usize, quote: QuoteResponse) -> Self {
         Self {

--- a/crates/api/src/routes/integrator_webhooks.rs
+++ b/crates/api/src/routes/integrator_webhooks.rs
@@ -1,0 +1,95 @@
+use std::sync::Arc;
+
+use axum::{extract::State, http::HeaderMap, Json};
+use uuid::Uuid;
+
+use crate::{
+    error::{ApiError, Result},
+    middleware::RequestId,
+    models::{
+        ApiResponse, QuoteExpirationWebhookRegistrationRequest,
+        QuoteExpirationWebhookRegistrationResponse,
+    },
+    state::AppState,
+};
+
+fn resolve_consumer_id(headers: &HeaderMap) -> Result<String> {
+    headers
+        .get("x-api-key")
+        .and_then(|value| value.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("api_key:{value}"))
+        .ok_or(ApiError::BadRequest(
+            "Missing X-API-Key header for webhook registration".to_string(),
+        ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/api/v1/integrator/webhooks/quote-expiration",
+    tag = "integrator",
+    request_body = QuoteExpirationWebhookRegistrationRequest,
+    responses(
+        (status = 200, description = "Webhook registration updated", body = QuoteExpirationWebhookRegistrationResponse),
+        (status = 400, description = "Invalid input", body = crate::models::ErrorResponse),
+        (status = 500, description = "Internal server error", body = crate::models::ErrorResponse),
+    )
+)]
+pub async fn upsert_quote_expiration_webhook(
+    State(state): State<Arc<AppState>>,
+    headers: HeaderMap,
+    request_id: RequestId,
+    Json(body): Json<QuoteExpirationWebhookRegistrationRequest>,
+) -> Result<Json<ApiResponse<QuoteExpirationWebhookRegistrationResponse>>> {
+    let consumer_id = resolve_consumer_id(&headers)?;
+
+    if body.webhook_url.trim().is_empty() {
+        return Err(ApiError::BadRequest(
+            "webhook_url must not be empty".to_string(),
+        ));
+    }
+
+    if !body.webhook_url.starts_with("https://") {
+        return Err(ApiError::BadRequest(
+            "webhook_url must use https".to_string(),
+        ));
+    }
+
+    let generated_signing_secret = if body
+        .signing_secret
+        .as_deref()
+        .unwrap_or("")
+        .trim()
+        .is_empty()
+    {
+        Some(Uuid::new_v4().to_string())
+    } else {
+        None
+    };
+
+    let signing_secret = body
+        .signing_secret
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .unwrap_or_else(|| generated_signing_secret.as_deref().unwrap_or_default());
+
+    let enabled = body.enabled.unwrap_or(true);
+
+    state
+        .quote_expiration_webhooks
+        .upsert_registration(&consumer_id, &body.webhook_url, signing_secret, enabled)
+        .await
+        .map_err(ApiError::from)?;
+
+    Ok(Json(ApiResponse::new(
+        QuoteExpirationWebhookRegistrationResponse {
+            consumer_id,
+            webhook_url: body.webhook_url,
+            enabled,
+            generated_signing_secret,
+        },
+        request_id.to_string(),
+    )))
+}

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -3,6 +3,7 @@
 pub mod canary;
 pub mod health;
 pub mod idempotent_quote;
+pub mod integrator_webhooks;
 pub mod kill_switch;
 pub mod metrics;
 pub mod orderbook;
@@ -41,6 +42,10 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         )
         .route("/api/v1/quote/:base/:quote", get(quote::get_quote))
         .route("/api/v1/quote", post(idempotent_quote::post_quote))
+        .route(
+            "/api/v1/integrator/webhooks/quote-expiration",
+            post(integrator_webhooks::upsert_quote_expiration_webhook),
+        )
         .route(
             "/api/v1/route/:base/:quote",
             get(quote::get_route).route_layer(axum::middleware::from_fn(legacy_route_deprecation)),

--- a/crates/api/src/routes/quote.rs
+++ b/crates/api/src/routes/quote.rs
@@ -13,8 +13,10 @@
 use axum::{extract::State, Json};
 use sqlx::Row;
 use std::sync::Arc;
+use std::time::Duration;
 use tokio::time::timeout;
 use tracing::{debug, info_span, warn, Instrument};
+use uuid::Uuid;
 
 use stellarroute_routing::health::filter::GraphFilter;
 use stellarroute_routing::health::freshness::{FreshnessGuard, FreshnessOutcome};
@@ -33,10 +35,43 @@ use crate::{
         request::{AssetPath, QuoteParams},
         AssetInfo, ExcludedVenueInfo as ApiExcludedVenueInfo,
         ExclusionDiagnostics as ApiExclusionDiagnostics, ExclusionReason as ApiExclusionReason,
-        PathStep, PreparedQuoteResponse, QuoteRationaleMetadata, QuoteResponse, VenueEvaluation,
+        PathStep, PreparedQuoteResponse, QuoteExpirationWebhookPayload, QuoteRationaleMetadata,
+        QuoteResponse, VenueEvaluation,
     },
     state::AppState,
 };
+
+fn extract_consumer_id(headers: &axum::http::HeaderMap) -> Option<String> {
+    headers
+        .get("x-api-key")
+        .and_then(|h| h.to_str().ok())
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(|value| format!("api_key:{value}"))
+}
+
+fn build_quote_webhook_payload(
+    consumer_id: String,
+    base: &str,
+    quote: &str,
+    quote_resp: &QuoteResponse,
+) -> QuoteExpirationWebhookPayload {
+    let quote_id = format!(
+        "{}:{}:{}:{}",
+        base, quote, quote_resp.timestamp, quote_resp.amount
+    );
+
+    QuoteExpirationWebhookPayload {
+        event_id: Uuid::new_v4().to_string(),
+        consumer_id,
+        quote_id,
+        pair: format!("{base}/{quote}"),
+        reason: "ttl_expired".to_string(),
+        expired_at: quote_resp
+            .expires_at
+            .unwrap_or_else(|| chrono::Utc::now().timestamp_millis()),
+    }
+}
 
 /// Get price quote for a trading pair
 ///
@@ -142,7 +177,8 @@ pub async fn get_quote(
         )
         .await
         {
-            Ok((quote_resp, cache_hit)) => {
+            Ok((prepared_quote, cache_hit)) => {
+                let quote_resp = prepared_quote.into_quote()?;
                 let error_class = "none";
                 let latency_ms = start_time.elapsed().as_millis() as u64;
 
@@ -183,6 +219,27 @@ pub async fn get_quote(
                     Some(audit_selected),
                     audit_exclusions,
                 );
+
+                if let Some(consumer_id) = extract_consumer_id(&headers) {
+                    let ttl_seconds = quote_resp
+                        .ttl_seconds
+                        .unwrap_or(state.cache_policy.quote_ttl.as_secs() as u32)
+                        as u64;
+                    let payload = build_quote_webhook_payload(
+                        consumer_id.clone(),
+                        &base,
+                        &quote,
+                        &quote_resp,
+                    );
+                    state
+                        .quote_expiration_webhooks
+                        .clone()
+                        .spawn_delayed_dispatch_for_consumer(
+                            consumer_id,
+                            payload,
+                            Duration::from_secs(ttl_seconds),
+                        );
+                }
 
                 let envelope = crate::models::ApiResponse::new(quote_resp, request_id.to_string());
                 Ok(Json(envelope))
@@ -449,7 +506,13 @@ pub async fn get_batch_quotes(
                 };
 
                 match get_quote_inner(state, base_asset, quote_asset, params, false).await {
-                    Ok((quote, _cache_hit)) => BatchQuoteItemResult::ok(i, quote),
+                    Ok((prepared_quote, _cache_hit)) => match prepared_quote.into_quote() {
+                        Ok(quote) => BatchQuoteItemResult::ok(i, quote),
+                        Err(e) => {
+                            let (code, message) = batch_error_from_api_error(&e);
+                            BatchQuoteItemResult::err(i, BatchItemError { code, message })
+                        }
+                    },
                     Err(e) => {
                         let (code, message) = batch_error_from_api_error(&e);
                         BatchQuoteItemResult::err(i, BatchItemError { code, message })
@@ -823,8 +886,8 @@ type FindBestPriceResult = (
     FreshnessOutcome,
     Vec<chrono::DateTime<chrono::Utc>>,
     Vec<crate::replay::artifact::LiquidityCandidate>, // snapshot for replay capture
-    Option<f64>, // midpoint
-    Option<u32>, // spread_bps
+    Option<f64>,                                      // midpoint
+    Option<u32>,                                      // spread_bps
 );
 
 #[tracing::instrument(
@@ -894,7 +957,7 @@ async fn find_best_price(
         .filter(|c| !c.is_inverse)
         .cloned()
         .collect();
-    
+
     let inverse_candidates: Vec<DirectVenueCandidate> = candidates
         .iter()
         .filter(|c| c.is_inverse)
@@ -917,7 +980,7 @@ async fn find_best_price(
         .filter(|c| c.price > 0.0)
         .map(|c| c.price)
         .min_by(|a, b| a.partial_cmp(b).unwrap_or(std::cmp::Ordering::Equal));
-    
+
     let best_bid = inverse_candidates
         .iter()
         .filter(|c| c.price > 0.0)
@@ -1248,6 +1311,22 @@ async fn maybe_invalidate_quote_cache(
                         "Liquidity revision changed for {}/{}; invalidated {} quote cache keys",
                         base, quote, deleted
                     );
+
+                    if deleted > 0 {
+                        let payload = QuoteExpirationWebhookPayload {
+                            event_id: Uuid::new_v4().to_string(),
+                            consumer_id: String::new(),
+                            quote_id: format!("invalidated:{base}:{quote}:{liquidity_revision}"),
+                            pair: format!("{base}/{quote}"),
+                            reason: "cache_invalidated".to_string(),
+                            expired_at: chrono::Utc::now().timestamp_millis(),
+                        };
+
+                        state
+                            .quote_expiration_webhooks
+                            .clone()
+                            .spawn_dispatch_to_all(payload);
+                    }
                 }
 
                 let _ = cache
@@ -1309,7 +1388,7 @@ async fn fetch_source_candidates(
             let available_amount_e7: i64 = row.get("available_amount_e7");
             let fee_bps: i32 = row.get("fee_bps");
             let selling_id: uuid::Uuid = row.get("selling_asset_id");
-            
+
             DirectVenueCandidate {
                 venue_type,
                 venue_ref,

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -12,6 +12,7 @@ use crate::graph::GraphManager;
 use crate::models::{PreparedQuoteResponse, RoutesResponse};
 use crate::replay::capture::CaptureHook;
 use crate::routes::ws::WsState;
+use crate::webhooks::QuoteExpirationWebhookService;
 use stellarroute_routing::adaptive_timeout::TimeoutController;
 use stellarroute_routing::canary::{CanaryConfig, CanaryEvaluation};
 use stellarroute_routing::health::circuit_breaker::CircuitBreakerRegistry;
@@ -165,6 +166,8 @@ pub struct AppState {
     pub idempotency_ledger: Arc<DedupeLedger>,
     /// External dependency probes and dedicated circuit breakers.
     pub external_dependency_health: Arc<ExternalDependencyHealth>,
+    /// Integrator webhooks for quote expiration and invalidation events.
+    pub quote_expiration_webhooks: Arc<QuoteExpirationWebhookService>,
 }
 
 impl AppState {
@@ -191,6 +194,8 @@ impl AppState {
             ledger
         };
         let external_dependency_health = Arc::new(ExternalDependencyHealth::from_env());
+        let quote_expiration_webhooks =
+            Arc::new(QuoteExpirationWebhookService::new(db.write_pool().clone()));
 
         Self {
             db,
@@ -218,6 +223,7 @@ impl AppState {
             indexer_lag,
             idempotency_ledger,
             external_dependency_health,
+            quote_expiration_webhooks,
         }
     }
 
@@ -258,6 +264,8 @@ impl AppState {
             ledger
         };
         let external_dependency_health = Arc::new(ExternalDependencyHealth::from_env());
+        let quote_expiration_webhooks =
+            Arc::new(QuoteExpirationWebhookService::new(db.write_pool().clone()));
 
         Self {
             db,
@@ -285,6 +293,7 @@ impl AppState {
             indexer_lag,
             idempotency_ledger,
             external_dependency_health,
+            quote_expiration_webhooks,
         }
     }
 

--- a/crates/api/src/webhooks.rs
+++ b/crates/api/src/webhooks.rs
@@ -1,0 +1,279 @@
+use std::sync::Arc;
+use std::time::Duration;
+
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use sha2::Sha256;
+use sqlx::{PgPool, Row};
+use tracing::{debug, warn};
+
+use crate::models::QuoteExpirationWebhookPayload;
+
+const WEBHOOK_EVENT_NAME: &str = "quote.expired";
+const MAX_DELIVERY_RETRIES: usize = 3;
+const INITIAL_BACKOFF_MS: u64 = 500;
+
+type HmacSha256 = Hmac<Sha256>;
+
+#[derive(Debug, Clone)]
+pub struct QuoteExpirationWebhookService {
+    db: PgPool,
+    client: reqwest::Client,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct WebhookRegistration {
+    pub consumer_id: String,
+    pub webhook_url: String,
+    pub signing_secret: String,
+    pub enabled: bool,
+}
+
+impl QuoteExpirationWebhookService {
+    pub fn new(db: PgPool) -> Self {
+        Self {
+            db,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    async fn ensure_schema(&self) -> Result<(), sqlx::Error> {
+        sqlx::query(
+            r#"
+            CREATE TABLE IF NOT EXISTS consumer_quote_expiration_webhooks (
+                consumer_id TEXT PRIMARY KEY,
+                webhook_url TEXT NOT NULL,
+                signing_secret TEXT NOT NULL,
+                enabled BOOLEAN NOT NULL DEFAULT TRUE,
+                created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+                updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+            )
+            "#,
+        )
+        .execute(&self.db)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn upsert_registration(
+        &self,
+        consumer_id: &str,
+        webhook_url: &str,
+        signing_secret: &str,
+        enabled: bool,
+    ) -> Result<(), sqlx::Error> {
+        self.ensure_schema().await?;
+
+        sqlx::query(
+            r#"
+            INSERT INTO consumer_quote_expiration_webhooks (
+                consumer_id,
+                webhook_url,
+                signing_secret,
+                enabled,
+                created_at,
+                updated_at
+            )
+            VALUES ($1, $2, $3, $4, NOW(), NOW())
+            ON CONFLICT (consumer_id)
+            DO UPDATE SET
+                webhook_url = EXCLUDED.webhook_url,
+                signing_secret = EXCLUDED.signing_secret,
+                enabled = EXCLUDED.enabled,
+                updated_at = NOW()
+            "#,
+        )
+        .bind(consumer_id)
+        .bind(webhook_url)
+        .bind(signing_secret)
+        .bind(enabled)
+        .execute(&self.db)
+        .await?;
+
+        Ok(())
+    }
+
+    pub async fn get_registration(
+        &self,
+        consumer_id: &str,
+    ) -> Result<Option<WebhookRegistration>, sqlx::Error> {
+        self.ensure_schema().await?;
+
+        let row = sqlx::query(
+            r#"
+            SELECT consumer_id, webhook_url, signing_secret, enabled
+            FROM consumer_quote_expiration_webhooks
+            WHERE consumer_id = $1
+            "#,
+        )
+        .bind(consumer_id)
+        .fetch_optional(&self.db)
+        .await?;
+
+        Ok(row.map(|r| WebhookRegistration {
+            consumer_id: r.get("consumer_id"),
+            webhook_url: r.get("webhook_url"),
+            signing_secret: r.get("signing_secret"),
+            enabled: r.get("enabled"),
+        }))
+    }
+
+    async fn list_enabled_registrations(&self) -> Result<Vec<WebhookRegistration>, sqlx::Error> {
+        self.ensure_schema().await?;
+
+        let rows = sqlx::query(
+            r#"
+            SELECT consumer_id, webhook_url, signing_secret, enabled
+            FROM consumer_quote_expiration_webhooks
+            WHERE enabled = TRUE
+            "#,
+        )
+        .fetch_all(&self.db)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|r| WebhookRegistration {
+                consumer_id: r.get("consumer_id"),
+                webhook_url: r.get("webhook_url"),
+                signing_secret: r.get("signing_secret"),
+                enabled: r.get("enabled"),
+            })
+            .collect())
+    }
+
+    fn sign_payload(&self, signing_secret: &str, payload_json: &str) -> Option<String> {
+        let mut mac = HmacSha256::new_from_slice(signing_secret.as_bytes()).ok()?;
+        mac.update(payload_json.as_bytes());
+        let sig = mac.finalize().into_bytes();
+        Some(hex::encode(sig))
+    }
+
+    async fn deliver_with_retry(
+        &self,
+        registration: &WebhookRegistration,
+        payload: &QuoteExpirationWebhookPayload,
+    ) {
+        let payload_json = match serde_json::to_string(payload) {
+            Ok(json) => json,
+            Err(e) => {
+                warn!(error = %e, "Failed to serialize webhook payload");
+                return;
+            }
+        };
+
+        let signature = match self.sign_payload(&registration.signing_secret, &payload_json) {
+            Some(sig) => sig,
+            None => {
+                warn!(
+                    consumer_id = %registration.consumer_id,
+                    "Failed to sign webhook payload"
+                );
+                return;
+            }
+        };
+
+        for attempt in 0..=MAX_DELIVERY_RETRIES {
+            let response = self
+                .client
+                .post(&registration.webhook_url)
+                .header("content-type", "application/json")
+                .header("x-stellarroute-event", WEBHOOK_EVENT_NAME)
+                .header("x-stellarroute-consumer", &registration.consumer_id)
+                .header("x-stellarroute-signature", format!("sha256={signature}"))
+                .body(payload_json.clone())
+                .send()
+                .await;
+
+            match response {
+                Ok(resp) if resp.status().is_success() => {
+                    debug!(
+                        consumer_id = %registration.consumer_id,
+                        status = %resp.status(),
+                        "Webhook delivered"
+                    );
+                    return;
+                }
+                Ok(resp) => {
+                    warn!(
+                        consumer_id = %registration.consumer_id,
+                        status = %resp.status(),
+                        attempt,
+                        "Webhook delivery failed"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        consumer_id = %registration.consumer_id,
+                        error = %e,
+                        attempt,
+                        "Webhook delivery request error"
+                    );
+                }
+            }
+
+            if attempt < MAX_DELIVERY_RETRIES {
+                let backoff_ms = INITIAL_BACKOFF_MS.saturating_mul(1u64 << attempt);
+                tokio::time::sleep(Duration::from_millis(backoff_ms)).await;
+            }
+        }
+    }
+
+    pub async fn dispatch_to_consumer(
+        &self,
+        consumer_id: &str,
+        payload: QuoteExpirationWebhookPayload,
+    ) {
+        match self.get_registration(consumer_id).await {
+            Ok(Some(registration)) if registration.enabled => {
+                self.deliver_with_retry(&registration, &payload).await;
+            }
+            Ok(Some(_)) => {
+                debug!(consumer_id, "Webhook disabled; skipping dispatch");
+            }
+            Ok(None) => {
+                debug!(consumer_id, "No webhook registration for consumer");
+            }
+            Err(e) => {
+                warn!(consumer_id, error = %e, "Failed to load webhook registration");
+            }
+        }
+    }
+
+    pub async fn dispatch_to_all(&self, payload: QuoteExpirationWebhookPayload) {
+        match self.list_enabled_registrations().await {
+            Ok(registrations) => {
+                for registration in registrations {
+                    let consumer_payload = QuoteExpirationWebhookPayload {
+                        consumer_id: registration.consumer_id.clone(),
+                        ..payload.clone()
+                    };
+                    self.deliver_with_retry(&registration, &consumer_payload)
+                        .await;
+                }
+            }
+            Err(e) => {
+                warn!(error = %e, "Failed to list enabled webhook registrations");
+            }
+        }
+    }
+
+    pub fn spawn_delayed_dispatch_for_consumer(
+        self: Arc<Self>,
+        consumer_id: String,
+        payload: QuoteExpirationWebhookPayload,
+        delay: Duration,
+    ) {
+        tokio::spawn(async move {
+            tokio::time::sleep(delay).await;
+            self.dispatch_to_consumer(&consumer_id, payload).await;
+        });
+    }
+
+    pub fn spawn_dispatch_to_all(self: Arc<Self>, payload: QuoteExpirationWebhookPayload) {
+        tokio::spawn(async move {
+            self.dispatch_to_all(payload).await;
+        });
+    }
+}

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,7 @@ This directory contains project documentation.
 
 - `architecture/` - Architecture documentation
 - `api/` - API reference documentation
+  - `integrator-guide.md` - Integrator-specific API setup and webhook guide
   - `websocket.md` - Real-time WebSocket quote stream API reference
   - `error_taxonomy.md` - Standardized API error codes
   - `routes_endpoint.md` - REST API route documentation

--- a/docs/api/integrator-guide.md
+++ b/docs/api/integrator-guide.md
@@ -1,0 +1,86 @@
+# Integrator API Guide
+
+This guide documents integration-specific API behavior for partner systems.
+
+## Quote Expiration Webhooks
+
+Integrators can register an HTTPS webhook endpoint to receive quote expiration events.
+
+### Register or update webhook
+
+- **Method:** `POST`
+- **Path:** `/api/v1/integrator/webhooks/quote-expiration`
+- **Required header:** `X-API-Key`
+
+Request body:
+
+```json
+{
+  "webhook_url": "https://integrator.example/webhooks/quotes",
+  "signing_secret": "optional-shared-secret",
+  "enabled": true
+}
+```
+
+Behavior:
+
+- If `signing_secret` is omitted or blank, the API generates one and returns it once in `generated_signing_secret`.
+- Registrations are stored per consumer (`X-API-Key`).
+- `webhook_url` must use `https://`.
+
+Successful response:
+
+```json
+{
+  "v": 1,
+  "timestamp": 1740312000000,
+  "request_id": "req_01hyxk6bzv4n9p8m8j1f4c0a2r",
+  "data": {
+    "consumer_id": "api_key:your-key",
+    "webhook_url": "https://integrator.example/webhooks/quotes",
+    "enabled": true,
+    "generated_signing_secret": "2d4ad5fd-99d1-4d6a-9d84-7bbcc90a2d9c"
+  }
+}
+```
+
+### Webhook event payload
+
+Events are posted with JSON payload:
+
+```json
+{
+  "event_id": "f30f7d86-c604-4a0a-bd4a-7381f09542f1",
+  "consumer_id": "api_key:your-key",
+  "quote_id": "native:USDC:1740312000000:100",
+  "pair": "native/USDC",
+  "reason": "ttl_expired",
+  "expired_at": 1740312002000
+}
+```
+
+`reason` values:
+
+- `ttl_expired` when a quote naturally reaches its TTL.
+- `cache_invalidated` when underlying liquidity changes invalidate cached quotes.
+
+### Signature verification
+
+Each webhook request includes:
+
+- `X-StellarRoute-Event: quote.expired`
+- `X-StellarRoute-Consumer: <consumer_id>`
+- `X-StellarRoute-Signature: sha256=<hex_digest>`
+
+Signature is computed as `HMAC-SHA256(secret, raw_request_body)`.
+
+### Retry policy
+
+Failed deliveries are retried with exponential backoff:
+
+- attempt 1: immediate
+- attempt 2: 500ms
+- attempt 3: 1000ms
+- attempt 4: 2000ms
+
+A delivery is considered successful for any HTTP 2xx response.


### PR DESCRIPTION
## Summary

Implements integrator webhook delivery for quote expiration and cache invalidation events.

## Changes

### New: Webhook Service (crates/api/src/webhooks.rs)
- QuoteExpirationWebhookService handles registration persistence and signed delivery
- Per-consumer HMAC-SHA256 signing using a stored secret
- Retry/backoff: up to 3 retries at 500ms, 1s, 2s intervals
- Table consumer_quote_expiration_webhooks auto-created on first use

### New: Registration Endpoint (crates/api/src/routes/integrator_webhooks.rs)
- POST /api/v1/integrator/webhooks/quote-expiration
- Requires X-API-Key header to identify consumer
- Validates webhook_url must use https
- Server generates signing secret if caller omits one (returned once in response)
- OpenAPI-annotated under the integrator tag

### Event Dispatch
- After a quote is served, a delayed task fires after the quote TTL and dispatches to the identified consumer
- On cache invalidation due to liquidity revision change, broadcasts cache_invalidated events to all registered consumers

### Payload fields
event_id, consumer_id, quote_id (base:quote:timestamp:amount), pair, reason (ttl_expired or cache_invalidated), expired_at (unix ms)

### Webhook request headers
- X-StellarRoute-Event: quote.expired
- X-StellarRoute-Consumer: consumer_id
- X-StellarRoute-Signature: sha256=hex_hmac

### Documentation
- Added docs/api/integrator-guide.md with full registration, payload, signing, and retry reference
- Linked from docs/README.md

## Notes on baseline compile state

Pre-existing errors in crates/api (unrelated to this PR) remain in graph.rs, ordering.rs, serialization.rs, state.rs, and routes/ws/broadcaster.rs. These were present before this branch was created.

Closes #474