### PR TITLE
docs: extend documentation hub index with all orphaned runbooks and frontend guides

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -23,8 +23,11 @@ This directory is the documentation hub for StellarRoute. It organizes design, d
 - [Versioning](api/versioning.md) — API versioning strategy.
 - [Versioning policy](api/versioning-policy.md) — lifecycle policy for API changes.
 - [Error taxonomy](api/error_taxonomy.md) — standardized API error responses.
+- [Canonical pair ordering](api/canonical_pair_ordering.md) — rules for normalizing asset pair order.
 - [v1 migration guide](api/v1-migration-guide.md) — compatibility and migration advice.
 - [OpenAPI spec](api/openapi.yaml) — machine-readable REST API schema.
+- [Integrator guide](api/integrator-guide.md) — quick-start and integration patterns for external API consumers.
+- [Integrator error guide](api/integrator-error-guide.md) — error handling and retry guidance for integrators.
 
 ### Contracts
 
@@ -44,21 +47,62 @@ This directory is the documentation hub for StellarRoute. It organizes design, d
 ### Development
 
 - [Setup guide](development/SETUP.md) — local environment setup and tooling.
+- [Indexer guide](development/indexer-guide.md) — indexer runbook, configuration, and troubleshooting.
 - [Testing guide](development/testing-guide.md) — project test strategies and commands.
 - [Wallet integration](development/wallet-integration.md) — frontend wallet integration patterns.
+- [Frontend developer guide](development/frontend-guide.md) — frontend setup, workflow, and contribution patterns.
 
 ### SDK
 
 - [TypeScript SDK documentation](sdk-js/README.md) — TypeScript SDK guides and API docs.
 - [Rust SDK documentation](sdk-rust/README.md) — Rust SDK usage and examples.
 
+### Operational runbooks
+
+- [Kill switch runbook](RUNBOOK_KILL_SWITCH.md) — emergency kill-switch activation and recovery procedure.
+- [Quote purger runbook](QUOTE_PURGER_RUNBOOK.md) — quote purger operation, scheduling, and troubleshooting.
+- [Routing canary](routing_canary.md) — canary routing configuration, promotion, and rollback.
+- [Indexer lag monitoring](indexer-lag-monitoring.md) — indexer lag alerting thresholds and remediation steps.
+- [Cache hierarchical invalidation](cache/hierarchical_invalidation.md) — cache invalidation strategy and failure modes.
+- [Swap end-to-end flow](swap-e2e-flow.md) — walkthrough of a complete swap from quote to on-chain settlement.
+- [Incident replay workflow](incident-replay-workflow.md) — replay and recovery workflow.
+- [Audit log retention](audit-log-retention.md) — audit log retention policy.
+
 ### Supporting docs
 
 - [Monitoring](monitoring.md) — monitoring and metrics guidance.
-- [Readiness](readiness/M2_GUIDE.md) — readiness and runbook content.
-- [Audit log retention](audit-log-retention.md) — audit log retention policy.
+- [Consistency strategy](CONSISTENCY_STRATEGY.md) — data consistency guarantees and trade-offs.
 - [Hybrid optimizer](hybrid_optimizer.md) — optimizer architecture and behavior.
-- [Incident replay workflow](incident-replay-workflow.md) — replay and recovery workflow.
+- [Key rotation](key_rotation.md) — credential and key rotation procedures.
+- [Performance budget](performance_budget.md) — frontend and API performance targets.
+- [Readiness](readiness/M2_GUIDE.md) — readiness and runbook content.
+
+### Design
+
+- [Information architecture](design/information-architecture.md) — sitemap, navigation hierarchy, and UX structure.
+- [Empty states spec](design/empty-states-spec.md) — design specification for empty and error states.
+- [Accessibility contrast audit](design/accessibility-contrast-audit.md) — WCAG colour contrast audit results.
+
+### Frontend documentation
+
+These docs live under [`frontend/docs/`](../frontend/docs/) and cover frontend-specific contributor topics.
+
+- [Motion design guidelines](../frontend/docs/motion-design-guidelines.md) — animation principles and approved motion patterns.
+- [Telemetry schema](../frontend/docs/telemetry-schema.md) — frontend event tracking schema and naming conventions.
+- [Trader error copy style guide](../frontend/docs/trader-error-copy-style-guide.md) — tone, phrasing, and copy standards for error messages.
+- [Debug overlay](../frontend/docs/debug-overlay.md) — developer debug panel usage and extension guide.
+- [Iconography system](../frontend/docs/iconography-system.md) — icon library conventions and usage rules.
+- [Wallet onboarding wireframes](../frontend/docs/WALLET_ONBOARDING_WIREFRAMES.md) — wireframes for the wallet connection onboarding flow.
+- [Quote refresh screen reader testing](../frontend/docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md) — accessibility testing guide for live-region quote announcements.
+- [Swap i18n audit](../frontend/docs/swap-i18n-audit.md) — internationalisation coverage audit for swap UI strings.
+- [Swap visual regression](../frontend/docs/swap-visual-regression.md) — visual regression test setup and baseline management.
+- [Price history sparkline](../frontend/docs/price-history.md) — implementation notes for the 24-hour price sparkline.
+- [Orderbook highlighting](../frontend/docs/orderbook-highlighting-feature.md) — feature spec for orderbook row highlighting.
+- [Hero CTA feature](../frontend/docs/hero-cta-feature.md) — implementation spec for the hero call-to-action component.
+- [Relative time feature](../frontend/docs/relative-time-feature.md) — design and implementation of the relative timestamp component.
+- [Status page feature](../frontend/docs/status-page-feature.md) — feature spec for the system status page.
+- [Feature flags](../frontend/src/FEATURE_FLAGS.md) — runtime feature flag reference and usage guide.
+- [Storybook guide](../frontend/STORYBOOK.md) — Storybook setup, story conventions, and CI snapshot workflow.
 
 ## Getting started
 


