### PR TITLE
[352] [frontend] In-app diagnostics panel for quote/debug metadata

### DIFF
--- a/crates/indexer/src/amm.rs
+++ b/crates/indexer/src/amm.rs
@@ -574,7 +574,10 @@ mod tests {
         let count = (1..=20)
             .filter(|n| UPSERT_AMM_POOL_RESERVE_SQL.contains(&format!("${}", n)))
             .count();
-        assert_eq!(count, 9, "SQL must bind 9 args: 7 core + trace_id + span_id");
+        assert_eq!(
+            count, 9,
+            "SQL must bind 9 args: 7 core + trace_id + span_id"
+        );
     }
 
     /// Verifies TraceContext fields are present and bindable (non-panicking default).

--- a/crates/indexer/src/db/connection.rs
+++ b/crates/indexer/src/db/connection.rs
@@ -65,11 +65,9 @@ impl Database {
         let migration_0007 =
             include_str!("../../migrations/0007_backfill_and_normalized_storage.sql");
         let migration_0008 = include_str!("../../migrations/0008_soroban_discovery_cursors.sql");
-        let migration_0009 =
-            include_str!("../../migrations/0009_finalize_unified_liquidity.sql");
+        let migration_0009 = include_str!("../../migrations/0009_finalize_unified_liquidity.sql");
         let migration_0010 = include_str!("../../migrations/0010_asset_metadata.sql");
-        let migration_0011 =
-            include_str!("../../migrations/0011_trace_context_provenance.sql");
+        let migration_0011 = include_str!("../../migrations/0011_trace_context_provenance.sql");
         let migration_0012 = include_str!("../../migrations/0012_contract_swap_activity.sql");
         let migration_0013 = include_str!("../../migrations/0013_amm_pools.sql");
 
@@ -221,10 +219,7 @@ impl Database {
             .await
             .map_err(|e| {
                 error!("Migration 0013 failed: {}", e);
-                IndexerError::DatabaseMigration(format!(
-                    "Failed to run 0013_amm_pools.sql: {}",
-                    e
-                ))
+                IndexerError::DatabaseMigration(format!("Failed to run 0013_amm_pools.sql: {}", e))
             })?;
 
         info!("Database migrations completed");

--- a/frontend/__mocks__/lucide-react.tsx
+++ b/frontend/__mocks__/lucide-react.tsx
@@ -40,6 +40,7 @@ export const Check = Icon;
 export const Clock = Icon;
 export const Clock3 = Icon;
 export const Copy = Icon;
+export const Stethoscope = Icon;
 export const History = Icon;
 export const Search = Icon;
 export const Download = Icon;

--- a/frontend/components/layout/app-shell.tsx
+++ b/frontend/components/layout/app-shell.tsx
@@ -8,7 +8,7 @@ import { Header } from './header';
 import { Footer } from './footer';
 import { cn } from '@/lib/utils';
 import { SessionRecoveryModal } from '@/components/modals/SessionRecoveryModal';
-import { useSessionRecoveryContext } from '@/components/providers/session-recovery-provider';
+import { useSessionRecovery } from '@/components/providers/session-recovery-provider';
 import { WalletSyncBanner } from '@/components/shared';
 import { DebugOverlay } from '@/components/debug/DebugOverlay';
 
@@ -37,7 +37,7 @@ export function AppShell({ children }: AppShellProps) {
     beginRecovery,
     completeRecovery,
     dismissRecovery,
-  } = useSessionRecoveryContext();
+  } = useSessionRecovery();
 
   // Determine if page should be full-width (orderbook, analytics) or centered (swap)
   const isFullWidth =

--- a/frontend/components/shared/DiagnosticsPanel.test.tsx
+++ b/frontend/components/shared/DiagnosticsPanel.test.tsx
@@ -29,7 +29,7 @@ const mockQuote: PriceQuote = {
       source: 'sdex',
     },
   ],
