### PR TITLE
[backend] Load real fee_bps from DB into routing graph edges

### DIFF
--- a/crates/api/src/graph.rs
+++ b/crates/api/src/graph.rs
@@ -8,6 +8,10 @@ use tracing::{debug, error, info, warn};
 
 use stellarroute_routing::compaction::CompactedGraph;
 
+// Fallback defaults used when fee information is not available in the DB.
+pub const DEFAULT_AMM_FEE_BPS: u32 = 30;
+pub const DEFAULT_SDEX_FEE_BPS: u32 = 20;
+
 /// Daemon that maintains an active in-memory cache of the routing graph
 pub struct GraphManager {
     pub db: PgPool,
@@ -141,11 +145,17 @@ impl GraphManager {
             hash_map.insert(id, canon);
         }
 
+        // Join to `amm_pool_reserves` to pull real fee_bps for AMM venues when available.
+        // Normalized liquidity currently doesn't include fee information directly.
+        // We fallback to module-level defaults when the DB doesn't provide a value.
+
         let rows = sqlx::query(
             r#"
-            SELECT selling_asset_id, buying_asset_id, venue_type, venue_ref, price, available_amount
-            FROM normalized_liquidity
-            WHERE available_amount > 0
+            SELECT nl.selling_asset_id, nl.buying_asset_id, nl.venue_type, nl.venue_ref, nl.price, nl.available_amount,
+                   amm.fee_bps as fee_bps
+            FROM normalized_liquidity nl
+            LEFT JOIN amm_pool_reserves amm ON nl.venue_type = 'amm' AND nl.venue_ref = amm.pool_address
+            WHERE nl.available_amount > 0
             "#,
         )
         .fetch_all(&self.db)
@@ -169,6 +179,14 @@ impl GraphManager {
                     if p > 0.0 && a > 0.0 {
                         let is_amm = venue_type == "amm";
                         let venue_ref = r.get::<String, _>("venue_ref");
+                        // `fee_bps` may be present from amm_pool_reserves (for AMM) or NULL.
+                        // We'll use DB-provided value when present; otherwise fallback.
+                        let db_fee: Option<i32> = r.get::<Option<i32>, _>("fee_bps");
+                        let fee_bps_u32: u32 = if is_amm {
+                            db_fee.map(|v| v as u32).unwrap_or(DEFAULT_AMM_FEE_BPS)
+                        } else {
+                            db_fee.map(|v| v as u32).unwrap_or(DEFAULT_SDEX_FEE_BPS)
+                        };
 
                         // Perform anomaly detection
                         let mut detector = self.anomaly_detector.lock().await;
@@ -189,7 +207,7 @@ impl GraphManager {
                             venue_ref,
                             liquidity: (a * 1e7) as i128,
                             price: p,
-                            fee_bps: if is_amm { 30 } else { 20 },
+                            fee_bps: fee_bps_u32,
                             anomaly_score: anomaly_res.score,
                             anomaly_reasons: anomaly_res.reasons,
                         });
@@ -323,5 +341,27 @@ mod tests {
             h.await.unwrap();
         }
         updater.await.unwrap();
+    }
+
+    #[test]
+    fn test_fee_selection_varied_fixtures() {
+        // Local helper reproducing the selection logic used in `sync_graph`.
+        fn select_fee(db_fee: Option<i32>, is_amm: bool) -> u32 {
+            if is_amm {
+                db_fee.map(|v| v as u32).unwrap_or(DEFAULT_AMM_FEE_BPS)
+            } else {
+                db_fee.map(|v| v as u32).unwrap_or(DEFAULT_SDEX_FEE_BPS)
+            }
+        }
+
+        // AMM with explicit DB fee
+        assert_eq!(select_fee(Some(25), true), 25);
+        // AMM missing DB fee -> fallback
+        assert_eq!(select_fee(None, true), DEFAULT_AMM_FEE_BPS);
+
+        // SDEX with explicit DB fee
+        assert_eq!(select_fee(Some(5), false), 5);
+        // SDEX missing DB fee -> fallback
+        assert_eq!(select_fee(None, false), DEFAULT_SDEX_FEE_BPS);
     }
 }


### PR DESCRIPTION
Stop hardcoding fee_bps in GraphManager; read AMM fees from amm_pool_reserves and fallback when missing.

# Changes:
- Read  in  and use as edge 
- Module-level fallbacks
- documented in code
- Added unit test
- 
# Notes:
-  currently has no  column; 
SDEX uses fallback until schema is extended.

Closes #651