### PR DESCRIPTION
## Summary
Extend `docs/README.md` with categorized links for every document that was previously reachable only by
directory browsing or grep. Adds a dedicated **Operational runbooks** section, a **Design** section, and
a new **Frontend documentation** subsection that surfaces all `frontend/docs/` and `frontend/src/` content
without duplicating it.

## Motivation
`docs/README.md` listed only a subset of the available documentation. Operational runbooks, integrator
guides, design specs, and all frontend contributor docs were completely absent from the index, making them
effectively invisible to contributors and operators who rely on the hub as their entry point.

## Linked Issue
Closes #621

## Proposed Changes

### `docs/README.md`

**API section** — added three missing entries:
- `api/integrator-guide.md` — quick-start and integration patterns for external consumers.
- `api/integrator-error-guide.md` — error handling and retry guidance for integrators.
- `api/canonical_pair_ordering.md` — rules for normalizing asset pair order.

**Development section** — added two missing entries:
- `development/indexer-guide.md` — indexer runbook, configuration, and troubleshooting.
- `development/frontend-guide.md` — frontend setup, workflow, and contribution patterns.

**Operational runbooks** _(new section)_ — indexes all production runbooks and flow docs that had no prior
entry in the hub:
- `RUNBOOK_KILL_SWITCH.md`, `QUOTE_PURGER_RUNBOOK.md`, `routing_canary.md`, `indexer-lag-monitoring.md`,
  `cache/hierarchical_invalidation.md`, `swap-e2e-flow.md`
- `incident-replay-workflow.md` and `audit-log-retention.md` moved here from *Supporting docs* where they were
  semantically misplaced.

**Supporting docs** — added three orphaned top-level docs:
- `CONSISTENCY_STRATEGY.md`, `key_rotation.md`, `performance_budget.md`.

**Design** _(new section)_ — indexes the three design specs found under `docs/design/`:
- `information-architecture.md`, `empty-states-spec.md`, `accessibility-contrast-audit.md`.

**Frontend documentation** _(new section)_ — relative links into `frontend/docs/` and `frontend/src/` for all
16 stable frontend contributor documents, including:
- `telemetry-schema.md`, `trader-error-copy-style-guide.md`, `motion-design-guidelines.md`,
  `debug-overlay.md`, `iconography-system.md`, `WALLET_ONBOARDING_WIREFRAMES.md`,
  `QUOTE_REFRESH_SCREEN_READER_TESTING.md`, `swap-i18n-audit.md`, `swap-visual-regression.md`,
  `price-history.md`, `orderbook-highlighting-feature.md`, `hero-cta-feature.md`,
  `relative-time-feature.md`, `status-page-feature.md`.
- `frontend/src/FEATURE_FLAGS.md` — runtime feature flag reference.
- `frontend/STORYBOOK.md` — Storybook setup and CI snapshot workflow.

## Verification
- All 68 links in the updated `docs/README.md` were verified to resolve to existing files via a PowerShell
  path-existence check — no broken links introduced.
- `README.md` and `CONTRIBUTING.md` contain no direct links to `docs/README.md`; no cross-reference
  breakage occurs.
- No files were moved or rewritten; this PR is purely additive index work.
