### PR TITLE
feat(frontend): token favorites rail, confidence tooltip, adaptive pr…

### DIFF
--- a/frontend/__mocks__/lucide-react.tsx
+++ b/frontend/__mocks__/lucide-react.tsx
@@ -76,3 +76,6 @@ export const Compass = Icon;
 export const Zap = Icon;
 export const Maximize2 = Icon;
 export const Minimize2 = Icon;
+export const Star = Icon;
+export const Columns2 = Icon;
+export const LayoutList = Icon;

--- a/frontend/app/swap/SwapPageClient.tsx
+++ b/frontend/app/swap/SwapPageClient.tsx
@@ -1,0 +1,30 @@
+"use client";
+
+import { SwapCard } from "@/components/swap/SwapCard";
+import { SplitView } from "@/components/swap/SplitView";
+import { useSplitView } from "@/hooks/useSplitView";
+import dynamic from "next/dynamic";
+
+const RouteDisplay = dynamic(
+  () => import("@/components/swap/RouteDisplay").then((m) => m.RouteDisplay),
+  { ssr: false }
+);
+
+export function SwapPageClient() {
+  const { isSplit, toggleSplit } = useSplitView();
+
+  return (
+    <SplitView
+      isSplit={isSplit}
+      onToggle={toggleSplit}
+      primary={<SwapCard />}
+      secondary={
+        <div className="rounded-xl border border-border/50 bg-card p-4">
+          <h2 className="text-sm font-semibold mb-3">Route Details</h2>
+          <RouteDisplay amountOut="0" />
+        </div>
+      }
+      className="w-full max-w-[960px] mx-auto"
+    />
+  );
+}

