### PR TITLE
infra: add frontend production build gate to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,3 +84,19 @@ jobs:
         run: cd sdk-js && npm run build
       - name: Run tests
         run: cd sdk-js && npm test
+
+  frontend-build:
+    name: Frontend Production Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci --prefix frontend
+      - name: Build frontend
+        run: npm --prefix frontend run build


### PR DESCRIPTION
Closes #638

**Summary of Changes:**
- Added a new `frontend-build` job to `.github/workflows/ci.yml`.
- Configured the job to use `npm ci --prefix frontend` for clean, reproducible dependency installation.
- Added the step to run `npm --prefix frontend run build` to catch broken imports before merging.
- The CI pipeline will now automatically fail and block merges if the frontend build breaks.