-  timestamp: Math.floor(Date.now() / 1000),
+  timestamp: Date.now(),
 };
 
 describe('DiagnosticsPanel', () => {
@@ -51,12 +51,14 @@ describe('DiagnosticsPanel', () => {
     render(
       <DiagnosticsPanel
         quote={mockQuote}
+        requestId="server-req-123"
+        lastQuotedAtMs={Date.now() - 1_000}
         isOpen={true}
         onOpenChange={vi.fn()}
       />,
     );
 
-    expect(screen.getByText(/Request ID:/)).toBeTruthy();
+    expect(screen.getByText('server-req-123')).toBeTruthy();
     expect(screen.getByText(/Quote Age:/)).toBeTruthy();
     expect(screen.getByText(/Route:/)).toBeTruthy();
   });
@@ -71,21 +73,7 @@ describe('DiagnosticsPanel', () => {
     );
 
     expect(screen.getByText('Copy')).toBeTruthy();
-    expect(screen.getByText(/Show|Hide/)).toBeTruthy();
     expect(screen.getByText('Export')).toBeTruthy();
-  });
-
-  it('displays sensitive field toggle button', () => {
-    render(
-      <DiagnosticsPanel
-        quote={mockQuote}
-        isOpen={true}
-        onOpenChange={vi.fn()}
-      />,
-    );
-
-    const sensitiveToggle = screen.getByText(/Show/);
-    expect(sensitiveToggle).toBeTruthy();
   });
 
   it('calls onOpenChange when dialog closes', () => {
@@ -118,5 +106,19 @@ describe('DiagnosticsPanel', () => {
 
     const selector = screen.getByRole('combobox', { hidden: true });
     expect(selector).toBeTruthy();
+  });
+
+  it('does not display raw issuer addresses in diagnostics text', () => {
+    render(
+      <DiagnosticsPanel
+        quote={mockQuote}
+        isOpen={true}
+        onOpenChange={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.queryByText(/GA5ZSEJYB37JRC5AVCIA5MOP4IHTZMAB5KYXOM5KBVG7GBJINW7JCXU/),
+    ).toBeNull();
   });
 });

--- a/frontend/components/shared/DiagnosticsPanel.tsx
+++ b/frontend/components/shared/DiagnosticsPanel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Copy, Download, Eye, EyeOff } from 'lucide-react';
+import { Copy, Download } from 'lucide-react';
 import { useState } from 'react';
 
 import { Button } from '@/components/ui/button';
@@ -25,25 +25,29 @@ import {
   formatDiagnosticsForDisplay,
   generateRequestId,
   redactSensitiveFields,
-  type QuoteDiagnostics,
 } from '@/lib/diagnostics';
 import type { PriceQuote } from '@/types';
 import { toast } from 'sonner';
 
 interface DiagnosticsPanelProps {
   quote: PriceQuote | undefined;
+  requestId?: string | null;
+  lastQuotedAtMs?: number | null;
   isOpen: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
 export function DiagnosticsPanel({
   quote,
+  requestId: requestIdProp,
+  lastQuotedAtMs,
   isOpen,
   onOpenChange,
 }: DiagnosticsPanelProps) {
   const [exportFormat, setExportFormat] = useState<'json' | 'csv'>('json');
-  const [showSensitiveFields, setShowSensitiveFields] = useState(false);
-  const [requestId] = useState(() => generateRequestId());
+  const [fallbackRequestId] = useState(() => generateRequestId());
+
+  const requestId = requestIdProp || fallbackRequestId;
 
   if (!quote) {
     return (
@@ -60,15 +64,16 @@ export function DiagnosticsPanel({
     );
   }
 
-  const diagnostics = collectQuoteDiagnostics(quote, requestId);
-  const displayText = formatDiagnosticsForDisplay(diagnostics);
-  const finalDisplayText = showSensitiveFields
-    ? displayText
-    : redactSensitiveFields(displayText);
+  const diagnostics = collectQuoteDiagnostics(quote, requestId, {
+    lastQuotedAtMs,
+  });
+  const displayText = redactSensitiveFields(
+    formatDiagnosticsForDisplay(diagnostics),
+  );
 
   const handleCopy = async () => {
     try {
-      await navigator.clipboard.writeText(finalDisplayText);
+      await navigator.clipboard.writeText(displayText);
       toast.success('Diagnostics copied to clipboard');
     } catch {
       toast.error('Failed to copy to clipboard');
@@ -116,7 +121,7 @@ export function DiagnosticsPanel({
         <div className="space-y-4">
           <Card className="bg-muted/30 p-4">
             <div className="font-mono text-xs whitespace-pre-wrap break-words">
-              {finalDisplayText}
+              {displayText}
             </div>
           </Card>
 
@@ -131,22 +136,11 @@ export function DiagnosticsPanel({
               Copy
             </Button>
 
-            <Button
-              size="sm"
-              variant="outline"
-              onClick={() => setShowSensitiveFields(!showSensitiveFields)}
-              className="gap-2"
-            >
-              {showSensitiveFields ? (
-                <EyeOff className="h-4 w-4" />
-              ) : (
-                <Eye className="h-4 w-4" />
-              )}
-              {showSensitiveFields ? 'Hide' : 'Show'} Sensitive
-            </Button>
-
             <div className="flex gap-2">
-              <Select value={exportFormat} onValueChange={(value: any) => setExportFormat(value)}>
+              <Select
+                value={exportFormat}
+                onValueChange={(value: 'json' | 'csv') => setExportFormat(value)}
+              >
                 <SelectTrigger className="w-24">
                   <SelectValue />
                 </SelectTrigger>

--- a/frontend/components/swap/RouteDisplay.tsx
+++ b/frontend/components/swap/RouteDisplay.tsx
@@ -136,7 +136,7 @@ export function RouteDisplay({
   const [selectedRouteId, setSelectedRouteId] = useState<string | null>(null);
   const routes = alternativeRoutes ?? buildAlternativeRoutes(amountOut);
   const scrollRef = useRef<HTMLDivElement | null>(null);
-  const { animateInClass } = useRouteSwitchTransition(routeKey ?? selectedRouteId);
+  const { animateInClass } = useRouteSwitchTransition(routeKey ?? selectedRouteId ?? undefined);
   const { showSkeleton, contentClassName } = useProgressiveLoadingTransition(isLoading);
 
   const handleSelect = (route: AlternativeRoute) => {

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -3,7 +3,7 @@
 import { useState, useCallback, useEffect, useMemo, useRef } from 'react';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { ArrowUpDown, RefreshCw } from 'lucide-react';
+import { ArrowUpDown, RefreshCw, Stethoscope } from 'lucide-react';
 import { AmountInput } from './AmountInput';
 import { TokenSelector } from './TokenSelector';
 import { PriceInfoPanel } from './PriceInfoPanel';
@@ -31,6 +31,7 @@ import { useCompactMode } from '@/hooks/useCompactMode';
 import { useShareableQuote } from '@/hooks/useShareableQuote';
 import { ShareQuoteButton } from './ShareQuoteButton';
 import { NetworkMismatchBanner } from '@/components/shared/NetworkMismatchBanner';
+import { DiagnosticsPanel } from '@/components/shared/DiagnosticsPanel';
 import { useWallet } from '@/components/providers/wallet-provider';
 import { signTransactionWithWallet } from '@/lib/wallet';
 import { submitToHorizon, getNetworkPassphrase } from '@/lib/wallet/submit';
@@ -180,6 +181,7 @@ export function SwapCard() {
   );
   const [isRecoveringSession, setIsRecoveringSession] = useState(false);
   const [shortcutHelpOpen, setShortcutHelpOpen] = useState(false);
+  const [diagnosticsOpen, setDiagnosticsOpen] = useState(false);
   const lastFocusedElementRef = useRef<HTMLElement | null>(null);
   const hiddenAtRef = useRef<number | null>(null);
   const recoveryReason: 'refresh' | 'wake' | null = wakeRecoveryOpen
@@ -613,6 +615,15 @@ export function SwapCard() {
               <Button
                 variant="ghost"
                 size="icon"
+                onClick={() => setDiagnosticsOpen(true)}
+                aria-label={t('swap.card.diagnostics')}
+                className="h-9 w-9 rounded-xl hover:bg-muted/80"
+              >
+                <Stethoscope className="h-4.5 w-4.5 text-muted-foreground" />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon"
                 onClick={() => quote.refresh()}
                 disabled={quote.loading}
                 aria-label={t('swap.card.refreshQuote')}
@@ -912,6 +923,14 @@ export function SwapCard() {
         isRecovering={isRecoveringSession}
         onRestore={handleRestoreRecovery}
         onDiscard={handleDiscardRecovery}
+      />
+
+      <DiagnosticsPanel
+        quote={quote.data}
+        requestId={quote.requestId}
+        lastQuotedAtMs={quote.lastQuotedAtMs}
+        isOpen={diagnosticsOpen}
+        onOpenChange={setDiagnosticsOpen}
       />
 
       {/* Footer Info */}

--- a/frontend/hooks/useApi.ts
+++ b/frontend/hooks/useApi.ts
@@ -230,9 +230,11 @@ export function useQuote(
 
   return useFetch(
     (signal) =>
-      stellarRouteClient.getQuote(base, quote, debouncedAmount, type, {
-        signal,
-      }),
+      stellarRouteClient
+        .getQuote(base, quote, debouncedAmount, type, {
+          signal,
+        })
+        .then((result) => result.quote),
     [base, quote, debouncedAmount, type],
     { refreshIntervalMs, skip },
   );

--- a/frontend/hooks/useQuote.ts
+++ b/frontend/hooks/useQuote.ts
@@ -28,6 +28,7 @@ export interface QuoteResult {
   refresh: (opts?: { force?: boolean }) => void;
   data: import('@/types').PriceQuote | undefined;
   lastQuotedAtMs: number | null;
+  requestId: string | null;
 }
 
 /**
@@ -47,6 +48,8 @@ export function useQuote({ fromToken, toToken, amount, type = 'sell' }: UseQuote
     pendingRetryRemainingMs,
     cancelRetry,
     refresh,
+    lastQuotedAtMs,
+    requestId,
   } = useQuoteRefresh(
     fromToken,
     toToken,
@@ -112,6 +115,7 @@ export function useQuote({ fromToken, toToken, amount, type = 'sell' }: UseQuote
     cancelRetry,
     refresh,
     data,
-    lastQuotedAtMs: data ? data.timestamp ?? null : null,
+    lastQuotedAtMs,
+    requestId,
   };
 }

--- a/frontend/hooks/useQuoteRefresh.test.ts
+++ b/frontend/hooks/useQuoteRefresh.test.ts
@@ -1,7 +1,7 @@
 import { act, cleanup, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import type { PriceQuote } from "@/types";
-import { StellarRouteApiError, stellarRouteClient } from "@/lib/api/client";
+import { StellarRouteApiError, stellarRouteClient, type QuoteFetchResult } from "@/lib/api/client";
 import { QUOTE_RETRY_EVENT_NAME } from "@/lib/quote-retry";
 import { useQuoteRefresh } from "./useQuoteRefresh";
 
@@ -27,7 +27,14 @@ function buildQuote(total: string): PriceQuote {
     total,
     quote_type: "sell",
     path: [],
-    timestamp: Math.floor(Date.now() / 1000),
+    timestamp: Date.now(),
+  };
+}
+
+function buildQuoteResult(total: string, requestId = "test-req-id"): QuoteFetchResult {
+  return {
+    quote: buildQuote(total),
+    requestId,
   };
 }
 
@@ -46,7 +53,7 @@ describe("useQuoteRefresh retries", () => {
       if (callCount === 1) {
         throw new Error("Failed to fetch");
       }
-      return buildQuote("98.0");
+      return buildQuoteResult("98.0");
     });
 
     const { result } = renderHook(() =>
@@ -103,7 +110,7 @@ describe("useQuoteRefresh retries", () => {
           50,
         ),
       )
-      .mockResolvedValueOnce(buildQuote("98.0"));
+      .mockResolvedValueOnce(buildQuoteResult("98.0"));
 
     const { result } = renderHook(() =>
       useQuoteRefresh("native", "USDC:G...", 100, "sell", {
@@ -205,7 +212,7 @@ describe("useQuoteRefresh retries", () => {
       if (callCount === 1) {
         throw new Error("Failed to fetch");
       }
-      return buildQuote("101.0");
+      return buildQuoteResult("101.0");
     });
 
     const telemetryListener = vi.fn();
@@ -245,8 +252,8 @@ describe("useQuoteRefresh retries", () => {
 
     const getQuoteMock = vi.mocked(stellarRouteClient.getQuote);
     getQuoteMock
-      .mockResolvedValueOnce(buildQuote("98.0"))
-      .mockResolvedValueOnce(buildQuote("99.0"));
+      .mockResolvedValueOnce(buildQuoteResult("98.0"))
+      .mockResolvedValueOnce(buildQuoteResult("99.0"));
 
     const { result } = renderHook(() =>
       useQuoteRefresh("native", "USDC:G...", 100, "sell", {

--- a/frontend/hooks/useQuoteRefresh.ts
+++ b/frontend/hooks/useQuoteRefresh.ts
@@ -74,6 +74,8 @@ export type UseQuoteRefreshState = UseApiState<PriceQuote> & {
   isStale: boolean;
   /** Wall-clock time of the last successful quote fetch, or null. */
   lastQuotedAtMs: number | null;
+  /** Server request ID from the last successful quote fetch, or null. */
+  requestId: string | null;
   /** True while transient online quote failures are being retried. */
   isRecovering: boolean;
   /** Current transient retry attempt count for the active request context. */
@@ -140,6 +142,7 @@ export function useQuoteRefresh(
   });
   const [manualCooldownUntil, setManualCooldownUntil] = useState(0);
   const [lastQuotedAtMs, setLastQuotedAtMs] = useState<number | null>(null);
+  const [requestId, setRequestId] = useState<string | null>(null);
   const [isRecovering, setIsRecovering] = useState(false);
   const [retryAttempt, setRetryAttempt] = useState(0);
   const [nowMs, setNowMs] = useState(() => Date.now());
@@ -189,6 +192,7 @@ export function useQuoteRefresh(
     setIsRecovering(false);
     setRateLimitUntilMs(0);
     setPendingRetry(null);
+    setRequestId(null);
   }, [base, quoteAsset, debouncedAmount, type]);
 
   const cancelRetry = useCallback(() => {
@@ -235,10 +239,11 @@ export function useQuoteRefresh(
       .getQuote(base, quoteAsset, debouncedAmount, type, {
         signal: controller.signal,
       })
-      .then((data) => {
+      .then((result) => {
         if (!controller.signal.aborted) {
           const t = Date.now();
           setLastQuotedAtMs(t);
+          setRequestId(result.requestId);
           if (retryAttempt > 0 && requestContext) {
             emitRetryEvent({
               stage: 'succeeded',
@@ -251,7 +256,7 @@ export function useQuoteRefresh(
           setIsRecovering(false);
           setRateLimitUntilMs(0);
           setPendingRetry(null);
-          setState({ data, loading: false, error: null });
+          setState({ data: result.quote, loading: false, error: null });
         }
       })
       .catch((err: unknown) => {
@@ -421,6 +426,7 @@ export function useQuoteRefresh(
     setAutoRefreshEnabled,
     isStale,
     lastQuotedAtMs,
+    requestId,
     isRecovering,
     retryAttempt,
     hasPendingRetry: pendingRetry !== null,

--- a/frontend/hooks/useResilienceNetwork.test.ts
+++ b/frontend/hooks/useResilienceNetwork.test.ts
@@ -15,7 +15,7 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { PriceQuote } from '@/types';
-import { StellarRouteApiError, stellarRouteClient } from '@/lib/api/client';
+import { StellarRouteApiError, stellarRouteClient, type QuoteFetchResult } from '@/lib/api/client';
 import { useQuoteRefresh } from '@/hooks/useQuoteRefresh';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 
@@ -41,7 +41,12 @@ const mockQuote = (): PriceQuote => ({
   total: '99.5',
   quote_type: 'sell',
   path: [],
-  timestamp: Math.floor(Date.now() / 1000),
+  timestamp: Date.now(),
+});
+
+const mockQuoteResult = (): QuoteFetchResult => ({
+  quote: mockQuote(),
+  requestId: 'test-req-id',
 });
 
 afterEach(() => {
@@ -61,7 +66,7 @@ describe('Resilience: packet loss (aborted requests)', () => {
     getQuoteMock.mockImplementation(async () => {
       calls += 1;
       if (calls <= 2) throw new Error('Failed to fetch'); // simulates abort
-      return mockQuote();
+      return mockQuoteResult();
     });
 
     const { result } = renderHook(() =>
@@ -107,7 +112,7 @@ describe('Resilience: packet loss (aborted requests)', () => {
 describe('Resilience: extreme latency', () => {
   it('does not fetch when going offline mid-session', async () => {
     const getQuoteMock = vi.mocked(stellarRouteClient.getQuote);
-    getQuoteMock.mockResolvedValue(mockQuote());
+    getQuoteMock.mockResolvedValue(mockQuoteResult());
 
     const { result } = renderHook(() => useOnlineStatus());
 
@@ -160,7 +165,7 @@ describe('Resilience: server errors (504/5xx)', () => {
       if (calls === 1) {
         throw new StellarRouteApiError(504, 'unknown_error', 'Gateway Timeout');
       }
-      return mockQuote();
+      return mockQuoteResult();
     });
 
     const { result } = renderHook(() =>
@@ -211,7 +216,7 @@ describe('Resilience: manual recovery', () => {
     // First call fails (network down)
     getQuoteMock.mockRejectedValueOnce(new Error('Failed to fetch'));
     // After manual refresh → success
-    getQuoteMock.mockResolvedValueOnce(mockQuote());
+    getQuoteMock.mockResolvedValueOnce(mockQuoteResult());
 
     const { result } = renderHook(() =>
       useQuoteRefresh('native', 'USDC:GABC', 100, 'sell', {

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -9,6 +9,7 @@
  */
 
 import type {
+  ApiResponse,
   HealthStatus,
   Orderbook,
   PriceHistoryResponse,
@@ -230,22 +231,106 @@ export class StellarRouteClient {
   /**
    * GET /api/v1/quote/{base}/{quote}?amount={amount}&quote_type={sell|buy}
    *
-   * @param base   Asset identifier
-   * @param quote  Asset identifier
-   * @param amount Amount to trade (optional)
-   * @param type   "sell" (default) or "buy"
+   * Unwraps the API envelope and captures the server `request_id` from the
+   * response body and `x-request-id` header for diagnostics correlation.
    */
-  getQuote(
+  async getQuote(
     base: string,
     quote: string,
     amount?: number,
     type: QuoteType = 'sell',
     opts?: FetchOptions,
-  ): Promise<PriceQuote> {
+  ): Promise<QuoteFetchResult> {
     const params = new URLSearchParams({ quote_type: type });
     if (amount !== undefined) params.set('amount', String(amount));
     const path = `/api/v1/quote/${encodeURIComponent(base)}/${encodeURIComponent(quote)}?${params}`;
-    return this.request<PriceQuote>(path, opts);
+    return this.requestQuote(path, opts);
+  }
+
+  private async requestQuote(
+    path: string,
+    opts: FetchOptions = {},
+    retries = 2,
+  ): Promise<QuoteFetchResult> {
+    const url = `${this.baseUrl}${path}`;
+    const controller = new AbortController();
+    const timer = setTimeout(
+      () => controller.abort(),
+      DEFAULT_TIMEOUT_MS,
+    );
+
+    opts.signal?.addEventListener('abort', () => controller.abort());
+
+    try {
+      const response = await fetch(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: controller.signal,
+      });
+
+      if (!response.ok) {
+        const retryAfterMs = parseRetryAfterMs(
+          response.headers.get('Retry-After'),
+        );
+
+        let code: ApiErrorCode = 'unknown_error';
+        let message = `HTTP ${response.status}`;
+        let details: unknown;
+
+        try {
+          const body = await response.json();
+          code = (body.error as ApiErrorCode) ?? code;
+          message = body.message ?? message;
+          details = body.details;
+        } catch {
+          // Body was not JSON — keep defaults
+        }
+
+        if ((response.status === 429 || response.status >= 500) && retries > 0) {
+          await sleep(retryAfterMs ?? 1_000 * (3 - retries));
+          return this.requestQuote(path, opts, retries - 1);
+        }
+
+        throw new StellarRouteApiError(
+          response.status,
+          code,
+          message,
+          details,
+          retryAfterMs,
+        );
+      }
+
+      const headerRequestId = response.headers.get('x-request-id');
+      const body = (await response.json()) as
+        | ApiResponse<PriceQuote>
+        | PriceQuote;
+
+      if (body && typeof body === 'object' && 'data' in body) {
+        const envelope = body as ApiResponse<PriceQuote>;
+        return {
+          quote: envelope.data,
+          requestId: envelope.request_id || headerRequestId || generateFallbackRequestId(),
+        };
+      }
+
+      return {
+        quote: body as PriceQuote,
+        requestId: headerRequestId || generateFallbackRequestId(),
+      };
+    } catch (err) {
+      if (err instanceof StellarRouteApiError) throw err;
+
+      if (retries > 0) {
+        await sleep(500 * (3 - retries));
+        return this.requestQuote(path, opts, retries - 1);
+      }
+
+      const message =
+        err instanceof Error ? err.message : 'Network error';
+      throw new StellarRouteApiError(0, 'network_error' as ApiErrorCode, message);
+    } finally {
+      clearTimeout(timer);
+    }
   }
 
   /**
@@ -294,6 +379,16 @@ export interface QuoteRequestItem {
 export interface BatchQuoteResponse {
   quotes: PriceQuote[];
   total: number;
+}
+
+/** Result of a single quote fetch including server correlation metadata. */
+export interface QuoteFetchResult {
+  quote: PriceQuote;
+  requestId: string;
+}
+
+function generateFallbackRequestId(): string {
+  return `req_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/frontend/lib/diagnostics.test.ts
+++ b/frontend/lib/diagnostics.test.ts
@@ -2,10 +2,12 @@ import { describe, expect, it } from 'vitest';
 
 import {
   collectQuoteDiagnostics,
+  computeQuoteAgeMs,
   exportDiagnosticsAsCsv,
   exportDiagnosticsAsJson,
   formatDiagnosticsForDisplay,
   generateRequestId,
+  redactDiagnosticsObject,
   redactSensitiveFields,
 } from '@/lib/diagnostics';
 import type { PriceQuote } from '@/types';
@@ -35,7 +37,7 @@ const mockQuote: PriceQuote = {
       source: 'sdex',
     },
   ],
-  timestamp: Math.floor(Date.now() / 1000),
+  timestamp: Date.now(),
 };
 
 describe('diagnostics utilities', () => {
@@ -70,6 +72,15 @@ describe('diagnostics utilities', () => {
     });
   });
 
+  describe('computeQuoteAgeMs', () => {
+    it('uses lastQuotedAtMs when provided', () => {
+      const lastQuotedAtMs = Date.now() - 5_000;
+      const age = computeQuoteAgeMs(mockQuote, lastQuotedAtMs);
+      expect(age).toBeGreaterThanOrEqual(4_900);
+      expect(age).toBeLessThan(6_000);
+    });
+  });
+
   describe('collectQuoteDiagnostics', () => {
     it('collects diagnostics from quote response', () => {
       const requestId = 'req_test_123';
@@ -87,9 +98,12 @@ describe('diagnostics utilities', () => {
 
     it('calculates quote age correctly', () => {
       const requestId = 'req_test_456';
-      const diag = collectQuoteDiagnostics(mockQuote, requestId);
+      const lastQuotedAtMs = Date.now() - 2_000;
+      const diag = collectQuoteDiagnostics(mockQuote, requestId, {
+        lastQuotedAtMs,
+      });
 
-      expect(diag.quoteAge).toBeGreaterThanOrEqual(0);
+      expect(diag.quoteAge).toBeGreaterThanOrEqual(1_900);
       expect(typeof diag.quoteAge).toBe('number');
     });
 
@@ -113,6 +127,48 @@ describe('diagnostics utilities', () => {
       const diag = collectQuoteDiagnostics(quoteWithAmm, 'req_amm_test');
       expect(diag.sources).toContain('AMM');
     });
+
+    it('extracts route diagnostics from quote metadata', () => {
+      const quoteWithDiagnostics: PriceQuote = {
+        ...mockQuote,
+        degraded: true,
+        rationale: {
+          strategy: 'single_hop_direct_venue_comparison',
+          selected_source: 'sdex:offer-1',
+          compared_venues: [
+            {
+              source: 'sdex:offer-1',
+              price: '0.105',
+              available_amount: '1000',
+              executable: true,
+            },
+          ],
+        },
+        exclusion_diagnostics: {
+          excluded_venues: [
+            {
+              venue_ref: 'amm:pool-1',
+              reason: { type: 'stale_data' },
+            },
+          ],
+        },
+        data_freshness: {
+          fresh_count: 2,
+          stale_count: 1,
+          max_staleness_secs: 45,
+        },
+      };
+
+      const diag = collectQuoteDiagnostics(quoteWithDiagnostics, 'req_route_test');
+      expect(diag.degraded).toBe(true);
+      expect(diag.routeDiagnostics?.strategy).toBe(
+        'single_hop_direct_venue_comparison',
+      );
+      expect(diag.routeDiagnostics?.selectedSource).toBe('sdex:offer-1');
+      expect(diag.routeDiagnostics?.comparedVenuesCount).toBe(1);
+      expect(diag.routeDiagnostics?.excludedVenues).toHaveLength(1);
+      expect(diag.routeDiagnostics?.dataFreshness?.freshCount).toBe(2);
+    });
   });
 
   describe('formatDiagnosticsForDisplay', () => {
@@ -131,10 +187,28 @@ describe('diagnostics utilities', () => {
 
     it('formats quote age in seconds', () => {
       const requestId = 'req_age_test';
-      const diag = collectQuoteDiagnostics(mockQuote, requestId);
+      const diag = collectQuoteDiagnostics(mockQuote, requestId, {
+        lastQuotedAtMs: Date.now() - 1_500,
+      });
       const formatted = formatDiagnosticsForDisplay(diag);
 
       expect(formatted).toMatch(/Quote Age: \d+\.\d{2}s/);
+    });
+
+    it('includes route diagnostics section when present', () => {
+      const quoteWithDiagnostics: PriceQuote = {
+        ...mockQuote,
+        rationale: {
+          strategy: 'single_hop_direct_venue_comparison',
+          selected_source: 'sdex:offer-1',
+          compared_venues: [],
+        },
+      };
+      const diag = collectQuoteDiagnostics(quoteWithDiagnostics, 'req_route_fmt');
+      const formatted = formatDiagnosticsForDisplay(diag);
+
+      expect(formatted).toContain('Route Diagnostics:');
+      expect(formatted).toContain('Strategy:');
     });
   });
 
@@ -149,6 +223,23 @@ describe('diagnostics utilities', () => {
       expect(parsed.requestId).toEqual(requestId);
       expect(parsed.amount).toEqual('100.00');
     });
+
+    it('redacts sensitive fields in JSON export', () => {
+      const quoteWithIssuer: PriceQuote = {
+        ...mockQuote,
+        rationale: {
+          strategy: 'test',
+          selected_source:
+            'sdex:GA5ZSEJYB37JRC5AVCIA5MOP4IHTZMAB5KYXOM5KBVG7GBJINW7JCXU',
+          compared_venues: [],
+        },
+      };
+      const diag = collectQuoteDiagnostics(quoteWithIssuer, 'req_redact_json');
+      const json = exportDiagnosticsAsJson(diag);
+
+      expect(json).not.toContain('GA5ZSEJYB37JRC5AVCIA5MOP4IHTZMAB5KYXOM5KBVG7GBJINW7JCXU');
+      expect(json).toContain('[REDACTED');
+    });
   });
 
   describe('exportDiagnosticsAsCsv', () => {
@@ -162,15 +253,25 @@ describe('diagnostics utilities', () => {
       expect(lines[0]).toContain('requestId');
       expect(lines[1]).toContain(requestId);
     });
+  });
 
-    it('properly escapes quoted fields in CSV', () => {
-      const requestId = 'req_csv_escape_test';
-      const diag = collectQuoteDiagnostics(mockQuote, requestId);
-      const csv = exportDiagnosticsAsCsv(diag);
+  describe('redactDiagnosticsObject', () => {
+    it('redacts nested route diagnostics fields', () => {
+      const diag = collectQuoteDiagnostics(
+        {
+          ...mockQuote,
+          rationale: {
+            strategy: 'test',
+            selected_source:
+              'sdex:GA5ZSEJYB37JRC5AVCIA5MOP4IHTZMAB5KYXOM5KBVG7GBJINW7JCXU',
+            compared_venues: [],
+          },
+        },
+        'req_obj_redact',
+      );
 
-      expect(csv).toBeTruthy();
-      const lines = csv.split('\n');
-      expect(lines.length).toBeGreaterThan(0);
+      const redacted = redactDiagnosticsObject(diag);
+      expect(redacted.routeDiagnostics?.selectedSource).toContain('[REDACTED');
     });
   });
 });

--- a/frontend/lib/diagnostics.ts
+++ b/frontend/lib/diagnostics.ts
@@ -3,7 +3,27 @@
  * Provides functionality to track, format, and export quote diagnostics
  */
 
-import type { PathStep, PriceQuote } from '@/types';
+import type {
+  ExcludedVenueInfo,
+  ExclusionReason,
+  PathStep,
+  PriceQuote,
+} from '@/types';
+
+/**
+ * Route-level diagnostics extracted from quote metadata
+ */
+export interface RouteDiagnostics {
+  strategy?: string;
+  selectedSource?: string;
+  comparedVenuesCount?: number;
+  excludedVenues?: { venueRef: string; reason: string }[];
+  dataFreshness?: {
+    freshCount: number;
+    staleCount: number;
+    maxStalenessSecs: number;
+  };
+}
 
 /**
  * Represents metadata about a quote request for diagnostics
@@ -20,6 +40,8 @@ export interface QuoteDiagnostics {
   total: string;
   pathLength: number;
   sources: string[];
+  degraded?: boolean;
+  routeDiagnostics?: RouteDiagnostics;
 }
 
 /**
@@ -27,13 +49,42 @@ export interface QuoteDiagnostics {
  * Redacts wallet addresses and issuer information
  */
 export function redactSensitiveFields(data: string): string {
-  // Redact full issuer addresses
   data = data.replace(/([A-Z0-9]{1,12}):[G][A-Z0-9]{54}/g, '$1:[REDACTED]');
-  // Redact full wallet addresses
   data = data.replace(/\bG[A-Z0-9]{54}\b/g, '[REDACTED_ADDRESS]');
-  // Redact any hex strings that look like hashes
   data = data.replace(/\b[a-f0-9]{64}\b/i, '[REDACTED_HASH]');
   return data;
+}
+
+/**
+ * Redacts sensitive fields from a diagnostics object for export
+ */
+export function redactDiagnosticsObject(diag: QuoteDiagnostics): QuoteDiagnostics {
+  const redact = (value: string) => redactSensitiveFields(value);
+
+  return {
+    ...diag,
+    base: redact(diag.base),
+    quote: redact(diag.quote),
+    amount: redact(diag.amount),
+    price: redact(diag.price),
+    total: redact(diag.total),
+    sources: diag.sources.map(redact),
+    routeDiagnostics: diag.routeDiagnostics
+      ? {
+          ...diag.routeDiagnostics,
+          strategy: diag.routeDiagnostics.strategy
+            ? redact(diag.routeDiagnostics.strategy)
+            : undefined,
+          selectedSource: diag.routeDiagnostics.selectedSource
+            ? redact(diag.routeDiagnostics.selectedSource)
+            : undefined,
+          excludedVenues: diag.routeDiagnostics.excludedVenues?.map((v) => ({
+            venueRef: redact(v.venueRef),
+            reason: redact(v.reason),
+          })),
+        }
+      : undefined,
+  };
 }
 
 /**
@@ -43,16 +94,87 @@ export function generateRequestId(): string {
   return `req_${Date.now()}_${Math.random().toString(36).substring(2, 9)}`;
 }
 
+function formatExclusionReason(reason: ExclusionReason): string {
+  switch (reason.type) {
+    case 'policy_threshold':
+      return `policy_threshold(${reason.threshold})`;
+    case 'override':
+      return 'override';
+    case 'stale_data':
+      return 'stale_data';
+    case 'circuit_breaker_open':
+      return 'circuit_breaker_open';
+    case 'liquidity_anomaly':
+      return 'liquidity_anomaly';
+    default:
+      return 'unknown';
+  }
+}
+
+function extractRouteDiagnostics(quote: PriceQuote): RouteDiagnostics | undefined {
+  const hasRationale = Boolean(quote.rationale);
+  const hasExclusions = Boolean(quote.exclusion_diagnostics?.excluded_venues?.length);
+  const hasFreshness = Boolean(quote.data_freshness);
+
+  if (!hasRationale && !hasExclusions && !hasFreshness) {
+    return undefined;
+  }
+
+  const routeDiagnostics: RouteDiagnostics = {};
+
+  if (quote.rationale) {
+    routeDiagnostics.strategy = quote.rationale.strategy;
+    routeDiagnostics.selectedSource = quote.rationale.selected_source;
+    routeDiagnostics.comparedVenuesCount = quote.rationale.compared_venues.length;
+  }
+
+  if (quote.exclusion_diagnostics?.excluded_venues?.length) {
+    routeDiagnostics.excludedVenues = quote.exclusion_diagnostics.excluded_venues.map(
+      (venue: ExcludedVenueInfo) => ({
+        venueRef: venue.venue_ref,
+        reason: formatExclusionReason(venue.reason),
+      }),
+    );
+  }
+
+  if (quote.data_freshness) {
+    routeDiagnostics.dataFreshness = {
+      freshCount: quote.data_freshness.fresh_count,
+      staleCount: quote.data_freshness.stale_count,
+      maxStalenessSecs: quote.data_freshness.max_staleness_secs,
+    };
+  }
+
+  return routeDiagnostics;
+}
+
+/**
+ * Computes quote age in milliseconds from client fetch time or quote timestamp
+ */
+export function computeQuoteAgeMs(
+  quote: PriceQuote,
+  lastQuotedAtMs?: number | null,
+): number {
+  if (lastQuotedAtMs != null) {
+    return Math.max(0, Date.now() - lastQuotedAtMs);
+  }
+
+  const quoteTimestampMs =
+    quote.timestamp > 1_000_000_000_000 ? quote.timestamp : quote.timestamp * 1000;
+
+  return Math.max(0, Date.now() - quoteTimestampMs);
+}
+
 /**
  * Collects diagnostics metadata from a quote response
  */
 export function collectQuoteDiagnostics(
   quote: PriceQuote,
   requestId: string,
+  options?: { lastQuotedAtMs?: number | null },
 ): QuoteDiagnostics {
   const timestamp = Date.now();
-  const quoteTimestamp = quote.timestamp * 1000;
-  const quoteAge = timestamp - quoteTimestamp;
+  const quoteAge = computeQuoteAgeMs(quote, options?.lastQuotedAtMs);
 
   const baseSymbol = quote.base_asset.asset_code || 'XLM';
   const quoteSymbol = quote.quote_asset.asset_code || 'native';
@@ -76,6 +198,8 @@ export function collectQuoteDiagnostics(
     total: quote.total,
     pathLength: quote.path.length,
     sources,
+    degraded: quote.degraded,
+    routeDiagnostics: extractRouteDiagnostics(quote),
   };
 }
 
@@ -86,27 +210,87 @@ export function formatDiagnosticsForDisplay(diag: QuoteDiagnostics): string {
   const quoteAgeSeconds = (diag.quoteAge / 1000).toFixed(2);
   const routeInfo = `${diag.pathLength} step${diag.pathLength !== 1 ? 's' : ''}`;
 
-  return `Request ID: ${diag.requestId}
-Quote Age: ${quoteAgeSeconds}s
-Route: ${routeInfo} (${diag.sources.join(', ')})
-Type: ${diag.type.toUpperCase()} ${diag.amount} ${diag.base}
-Price: ${diag.price} ${diag.quote}/${diag.base}
-Total: ${diag.total} ${diag.quote}`;
+  const lines = [
+    `Request ID: ${diag.requestId}`,
+    `Quote Age: ${quoteAgeSeconds}s`,
+    `Route: ${routeInfo} (${diag.sources.join(', ')})`,
+    `Type: ${diag.type.toUpperCase()} ${diag.amount} ${diag.base}`,
+    `Price: ${diag.price} ${diag.quote}/${diag.base}`,
+    `Total: ${diag.total} ${diag.quote}`,
+  ];
+
+  if (diag.degraded) {
+    lines.push('Status: DEGRADED');
+  }
+
+  if (diag.routeDiagnostics) {
+    lines.push('', 'Route Diagnostics:');
+    if (diag.routeDiagnostics.strategy) {
+      lines.push(`  Strategy: ${diag.routeDiagnostics.strategy}`);
+    }
+    if (diag.routeDiagnostics.selectedSource) {
+      lines.push(`  Selected Source: ${diag.routeDiagnostics.selectedSource}`);
+    }
+    if (diag.routeDiagnostics.comparedVenuesCount !== undefined) {
+      lines.push(`  Compared Venues: ${diag.routeDiagnostics.comparedVenuesCount}`);
+    }
+    if (diag.routeDiagnostics.dataFreshness) {
+      const { freshCount, staleCount, maxStalenessSecs } =
+        diag.routeDiagnostics.dataFreshness;
+      lines.push(
+        `  Data Freshness: ${freshCount} fresh, ${staleCount} stale (max ${maxStalenessSecs}s)`,
+      );
+    }
+    if (diag.routeDiagnostics.excludedVenues?.length) {
+      lines.push('  Excluded Venues:');
+      for (const venue of diag.routeDiagnostics.excludedVenues) {
+        lines.push(`    - ${venue.venueRef}: ${venue.reason}`);
+      }
+    }
+  }
+
+  return lines.join('\n');
 }
 
 /**
- * Exports diagnostics data as JSON
+ * Exports diagnostics data as JSON with sensitive fields redacted
  */
 export function exportDiagnosticsAsJson(diag: QuoteDiagnostics): string {
-  return JSON.stringify(diag, null, 2);
+  return JSON.stringify(redactDiagnosticsObject(diag), null, 2);
 }
 
 /**
- * Exports diagnostics data as CSV
+ * Exports diagnostics data as CSV with sensitive fields redacted
  */
 export function exportDiagnosticsAsCsv(diag: QuoteDiagnostics): string {
-  const headers = Object.keys(diag).join(',');
-  const values = Object.values(diag)
+  const redacted = redactDiagnosticsObject(diag);
+  const flat: Record<string, string | number | boolean> = {
+    requestId: redacted.requestId,
+    timestamp: redacted.timestamp,
+    quoteAge: redacted.quoteAge,
+    base: redacted.base,
+    quote: redacted.quote,
+    amount: redacted.amount,
+    type: redacted.type,
+    price: redacted.price,
+    total: redacted.total,
+    pathLength: redacted.pathLength,
+    sources: redacted.sources.join(';'),
+    degraded: redacted.degraded ?? false,
+    routeStrategy: redacted.routeDiagnostics?.strategy ?? '',
+    selectedSource: redacted.routeDiagnostics?.selectedSource ?? '',
+    comparedVenuesCount: redacted.routeDiagnostics?.comparedVenuesCount ?? '',
+    freshCount: redacted.routeDiagnostics?.dataFreshness?.freshCount ?? '',
+    staleCount: redacted.routeDiagnostics?.dataFreshness?.staleCount ?? '',
+    maxStalenessSecs:
+      redacted.routeDiagnostics?.dataFreshness?.maxStalenessSecs ?? '',
+    excludedVenues: redacted.routeDiagnostics?.excludedVenues
+      ?.map((v) => `${v.venueRef}:${v.reason}`)
+      .join(';') ?? '',
+  };
+
+  const headers = Object.keys(flat).join(',');
+  const values = Object.values(flat)
     .map((v) => {
       if (typeof v === 'string') {
         return `"${v.replace(/"/g, '""')}"`;
@@ -114,5 +298,6 @@ export function exportDiagnosticsAsCsv(diag: QuoteDiagnostics): string {
       return v;
     })
     .join(',');
+
   return `${headers}\n${values}`;
 }

--- a/frontend/lib/swap-i18n.ts
+++ b/frontend/lib/swap-i18n.ts
@@ -86,6 +86,7 @@ export type SwapTranslationKey =
   | "swap.cta.swapping"
   | "swap.cta.errorFetchingQuote"
   | "swap.card.refreshQuote"
+  | "swap.card.diagnostics"
   | "swap.card.outdated"
   | "swap.card.recoveringQuote"
   | "swap.card.recoveringQuoteCountdown"
@@ -190,6 +191,7 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.cta.swapping": "Swapping...",
     "swap.cta.errorFetchingQuote": "Error fetching quote",
     "swap.card.refreshQuote": "Refresh quote",
+    "swap.card.diagnostics": "View quote diagnostics",
     "swap.card.outdated": "Quote outdated — refresh for latest price",
     "swap.card.recoveringQuote": "Retrying quote...",
     "swap.card.recoveringQuoteCountdown": "Retrying quote in {seconds}s...",
@@ -285,6 +287,7 @@ const SWAP_TRANSLATIONS: Record<SupportedSwapLocale, SwapTranslations> = {
     "swap.cta.swapping": "兑换中...",
     "swap.cta.errorFetchingQuote": "获取报价失败",
     "swap.card.refreshQuote": "刷新报价",
+    "swap.card.diagnostics": "查看报价诊断信息",
     "swap.card.outdated": "报价已过期——请刷新获取最新价格",
     "swap.card.recoveringQuote": "正在重试报价...",
     "swap.card.recoveringQuoteCountdown": "{seconds} 秒后重试报价...",

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -60,6 +60,49 @@ export interface PriceHistoryResponse {
 
 export type QuoteType = 'sell' | 'buy';
 
+/** Standard API response envelope from the backend */
+export interface ApiResponse<T> {
+  v: number;
+  timestamp: number;
+  request_id: string;
+  data: T;
+}
+
+export interface VenueEvaluation {
+  source: string;
+  price: string;
+  available_amount: string;
+  executable: boolean;
+}
+
+export interface QuoteRationaleMetadata {
+  strategy: string;
+  selected_source: string;
+  compared_venues: VenueEvaluation[];
+}
+
+export type ExclusionReason =
+  | { type: 'policy_threshold'; threshold: number }
+  | { type: 'override' }
+  | { type: 'stale_data' }
+  | { type: 'circuit_breaker_open' }
+  | { type: 'liquidity_anomaly' };
+
+export interface ExcludedVenueInfo {
+  venue_ref: string;
+  reason: ExclusionReason;
+}
+
+export interface ExclusionDiagnostics {
+  excluded_venues: ExcludedVenueInfo[];
+}
+
+export interface DataFreshness {
+  fresh_count: number;
+  stale_count: number;
+  max_staleness_secs: number;
+}
+
 export interface PathStep {
   from_asset: Asset;
   to_asset: Asset;
@@ -89,7 +132,7 @@ export interface PriceQuote {
   /** Route breakdown */
   path: PathStep[];
   priceImpact?: string;
-  /** Unix timestamp (seconds) */
+  /** Unix timestamp (milliseconds) when this quote was generated */
   timestamp: number;
   /** Unix timestamp (ms) when this quote expires */
   expires_at?: number;
@@ -101,6 +144,12 @@ export interface PriceQuote {
   price_impact?: string;
   /** Optional alternative routes provided by the aggregator */
   alternativeRoutes?: { id: string; venue: string; expectedAmount: string }[];
+  /** Rationale for quote venue selection */
+  rationale?: QuoteRationaleMetadata;
+  /** Venues excluded from routing and the reason for each exclusion */
+  exclusion_diagnostics?: ExclusionDiagnostics;
+  /** Freshness metadata about the data sources used to compute this quote */
+  data_freshness?: DataFreshness;
 }
 
 export interface HealthStatus {


### PR DESCRIPTION
## Summary
- Wire the existing DiagnosticsPanel into SwapCard via a non-blocking header toggle
- Capture server request_id from API envelope and x-request-id header
- Display quote age, route diagnostics (strategy, exclusions, data freshness), and redacted copy/export for support

## Test plan
- [x] lib/diagnostics.test.ts passes
- [x] DiagnosticsPanel.test.tsx passes
- [x] Frontend production build succeeds

Closes #352

Made with [Cursor](https://cursor.com)