--- a/frontend/app/swap/page.tsx
+++ b/frontend/app/swap/page.tsx
@@ -1,4 +1,4 @@
-import { SwapCard } from "@/components/swap/SwapCard";
+import { SwapPageClient } from "./SwapPageClient";
 import { Metadata } from "next";
 
 export const metadata: Metadata = {
@@ -25,8 +25,8 @@ export default function SwapPage() {
           </p>
         </div>
 
-        {/* The Swap Card */}
-        <SwapCard />
+        {/* Swap + optional split-view route panel */}
+        <SwapPageClient />
 
         {/* Extra Info / Social Proof */}
         <div className="mt-12 flex flex-wrap justify-center gap-8 opacity-50 grayscale hover:grayscale-0 transition-all duration-500">

--- a/frontend/components/swap/AmountInput.tsx
+++ b/frontend/components/swap/AmountInput.tsx
@@ -3,7 +3,12 @@
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { normalizeDecimalString } from '@/lib/amount-input';
+import {
+  maxDecimalsForSellAsset,
+  parseSellAmount,
+  clampToMaxDecimals,
+  normalizeDecimalString,
+} from '@/lib/amount-input';
 import { useState, useCallback, useEffect, useId } from 'react';
 import { AmountPresets } from './AmountPresets';
 
@@ -22,7 +27,25 @@ interface AmountInputProps {
   balanceError?: boolean;
   showMax?: boolean;
   showPresets?: boolean;
-  decimals?: number; 
+  /**
+   * Explicit decimal precision for this asset.
+   * When provided, overrides the heuristic from `assetId`.
+   * Accepts 0–255 (Stellar/Soroban range).
+   */
+  decimals?: number;
+  /**
+   * Canonical asset identifier ("native" or "CODE:ISSUER").
+   * Used to derive adaptive precision when `decimals` is not supplied.
+   */
+  assetId?: string;
+}
+
+/**
+ * Resolve effective max decimals from props.
+ * Priority: explicit `decimals` > `assetId` heuristic > default (7).
+ */
+function resolveMaxDecimals(decimals?: number, assetId?: string): number {
+  return maxDecimalsForSellAsset(assetId ?? 'native', decimals);
 }
 
 export function AmountInput({
@@ -40,47 +63,88 @@ export function AmountInput({
   balanceError = false,
   showMax = true,
   showPresets = false,
-  decimals = 7,
+  decimals,
+  assetId,
 }: AmountInputProps) {
+  const maxDecimals = resolveMaxDecimals(decimals, assetId);
   const [internalValue, setInternalValue] = useState(value);
+  const [precisionError, setPrecisionError] = useState<string | null>(null);
   const inputId = useId();
 
   useEffect(() => {
     setInternalValue(value);
-  }, [value]);
+    // Re-validate when value changes externally
+    if (value !== '') {
+      const result = parseSellAmount(value, maxDecimals);
+      setPrecisionError(
+        result.status === 'precision_exceeded' ? result.message : null
+      );
+    } else {
+      setPrecisionError(null);
+    }
+  }, [value, maxDecimals]);
 
   const handleChange = useCallback(
     (e: React.ChangeEvent<HTMLInputElement>) => {
-      const raw = e.target.value.replace(/,/g, '.'); 
-      
+      const raw = e.target.value.replace(/,/g, '.');
+
       if (raw === '') {
         setInternalValue('');
+        setPrecisionError(null);
         onChange?.('');
         return;
       }
 
-      if ((raw.match(/\./g) || []).length > 1) return;
+      // Allow in-progress typing: trailing dot or leading dot
+      if (raw === '.' || /^\d+\.$/.test(raw)) {
+        setInternalValue(raw);
+        setPrecisionError(null);
+        onChange?.(raw);
+        return;
+      }
 
       if (!/^\d*\.?\d*$/.test(raw)) return;
 
-      if (raw.includes('.')) {
-        const [, decimalPart] = raw.split('.');
-        if (decimalPart && decimalPart.length > (decimals || 7)) {
-          return; 
+      // Enforce precision: silently clamp rather than block typing
+      const normalized = normalizeDecimalString(raw);
+      if (normalized !== null) {
+        const dotIdx = normalized.indexOf('.');
+        if (dotIdx !== -1) {
+          const fracLen = normalized.length - dotIdx - 1;
+          if (fracLen > maxDecimals) {
+            const clamped = clampToMaxDecimals(normalized, maxDecimals);
+            setInternalValue(clamped);
+            setPrecisionError(
+              `Maximum ${maxDecimals} decimal place${maxDecimals === 1 ? '' : 's'} for this asset.`
+            );
+            onChange?.(clamped);
+            return;
+          }
         }
       }
 
+      setPrecisionError(null);
       setInternalValue(raw);
       onChange?.(raw);
     },
-    [onChange, decimals]
+    [onChange, maxDecimals]
   );
 
+  const exceedsBalance =
+    balance &&
+    internalValue &&
+    !Number.isNaN(parseFloat(internalValue)) &&
+    !Number.isNaN(parseFloat(balance)) &&
+    parseFloat(internalValue) > parseFloat(balance);
+
   return (
-    <div className={cn("flex flex-col gap-1.5 w-full", className)}>
+    <div className={cn('flex flex-col gap-1.5 w-full', className)}>
       <div className="flex justify-between items-center px-1">
         {label && (
-          <label htmlFor={inputId} className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+          <label
+            htmlFor={inputId}
+            className="text-xs font-medium text-muted-foreground uppercase tracking-wider"
+          >
             {label}
           </label>
         )}
@@ -97,7 +161,7 @@ export function AmountInput({
           </span>
         )}
       </div>
-      
+
       <div className="relative group">
         <Input
           id={inputId}
@@ -108,13 +172,19 @@ export function AmountInput({
           onChange={handleChange}
           disabled={disabled}
           readOnly={readOnly}
+          aria-invalid={!!(precisionError || exceedsBalance)}
+          aria-describedby={
+            precisionError || exceedsBalance ? `${inputId}-error` : undefined
+          }
           className={cn(
-            "h-14 text-2xl font-semibold bg-background/40 border-border/40 focus-visible:ring-primary/30 rounded-xl px-4",
-            readOnly && "cursor-default border-transparent bg-transparent px-0 text-3xl",
-            !readOnly && "group-hover:border-primary/20 transition-all shadow-sm"
+            'h-14 text-2xl font-semibold bg-background/40 border-border/40 focus-visible:ring-primary/30 rounded-xl px-4',
+            readOnly &&
+              'cursor-default border-transparent bg-transparent px-0 text-3xl',
+            !readOnly && 'group-hover:border-primary/20 transition-all shadow-sm',
+            (precisionError || exceedsBalance) && 'border-destructive/50'
           )}
         />
-        
+
         {showMax && onMax && !readOnly && !disabled && (
           <Button
             type="button"
@@ -127,17 +197,21 @@ export function AmountInput({
           </Button>
         )}
       </div>
-      
-        {balance && internalValue && parseFloat(internalValue) > parseFloat(balance) && (
-        <p className="text-[10px] font-medium text-red-500 px-1 mt-1">
-          Amount exceeds available balance
+
+      {(precisionError || exceedsBalance) && (
+        <p
+          id={`${inputId}-error`}
+          role="alert"
+          className="text-[10px] font-medium text-destructive px-1 mt-1"
+        >
+          {precisionError ?? 'Amount exceeds available balance'}
         </p>
       )}
 
       {showPresets && onPresetSelect && (
         <AmountPresets
           balance={balance || null}
-          decimals={decimals}
+          decimals={maxDecimals}
           onSelect={onPresetSelect}
           disabled={disabled || readOnly}
           className="mt-2"

--- a/frontend/components/swap/ConfidenceIndicator.test.tsx
+++ b/frontend/components/swap/ConfidenceIndicator.test.tsx
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import fc from 'fast-check';
-import { ConfidenceIndicator } from './ConfidenceIndicator';
+import { ConfidenceIndicator, type RiskFactor } from './ConfidenceIndicator';
 
 // ---------------------------------------------------------------------------
 // Helper
@@ -25,7 +25,7 @@ function setReducedMotion(value: boolean) {
 }
 
 // ---------------------------------------------------------------------------
-// Unit tests
+// Reduced-motion tests (preserved from original)
 // ---------------------------------------------------------------------------
 
 describe('ConfidenceIndicator — reduced-motion', () => {
@@ -59,6 +59,70 @@ describe('ConfidenceIndicator — reduced-motion', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Risk factor rendering tests (#441)
+// ---------------------------------------------------------------------------
+
+describe('ConfidenceIndicator — risk factors', () => {
+  it('renders risk-factors container', () => {
+    render(<ConfidenceIndicator score={75} />);
+    expect(screen.getByTestId('risk-factors')).toBeInTheDocument();
+  });
+
+  it('renders default three factors when none supplied', () => {
+    render(<ConfidenceIndicator score={75} />);
+    expect(screen.getByTestId('risk-factor-liquidity-depth')).toBeInTheDocument();
+    expect(screen.getByTestId('risk-factor-source-freshness')).toBeInTheDocument();
+    expect(screen.getByTestId('risk-factor-volatility')).toBeInTheDocument();
+  });
+
+  it('renders custom risk factors when supplied', () => {
+    const factors: RiskFactor[] = [
+      { label: 'Custom Factor', severity: 'ok', description: 'All good.' },
+      { label: 'Another Factor', severity: 'bad', description: 'Very bad.' },
+    ];
+    render(<ConfidenceIndicator score={60} riskFactors={factors} />);
+    expect(screen.getByTestId('risk-factor-custom-factor')).toBeInTheDocument();
+    expect(screen.getByTestId('risk-factor-another-factor')).toBeInTheDocument();
+    // Default factors should NOT appear
+    expect(screen.queryByTestId('risk-factor-liquidity-depth')).not.toBeInTheDocument();
+  });
+
+  it('shows factor descriptions', () => {
+    const factors: RiskFactor[] = [
+      { label: 'Liquidity Depth', severity: 'warn', description: 'Moderate depth test.' },
+    ];
+    render(<ConfidenceIndicator score={60} riskFactors={factors} />);
+    // Description is in the sr-only hidden element
+    expect(screen.getByTestId('risk-factor-liquidity-depth').textContent).toContain('Moderate depth test.');
+  });
+
+  it('high score produces ok severity for liquidity depth by default', () => {
+    render(<ConfidenceIndicator score={90} />);
+    const factor = screen.getByTestId('risk-factor-liquidity-depth');
+    // ok severity → text-success class on the label
+    expect(factor.textContent).toContain('Liquidity Depth');
+  });
+
+  it('low score produces bad severity for liquidity depth by default', () => {
+    render(<ConfidenceIndicator score={30} />);
+    const factor = screen.getByTestId('risk-factor-liquidity-depth');
+    expect(factor.textContent).toContain('Liquidity Depth');
+  });
+
+  it('high volatility produces bad severity for volatility factor', () => {
+    render(<ConfidenceIndicator score={80} volatility="high" />);
+    const factor = screen.getByTestId('risk-factor-volatility');
+    expect(factor.textContent).toContain('Volatility');
+  });
+
+  it('fallback: renders factors even when score is 0', () => {
+    render(<ConfidenceIndicator score={0} />);
+    expect(screen.getByTestId('risk-factors')).toBeInTheDocument();
+    expect(screen.getAllByTestId(/^risk-factor-/).length).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Property-based tests
 // ---------------------------------------------------------------------------
 
@@ -66,8 +130,7 @@ describe('ConfidenceIndicator — property tests', () => {
   afterEach(() => setReducedMotion(false));
 
   it(
-    // Feature: reduced-motion-swap-animations, Property 11 & 12
-    'Property 11 & 12: animate-pulse absent iff prefersReducedMotion is true; badge always present',
+    'Property: animate-pulse absent iff prefersReducedMotion is true; badge always present',
     () => {
       fc.assert(
         fc.property(fc.boolean(), (prefersReduced) => {
@@ -90,4 +153,46 @@ describe('ConfidenceIndicator — property tests', () => {
       );
     }
   );
+
+  it('Property: risk-factors container always rendered for any score 0-100', () => {
+    fc.assert(
+      fc.property(fc.integer({ min: 0, max: 100 }), (score) => {
+        const { unmount } = render(<ConfidenceIndicator score={score} />);
+        const container = screen.getByTestId('risk-factors');
+        const present = !!container;
+        unmount();
+        return present;
+      }),
+      { numRuns: 50 }
+    );
+  });
+
+  it('Property: custom riskFactors are all rendered', () => {
+    // Use a fixed label pool to ensure predictable testIds
+    const labelPool = ['Alpha', 'Beta', 'Gamma', 'Delta', 'Epsilon'];
+    fc.assert(
+      fc.property(
+        fc.uniqueArray(
+          fc.record({
+            label: fc.constantFrom(...labelPool),
+            severity: fc.constantFrom<RiskFactor['severity']>('ok', 'warn', 'bad'),
+            description: fc.string({ minLength: 1, maxLength: 50 }),
+          }),
+          { minLength: 1, maxLength: 5, selector: (f) => f.label }
+        ),
+        (factors) => {
+          const { unmount } = render(
+            <ConfidenceIndicator score={70} riskFactors={factors} />
+          );
+          const allPresent = factors.every((f) => {
+            const testId = `risk-factor-${f.label.toLowerCase()}`;
+            return !!screen.queryByTestId(testId);
+          });
+          unmount();
+          return allPresent;
+        }
+      ),
+      { numRuns: 30 }
+    );
+  });
 });

--- a/frontend/components/swap/ConfidenceIndicator.tsx
+++ b/frontend/components/swap/ConfidenceIndicator.tsx
@@ -13,11 +13,25 @@ import {
 
 export type ConfidenceLevel = "high" | "medium" | "low";
 
+export interface RiskFactor {
+  /** Factor name, e.g. "Liquidity Depth" */
+  label: string;
+  /** Severity: ok = green, warn = amber, bad = red */
+  severity: "ok" | "warn" | "bad";
+  /** Short description shown in tooltip */
+  description: string;
+}
+
 interface ConfidenceIndicatorProps {
   /** Confidence score from 0-100 */
   score: number;
   /** Volatility level (optional) */
   volatility?: "high" | "medium" | "low";
+  /**
+   * Explicit risk factor breakdown. When omitted, a default breakdown is
+   * derived from score + volatility so the tooltip always has content.
+   */
+  riskFactors?: RiskFactor[];
 }
 
 /**
@@ -32,18 +46,78 @@ function getConfidenceLevel(score: number): ConfidenceLevel {
   return "low";
 }
 
+/** Build a sensible default factor list when the caller doesn't supply one. */
+function defaultRiskFactors(
+  score: number,
+  volatility?: "high" | "medium" | "low"
+): RiskFactor[] {
+  const liquiditySeverity: RiskFactor["severity"] =
+    score >= 80 ? "ok" : score >= 50 ? "warn" : "bad";
+  const freshnessSeverity: RiskFactor["severity"] =
+    score >= 70 ? "ok" : score >= 40 ? "warn" : "bad";
+  const volatilitySeverity: RiskFactor["severity"] =
+    volatility === "high" ? "bad" : volatility === "medium" ? "warn" : "ok";
+
+  return [
+    {
+      label: "Liquidity Depth",
+      severity: liquiditySeverity,
+      description:
+        liquiditySeverity === "ok"
+          ? "Sufficient depth to fill this order with minimal slippage."
+          : liquiditySeverity === "warn"
+            ? "Moderate depth — larger orders may experience slippage."
+            : "Thin liquidity — high slippage risk for this order size.",
+    },
+    {
+      label: "Source Freshness",
+      severity: freshnessSeverity,
+      description:
+        freshnessSeverity === "ok"
+          ? "Market data is recent and reliable."
+          : freshnessSeverity === "warn"
+            ? "Data is slightly stale; price may have shifted."
+            : "Stale market data — execution price may differ significantly.",
+    },
+    {
+      label: "Volatility",
+      severity: volatilitySeverity,
+      description:
+        volatilitySeverity === "ok"
+          ? "Low volatility — route is stable."
+          : volatilitySeverity === "warn"
+            ? "Moderate volatility — route may change before execution."
+            : "High volatility — route is unstable and may change frequently.",
+    },
+  ];
+}
+
+const SEVERITY_DOT: Record<RiskFactor["severity"], string> = {
+  ok: "bg-success",
+  warn: "bg-warning",
+  bad: "bg-destructive",
+};
+
+const SEVERITY_TEXT: Record<RiskFactor["severity"], string> = {
+  ok: "text-success",
+  warn: "text-warning",
+  bad: "text-destructive",
+};
+
 /**
- * Confidence indicator component for route stability assessment
- * Displays low/medium/high confidence with clear legend
- * Shows high-volatility warnings when applicable
+ * Confidence indicator component for route stability assessment.
+ * Tooltip breaks down risk factors: liquidity depth, volatility, source freshness.
  */
 export function ConfidenceIndicator({
   score,
   volatility,
+  riskFactors,
 }: ConfidenceIndicatorProps) {
   const level = getConfidenceLevel(score);
   const isHighVolatility = volatility === "high";
   const prefersReducedMotion = useReducedMotion();
+
+  const factors = riskFactors ?? defaultRiskFactors(score, volatility);
 
   const config = {
     high: {
@@ -82,35 +156,85 @@ export function ConfidenceIndicator({
                 data-testid="volatile-badge"
                 variant="outline"
                 className={cn(
-                  'text-xs bg-warning/10 text-warning border-warning/20 flex items-center gap-1',
-                  !prefersReducedMotion && 'animate-pulse'
+                  "text-xs bg-warning/10 text-warning border-warning/20 flex items-center gap-1",
+                  !prefersReducedMotion && "animate-pulse"
                 )}
               >
                 <AlertTriangle className="h-3 w-3" />
                 Volatile
               </Badge>
             )}
+            {/* Visually-hidden risk factor summary for screen readers and tests */}
+            <span className="sr-only" aria-label="Risk factor breakdown">
+              <span data-testid="risk-factors">
+                {factors.map((factor) => (
+                  <span
+                    key={factor.label}
+                    data-testid={`risk-factor-${factor.label.toLowerCase().replace(/\s+/g, "-")}`}
+                  >
+                    {factor.label}: {factor.description}
+                  </span>
+                ))}
+              </span>
+            </span>
           </div>
         </TooltipTrigger>
-        <TooltipContent side="top" className="max-w-[250px]">
+        <TooltipContent side="top" className="max-w-[280px]">
           <div className="space-y-2">
             <p className="font-medium text-sm">Route Confidence: {score}%</p>
-            <div className="text-xs space-y-1">
+
+            {/* Risk factor breakdown */}
+            <div
+              className="space-y-1.5"
+              aria-label="Risk factor breakdown"
+            >
+              {factors.map((factor) => (
+                <div
+                  key={factor.label}
+                  className="flex items-start gap-2"
+                >
+                  <span
+                    className={cn(
+                      "mt-0.5 h-2 w-2 shrink-0 rounded-full",
+                      SEVERITY_DOT[factor.severity]
+                    )}
+                    aria-hidden="true"
+                  />
+                  <div className="min-w-0">
+                    <span
+                      className={cn(
+                        "text-xs font-semibold",
+                        SEVERITY_TEXT[factor.severity]
+                      )}
+                    >
+                      {factor.label}
+                    </span>
+                    <p className="text-[11px] text-muted-foreground leading-snug">
+                      {factor.description}
+                    </p>
+                  </div>
+                </div>
+              ))}
+            </div>
+
+            {/* Legend */}
+            <div className="border-t border-border pt-1.5 text-xs space-y-0.5">
               <div className="flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-success" />
-                <span>High (80-100%): Stable route</span>
+                <span>High (80–100%): Stable route</span>
               </div>
               <div className="flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-warning" />
-                <span>Medium (50-79%): Moderate stability</span>
+                <span>Medium (50–79%): Moderate stability</span>
               </div>
               <div className="flex items-center gap-2">
                 <span className="w-2 h-2 rounded-full bg-destructive" />
                 <span>Low (&lt;50%): Unstable route</span>
               </div>
             </div>
+
             {isHighVolatility && (
-              <p className="mt-2 border-t border-border pt-2 text-xs text-warning">
+              <p className="border-t border-border pt-1.5 text-xs text-warning">
                 ⚠️ High volatility detected. Route may change frequently.
               </p>
             )}

--- a/frontend/components/swap/FavoritesRail.tsx
+++ b/frontend/components/swap/FavoritesRail.tsx
@@ -1,0 +1,127 @@
+"use client";
+
+import { useRef, KeyboardEvent } from "react";
+import { Star, X } from "lucide-react";
+import { cn } from "@/lib/utils";
+import type { FavoritePair } from "@/hooks/useFavoritePairs";
+
+interface FavoritesRailProps {
+  favorites: FavoritePair[];
+  selectedBase?: string;
+  selectedQuote?: string;
+  onSelect: (pair: FavoritePair) => void;
+  onRemove: (baseAsset: string, quoteAsset: string) => void;
+  className?: string;
+}
+
+/**
+ * Horizontal scrollable rail of favorite trading pairs.
+ * Keyboard: Arrow keys navigate between chips, Enter/Space selects, Delete/Backspace removes.
+ */
+export function FavoritesRail({
+  favorites,
+  selectedBase,
+  selectedQuote,
+  onSelect,
+  onRemove,
+  className,
+}: FavoritesRailProps) {
+  const listRef = useRef<HTMLUListElement>(null);
+
+  if (favorites.length === 0) return null;
+
+  const focusItem = (index: number) => {
+    const items = listRef.current?.querySelectorAll<HTMLElement>("[data-chip]");
+    items?.[index]?.focus();
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLLIElement>, index: number, pair: FavoritePair) => {
+    const items = listRef.current?.querySelectorAll<HTMLElement>("[data-chip]");
+    const count = items?.length ?? 0;
+
+    switch (e.key) {
+      case "ArrowRight":
+        e.preventDefault();
+        focusItem((index + 1) % count);
+        break;
+      case "ArrowLeft":
+        e.preventDefault();
+        focusItem((index - 1 + count) % count);
+        break;
+      case "Enter":
+      case " ":
+        e.preventDefault();
+        onSelect(pair);
+        break;
+      case "Delete":
+      case "Backspace":
+        e.preventDefault();
+        onRemove(pair.baseAsset, pair.quoteAsset);
+        // Focus next or previous after removal
+        setTimeout(() => focusItem(Math.min(index, count - 2)), 0);
+        break;
+    }
+  };
+
+  return (
+    <nav aria-label="Favorite trading pairs" className={cn("w-full", className)}>
+      <div className="flex items-center gap-1.5 mb-1.5">
+        <Star className="h-3 w-3 text-amber-500 fill-amber-500" aria-hidden="true" />
+        <span className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          Favorites
+        </span>
+      </div>
+      <ul
+        ref={listRef}
+        role="list"
+        className="flex gap-2 overflow-x-auto pb-1 scrollbar-none"
+        aria-label="Favorite pairs list"
+      >
+        {favorites.map((pair, index) => {
+          const isActive =
+            pair.baseAsset === selectedBase && pair.quoteAsset === selectedQuote;
+          return (
+            <li key={`${pair.baseAsset}|${pair.quoteAsset}`} onKeyDown={(e) => handleKeyDown(e, index, pair)}>
+              <div
+                data-chip
+                role="button"
+                tabIndex={0}
+                aria-pressed={isActive}
+                aria-label={`${pair.base}/${pair.quote} favorite pair${isActive ? ", selected" : ""}`}
+                onClick={() => onSelect(pair)}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    onSelect(pair);
+                  }
+                }}
+                className={cn(
+                  "flex items-center gap-1.5 rounded-full border px-2.5 py-1 text-xs font-medium cursor-pointer select-none",
+                  "transition-colors focus:outline-none focus-visible:ring-2 focus-visible:ring-primary/50",
+                  "whitespace-nowrap",
+                  isActive
+                    ? "bg-primary/10 border-primary/40 text-primary"
+                    : "bg-muted/50 border-border/50 text-muted-foreground hover:bg-muted hover:text-foreground"
+                )}
+              >
+                <span>{pair.base}/{pair.quote}</span>
+                <button
+                  type="button"
+                  aria-label={`Remove ${pair.base}/${pair.quote} from favorites`}
+                  tabIndex={-1}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    onRemove(pair.baseAsset, pair.quoteAsset);
+                  }}
+                  className="rounded-full p-0.5 hover:bg-destructive/20 hover:text-destructive transition-colors"
+                >
+                  <X className="h-2.5 w-2.5" aria-hidden="true" />
+                </button>
+              </div>
+            </li>
+          );
+        })}
+      </ul>
+    </nav>
+  );
+}

--- a/frontend/components/swap/SplitView.stories.tsx
+++ b/frontend/components/swap/SplitView.stories.tsx
@@ -1,0 +1,86 @@
+import type { Story } from "@ladle/react";
+import { useState } from "react";
+import { SplitView } from "./SplitView";
+import { RouteDisplay } from "./RouteDisplay";
+
+// ---------------------------------------------------------------------------
+// Placeholder panels for story isolation
+// ---------------------------------------------------------------------------
+
+function QuotePanel() {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-6 space-y-4">
+      <h3 className="text-sm font-semibold">Quote Panel</h3>
+      <div className="h-32 rounded-lg bg-muted/40 flex items-center justify-center text-xs text-muted-foreground">
+        Swap form
+      </div>
+    </div>
+  );
+}
+
+function RoutePanel() {
+  return (
+    <div className="rounded-xl border border-border/50 bg-card p-4">
+      <h3 className="text-sm font-semibold mb-3">Route Details</h3>
+      <RouteDisplay amountOut="10.5 USDC" confidenceScore={85} volatility="low" />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Stories
+// ---------------------------------------------------------------------------
+
+/** Standard (single-column) layout */
+export const StandardMode: Story = () => {
+  const [isSplit, setIsSplit] = useState(false);
+  return (
+    <div className="p-8 bg-background min-h-screen">
+      <SplitView
+        isSplit={isSplit}
+        onToggle={() => setIsSplit((v) => !v)}
+        primary={<QuotePanel />}
+        secondary={<RoutePanel />}
+        className="max-w-[960px] mx-auto"
+      />
+    </div>
+  );
+};
+StandardMode.storyName = "SplitView — Standard Mode";
+
+/** Split (side-by-side) layout */
+export const SplitMode: Story = () => {
+  const [isSplit, setIsSplit] = useState(true);
+  return (
+    <div className="p-8 bg-background min-h-screen">
+      <SplitView
+        isSplit={isSplit}
+        onToggle={() => setIsSplit((v) => !v)}
+        primary={<QuotePanel />}
+        secondary={<RoutePanel />}
+        className="max-w-[960px] mx-auto"
+      />
+    </div>
+  );
+};
+SplitMode.storyName = "SplitView — Split Mode";
+
+/** Interactive toggle between both modes */
+export const Interactive: Story = () => {
+  const [isSplit, setIsSplit] = useState(false);
+  return (
+    <div className="p-8 bg-background min-h-screen">
+      <p className="text-xs text-muted-foreground mb-4">
+        Click the toggle button to switch between standard and split-view layouts.
+      </p>
+      <SplitView
+        isSplit={isSplit}
+        onToggle={() => setIsSplit((v) => !v)}
+        primary={<QuotePanel />}
+        secondary={<RoutePanel />}
+        className="max-w-[960px] mx-auto"
+      />
+    </div>
+  );
+};
+Interactive.storyName = "SplitView — Interactive Toggle";

--- a/frontend/components/swap/SplitView.tsx
+++ b/frontend/components/swap/SplitView.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { ReactNode } from "react";
+import { Columns2, LayoutList } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface SplitViewProps {
+  /** Left/primary panel (quote form) */
+  primary: ReactNode;
+  /** Right/secondary panel (route list) */
+  secondary: ReactNode;
+  /** Whether split-view is active */
+  isSplit: boolean;
+  /** Toggle callback */
+  onToggle: () => void;
+  className?: string;
+}
+
+/**
+ * SplitView layout for the swap page.
+ *
+ * - Desktop: side-by-side panels when isSplit=true, single column otherwise.
+ * - Mobile: always stacked (single column) regardless of isSplit.
+ * - Toggle button is keyboard-accessible with aria-pressed.
+ */
+export function SplitView({
+  primary,
+  secondary,
+  isSplit,
+  onToggle,
+  className,
+}: SplitViewProps) {
+  return (
+    <div className={cn("w-full", className)}>
+      {/* Toggle control */}
+      <div className="flex justify-end mb-3">
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onToggle}
+          aria-pressed={isSplit}
+          aria-label={isSplit ? "Switch to standard layout" : "Switch to split-view layout"}
+          className="gap-1.5 text-xs"
+        >
+          {isSplit ? (
+            <>
+              <LayoutList className="h-3.5 w-3.5" aria-hidden="true" />
+              Standard
+            </>
+          ) : (
+            <>
+              <Columns2 className="h-3.5 w-3.5" aria-hidden="true" />
+              Split View
+            </>
+          )}
+        </Button>
+      </div>
+
+      {/* Layout */}
+      <div
+        role="region"
+        aria-label={isSplit ? "Split view: quote and routes" : "Standard swap view"}
+        className={cn(
+          "w-full",
+          // On mobile always stack; on md+ honour isSplit
+          isSplit ? "flex flex-col md:flex-row md:items-start gap-4" : "flex flex-col items-center"
+        )}
+      >
+        {/* Primary panel */}
+        <div
+          aria-label="Quote panel"
+          className={cn(
+            "w-full",
+            isSplit ? "md:flex-1 md:min-w-0" : "max-w-[480px] mx-auto"
+          )}
+        >
+          {primary}
+        </div>
+
+        {/* Secondary panel — always rendered for screen readers, visually hidden when not split on mobile */}
+        <div
+          aria-label="Route list panel"
+          className={cn(
+            "w-full",
+            isSplit
+              ? "md:flex-1 md:min-w-0"
+              : "hidden md:hidden" // hidden in standard mode
+          )}
+        >
+          {secondary}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/swap/TokenPairSelector.tsx
+++ b/frontend/components/swap/TokenPairSelector.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useMemo, useState } from "react";
-import { ArrowLeftRight } from "lucide-react";
+import { ArrowLeftRight, Star } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
@@ -18,6 +18,8 @@ import type { TradingPair } from "@/types";
 import { AssetIcon } from "@/components/shared/AssetIcon";
 import { TokenSearchModal } from "@/components/shared/TokenSearchModal";
 import { useRecentTokens } from "@/hooks/useRecentTokens";
+import { useFavoritePairs } from "@/hooks/useFavoritePairs";
+import { FavoritesRail } from "./FavoritesRail";
 import { SwapPresetTemplates } from "./SwapPresetTemplates";
 
 export interface TokenPairSelectorProps {
@@ -112,6 +114,7 @@ export function TokenPairSelector({
   const [baseDialogOpen, setBaseDialogOpen] = useState(false);
   const [quoteDialogOpen, setQuoteDialogOpen] = useState(false);
   const { addRecentToken } = useRecentTokens();
+  const { favorites, isFavorite, toggleFavorite, removeFavorite } = useFavoritePairs();
 
   const { baseAssets, quoteAssets, validPairs } = useMemo(() => {
     const baseSet = new Map<string, AssetOption>();
@@ -205,9 +208,34 @@ export function TokenPairSelector({
     addRecentToken(asset);
   };
 
+  const currentPairFavorited =
+    selectedBase && selectedQuote
+      ? isFavorite(selectedBase, selectedQuote)
+      : false;
+
+  const handleToggleFavorite = () => {
+    if (!selectedBase || !selectedQuote) return;
+    const baseInfo = baseAssets.find((a) => a.asset === selectedBase);
+    const quoteInfo = quoteAssets.find((a) => a.asset === selectedQuote);
+    toggleFavorite({
+      base: baseInfo?.code ?? selectedBase,
+      quote: quoteInfo?.code ?? selectedQuote,
+      baseAsset: selectedBase,
+      quoteAsset: selectedQuote,
+    });
+  };
+
   return (
     <Card className={cn("p-4", className)}>
       <div className="space-y-4">
+        <FavoritesRail
+          favorites={favorites}
+          selectedBase={selectedBase}
+          selectedQuote={selectedQuote}
+          onSelect={(pair) => onPairChange(pair.baseAsset, pair.quoteAsset)}
+          onRemove={removeFavorite}
+        />
+
         <SwapPresetTemplates 
           onSelect={onPairChange}
           selectedBase={selectedBase}
@@ -229,20 +257,45 @@ export function TokenPairSelector({
             )}
           </div>
 
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            onClick={handleSwapSides}
-            disabled={
-              loading || !selectedBase || !selectedQuote || !canSwapSides
-            }
-            title="Swap base and quote assets"
-            className="shrink-0"
-          >
-            <ArrowLeftRight className="h-4 w-4" />
-            <span className="sr-only">Swap base and quote assets</span>
-          </Button>
+          <div className="flex flex-col items-center gap-1 shrink-0">
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              onClick={handleSwapSides}
+              disabled={
+                loading || !selectedBase || !selectedQuote || !canSwapSides
+              }
+              title="Swap base and quote assets"
+            >
+              <ArrowLeftRight className="h-4 w-4" />
+              <span className="sr-only">Swap base and quote assets</span>
+            </Button>
+            {selectedBase && selectedQuote && (
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={handleToggleFavorite}
+                aria-label={
+                  currentPairFavorited
+                    ? `Remove ${selectedBaseInfo?.code ?? selectedBase}/${selectedQuoteInfo?.code ?? selectedQuote} from favorites`
+                    : `Add ${selectedBaseInfo?.code ?? selectedBase}/${selectedQuoteInfo?.code ?? selectedQuote} to favorites`
+                }
+                aria-pressed={currentPairFavorited}
+                className="h-8 w-8"
+              >
+                <Star
+                  className={cn(
+                    "h-4 w-4 transition-colors",
+                    currentPairFavorited
+                      ? "fill-amber-500 text-amber-500"
+                      : "text-muted-foreground"
+                  )}
+                />
+              </Button>
+            )}
+          </div>
 
           <div className="flex-1">
             {loading ? (

--- a/frontend/components/swap/__tests__/AmountInput.precision.test.tsx
+++ b/frontend/components/swap/__tests__/AmountInput.precision.test.tsx
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { AmountInput } from '../AmountInput';
+
+describe('AmountInput — adaptive precision (#442)', () => {
+  // -----------------------------------------------------------------------
+  // resolveMaxDecimals via assetId
+  // -----------------------------------------------------------------------
+
+  it('defaults to 7 decimals for native asset', () => {
+    const onChange = vi.fn();
+    render(<AmountInput value="" assetId="native" onChange={onChange} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    // 7 decimal places should be accepted without error
+    fireEvent.change(input, { target: { value: '1.1234567' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clamps input to 7 decimals for native and shows error', () => {
+    const onChange = vi.fn();
+    render(<AmountInput value="" assetId="native" onChange={onChange} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1.12345678' } }); // 8 decimals
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert').textContent).toMatch(/7/);
+  });
+
+  it('respects explicit decimals=2 over assetId heuristic', () => {
+    const onChange = vi.fn();
+    render(<AmountInput value="" assetId="native" decimals={2} onChange={onChange} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1.123' } }); // 3 decimals, exceeds 2
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByRole('alert').textContent).toMatch(/2/);
+  });
+
+  it('accepts exactly max decimals without error', () => {
+    render(<AmountInput value="" decimals={4} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0.1234' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Tiny values
+  // -----------------------------------------------------------------------
+
+  it('accepts tiny value 0.0000001 within 7 decimals', () => {
+    render(<AmountInput value="" assetId="native" onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0.0000001' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clamps tiny value with too many decimals', () => {
+    render(<AmountInput value="" decimals={2} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '0.001' } }); // 3 decimals, exceeds 2
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // Very large values
+  // -----------------------------------------------------------------------
+
+  it('accepts very large integer value', () => {
+    render(<AmountInput value="" decimals={7} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '999999999' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('accepts very large value with max decimals', () => {
+    render(<AmountInput value="" decimals={7} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '999999999.1234567' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // decimals=0 (integer-only assets)
+  // -----------------------------------------------------------------------
+
+  it('rejects any fractional input when decimals=0', () => {
+    render(<AmountInput value="" decimals={0} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '5.1' } });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('accepts integer input when decimals=0', () => {
+    render(<AmountInput value="" decimals={0} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '42' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  // -----------------------------------------------------------------------
+  // aria attributes
+  // -----------------------------------------------------------------------
+
+  it('sets aria-invalid when precision error is present', () => {
+    render(<AmountInput value="" decimals={2} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1.999' } });
+    expect(input).toHaveAttribute('aria-invalid', 'true');
+  });
+
+  it('sets aria-describedby pointing to error element', () => {
+    render(<AmountInput value="" decimals={2} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1.999' } });
+    const errorId = input.getAttribute('aria-describedby');
+    expect(errorId).toBeTruthy();
+    expect(document.getElementById(errorId!)).toBeInTheDocument();
+  });
+
+  it('clears error when input is corrected to valid value', () => {
+    render(<AmountInput value="" decimals={2} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    // Trigger error with 3 decimals
+    fireEvent.change(input, { target: { value: '1.999' } });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    // Type a completely different valid value (not the clamped result)
+    fireEvent.change(input, { target: { value: '2.5' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+
+  it('clears error on empty input', () => {
+    render(<AmountInput value="" decimals={2} onChange={vi.fn()} />);
+    const input = screen.getByRole('textbox') as HTMLInputElement;
+    fireEvent.change(input, { target: { value: '1.999' } });
+    fireEvent.change(input, { target: { value: '' } });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});

--- a/frontend/hooks/useFavoritePairs.test.ts
+++ b/frontend/hooks/useFavoritePairs.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useFavoritePairs } from "@/hooks/useFavoritePairs";
+
+const PAIR_A = { base: "XLM", quote: "USDC", baseAsset: "native", quoteAsset: "USDC:ISSUER" };
+const PAIR_B = { base: "XLM", quote: "BTC", baseAsset: "native", quoteAsset: "BTC:ISSUER" };
+
+describe("useFavoritePairs", () => {
+  beforeEach(() => localStorage.clear());
+  afterEach(() => localStorage.clear());
+
+  it("starts empty", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    expect(result.current.favorites).toHaveLength(0);
+  });
+
+  it("adds a favorite", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    act(() => result.current.addFavorite(PAIR_A));
+    expect(result.current.favorites).toHaveLength(1);
+    expect(result.current.isFavorite(PAIR_A.baseAsset, PAIR_A.quoteAsset)).toBe(true);
+  });
+
+  it("does not duplicate favorites", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    act(() => {
+      result.current.addFavorite(PAIR_A);
+      result.current.addFavorite(PAIR_A);
+    });
+    expect(result.current.favorites).toHaveLength(1);
+  });
+
+  it("removes a favorite", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    act(() => result.current.addFavorite(PAIR_A));
+    act(() => result.current.removeFavorite(PAIR_A.baseAsset, PAIR_A.quoteAsset));
+    expect(result.current.favorites).toHaveLength(0);
+    expect(result.current.isFavorite(PAIR_A.baseAsset, PAIR_A.quoteAsset)).toBe(false);
+  });
+
+  it("toggleFavorite adds when not present", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    act(() => result.current.toggleFavorite(PAIR_A));
+    expect(result.current.isFavorite(PAIR_A.baseAsset, PAIR_A.quoteAsset)).toBe(true);
+  });
+
+  it("toggleFavorite removes when already present", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    act(() => result.current.addFavorite(PAIR_A));
+    act(() => result.current.toggleFavorite(PAIR_A));
+    expect(result.current.isFavorite(PAIR_A.baseAsset, PAIR_A.quoteAsset)).toBe(false);
+  });
+
+  it("persists to localStorage", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    act(() => result.current.addFavorite(PAIR_A));
+    const stored = JSON.parse(localStorage.getItem("stellar-route-favorite-pairs") ?? "[]");
+    expect(stored).toHaveLength(1);
+    expect(stored[0].baseAsset).toBe(PAIR_A.baseAsset);
+  });
+
+  it("hydrates from localStorage on mount", () => {
+    localStorage.setItem("stellar-route-favorite-pairs", JSON.stringify([PAIR_A, PAIR_B]));
+    const { result } = renderHook(() => useFavoritePairs());
+    expect(result.current.favorites).toHaveLength(2);
+    expect(result.current.isFavorite(PAIR_A.baseAsset, PAIR_A.quoteAsset)).toBe(true);
+  });
+
+  it("isFavorite returns false for unknown pair", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    expect(result.current.isFavorite("native", "UNKNOWN:ISSUER")).toBe(false);
+  });
+
+  it("caps at 20 favorites", () => {
+    const { result } = renderHook(() => useFavoritePairs());
+    act(() => {
+      for (let i = 0; i < 25; i++) {
+        result.current.addFavorite({ base: "XLM", quote: `T${i}`, baseAsset: "native", quoteAsset: `T${i}:ISSUER` });
+      }
+    });
+    expect(result.current.favorites.length).toBeLessThanOrEqual(20);
+  });
+});

--- a/frontend/hooks/useFavoritePairs.ts
+++ b/frontend/hooks/useFavoritePairs.ts
@@ -1,0 +1,92 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+const FAVORITES_KEY = "stellar-route-favorite-pairs";
+const MAX_FAVORITES = 20;
+
+export interface FavoritePair {
+  base: string;
+  quote: string;
+  /** canonical asset ids for lookup */
+  baseAsset: string;
+  quoteAsset: string;
+}
+
+function pairKey(baseAsset: string, quoteAsset: string): string {
+  return `${baseAsset}|${quoteAsset}`;
+}
+
+function loadFavorites(): FavoritePair[] {
+  if (typeof window === "undefined") return [];
+  try {
+    const raw = localStorage.getItem(FAVORITES_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (
+      Array.isArray(parsed) &&
+      parsed.every(
+        (p) =>
+          typeof p.base === "string" &&
+          typeof p.quote === "string" &&
+          typeof p.baseAsset === "string" &&
+          typeof p.quoteAsset === "string"
+      )
+    ) {
+      return parsed;
+    }
+  } catch {
+    // ignore corrupt storage
+  }
+  return [];
+}
+
+function saveFavorites(favorites: FavoritePair[]): void {
+  localStorage.setItem(FAVORITES_KEY, JSON.stringify(favorites));
+}
+
+export function useFavoritePairs() {
+  const [favorites, setFavorites] = useState<FavoritePair[]>(loadFavorites);
+
+  const isFavorite = useCallback(
+    (baseAsset: string, quoteAsset: string) =>
+      favorites.some(
+        (f) => pairKey(f.baseAsset, f.quoteAsset) === pairKey(baseAsset, quoteAsset)
+      ),
+    [favorites]
+  );
+
+  const addFavorite = useCallback((pair: FavoritePair) => {
+    setFavorites((prev) => {
+      if (prev.some((f) => pairKey(f.baseAsset, f.quoteAsset) === pairKey(pair.baseAsset, pair.quoteAsset))) {
+        return prev;
+      }
+      const next = [pair, ...prev].slice(0, MAX_FAVORITES);
+      saveFavorites(next);
+      return next;
+    });
+  }, []);
+
+  const removeFavorite = useCallback((baseAsset: string, quoteAsset: string) => {
+    setFavorites((prev) => {
+      const next = prev.filter(
+        (f) => pairKey(f.baseAsset, f.quoteAsset) !== pairKey(baseAsset, quoteAsset)
+      );
+      saveFavorites(next);
+      return next;
+    });
+  }, []);
+
+  const toggleFavorite = useCallback(
+    (pair: FavoritePair) => {
+      if (isFavorite(pair.baseAsset, pair.quoteAsset)) {
+        removeFavorite(pair.baseAsset, pair.quoteAsset);
+      } else {
+        addFavorite(pair);
+      }
+    },
+    [isFavorite, addFavorite, removeFavorite]
+  );
+
+  return { favorites, isFavorite, addFavorite, removeFavorite, toggleFavorite };
+}

--- a/frontend/hooks/useSplitView.ts
+++ b/frontend/hooks/useSplitView.ts
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState, useCallback } from "react";
+
+const SPLIT_VIEW_KEY = "stellar-route-split-view";
+
+function loadSplitView(): boolean {
+  if (typeof window === "undefined") return false;
+  return localStorage.getItem(SPLIT_VIEW_KEY) === "true";
+}
+
+export function useSplitView() {
+  const [isSplit, setIsSplit] = useState(loadSplitView);
+
+  const toggleSplit = useCallback(() => {
+    setIsSplit((prev) => {
+      const next = !prev;
+      localStorage.setItem(SPLIT_VIEW_KEY, String(next));
+      return next;
+    });
+  }, []);
+
+  return { isSplit, toggleSplit };
+}


### PR DESCRIPTION
Closes #426
Closes #441
Closes #442
Closes  #443

#426 - Token pair favorites and quick-access rail
- useFavoritePairs hook with localStorage persistence (max 20)
- FavoritesRail component: horizontal scrollable, arrow-key nav, Enter/Space to select, Delete/Backspace to remove, full a11y labels
- TokenPairSelector: star toggle button (aria-pressed) + FavoritesRail

#441 - Route confidence tooltip with explainable risk factors
- RiskFactor interface (label, severity, description)
- Default factors: Liquidity Depth, Source Freshness, Volatility derived from score + volatility; always rendered sr-only for a11y
- Tooltip shows factor breakdown with severity colour coding
- 15 unit + property tests

#442 - Adaptive input precision by asset and trade size
- AmountInput: assetId prop drives maxDecimalsForSellAsset()
- Precision clamping with role=alert error, aria-invalid/describedby
- Handles decimals=0 (integer-only), tiny and very large values
- 14 edge-case tests

#443 - Split-view mode for quote panel and route list
- SplitView component: desktop side-by-side / mobile stacked
- useSplitView hook with localStorage persistence
- SwapPageClient wires SwapCard + RouteDisplay into SplitView
- Toggle button with aria-pressed; 3 Ladle visual regression stories