### PR TITLE
fix(frontend): resolve app-shell and RouteDisplay build errors blocking production

### DIFF
--- a/frontend/components/layout/app-shell.tsx
+++ b/frontend/components/layout/app-shell.tsx
@@ -8,7 +8,7 @@ import { Header } from './header';
 import { Footer } from './footer';
 import { cn } from '@/lib/utils';
 import { SessionRecoveryModal } from '@/components/modals/SessionRecoveryModal';
-import { useSessionRecoveryContext } from '@/components/providers/session-recovery-provider';
+import { useSessionRecovery } from '@/components/providers/session-recovery-provider';
 import { WalletSyncBanner } from '@/components/shared';
 import { DebugOverlay } from '@/components/debug/DebugOverlay';
 
@@ -37,7 +37,7 @@ export function AppShell({ children }: AppShellProps) {
     beginRecovery,
     completeRecovery,
     dismissRecovery,
-  } = useSessionRecoveryContext();
+  } = useSessionRecovery();
 
   // Determine if page should be full-width (orderbook, analytics) or centered (swap)
   const isFullWidth =

--- a/frontend/components/swap/RouteDisplay.tsx
+++ b/frontend/components/swap/RouteDisplay.tsx
@@ -136,7 +136,7 @@ export function RouteDisplay({
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
   const routes = alternativeRoutes ?? buildAlternativeRoutes(amountOut);
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const { animateInClass } = useRouteSwitchTransition(routeKey ?? selectedRouteId);
+  const { animateInClass } = useRouteSwitchTransition(routeKey ?? selectedRouteId ?? undefined);
   const { showSkeleton, contentClassName } = useProgressiveLoadingTransition(isLoading);
 
   const handleSelect = (route: AlternativeRoute) => {


### PR DESCRIPTION
## Summary
Fix two TypeScript/module errors that block the production frontend build: a non-existent hook name
used in the app shell, and a `null`-vs-`undefined` type mismatch in the route display component.

## Motivation
`npm --prefix frontend run build` fails on `main` with two errors:

1. `app-shell.tsx` imports and calls `useSessionRecoveryContext`, which does not exist — the provider
   only exports `useSessionRecovery`. This causes a hard compile failure in both webpack and Turbopack.
2. `RouteDisplay.tsx` passes `routeKey ?? selectedRouteId` to `useRouteSwitchTransition`, but
   `selectedRouteId` is typed as `string | null` while the hook expects `string | number | undefined`.
   Turbopack's stricter TypeScript checker rejects `null` as an invalid argument.

> **Note on the issue description:** The `SwapViewState` import in `RouteRow.tsx` is not itself broken
> — `ViewState.tsx` correctly exports `SwapViewState`. The `Module not found: Can't resolve './ViewState'`
> error in the webpack output was a cascade failure triggered by the two errors above preventing the
> barrel `index.ts` from resolving cleanly.

## Linked Issue
Closes #630

## Proposed Changes

### `frontend/components/layout/app-shell.tsx`
- Replaced the non-existent `useSessionRecoveryContext` import with the correct `useSessionRecovery`
  export from `session-recovery-provider.tsx`.
- Updated the destructuring call site at line 40 to match.

### `frontend/components/swap/RouteDisplay.tsx`
- Added `?? undefined` as a final fallback in `routeKey ?? selectedRouteId ?? undefined` to coerce
  the `null` initial state of `selectedRouteId` to `undefined`, satisfying the `string | number | undefined`
  signature of `useRouteSwitchTransition`.

## Testing Performed
- **Production build**: `npm --prefix frontend run build` — compiled successfully with no errors.
- **Unit tests**: `npm --prefix frontend run test` — all **66 tests across 20 test files** passed.
