### PR TITLE
[infra] Simplify CI for contributor-friendly green checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,24 +49,6 @@ jobs:
       - name: Run tests
         run: cd frontend && NODE_OPTIONS=--max-old-space-size=8192 npm test -- --maxWorkers=1 --exclude hooks/useQuoteRefresh.test.ts
 
-  frontend-visual-regression:
-    name: Frontend Visual Regression
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: "npm"
-          cache-dependency-path: frontend/package-lock.json
-      - name: Install dependencies
-        run: cd frontend && npm ci --legacy-peer-deps
-      - name: Install Playwright browsers
-        run: cd frontend && npx playwright install --with-deps chromium
-      - name: Run visual regression
-        run: cd frontend && npx playwright test e2e/visual-baseline.spec.ts --update-snapshots
-
   sdk-checks:
     name: JS SDK Checks
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -1,9 +1,6 @@
 name: Deploy to Testnet
 
 on:
-  push:
-    branches:
-      - main
   workflow_dispatch:
     inputs:
       contract_id:

--- a/.github/workflows/gas-benchmarks.yml
+++ b/.github/workflows/gas-benchmarks.yml
@@ -5,10 +5,7 @@ on:
     branches: [main, develop]
     paths:
       - 'crates/contracts/**'
-  pull_request:
-    branches: [main, develop]
-    paths:
-      - 'crates/contracts/**'
+  workflow_dispatch:
 
 jobs:
   benchmark:

--- a/.github/workflows/slo-probes.yml
+++ b/.github/workflows/slo-probes.yml
@@ -1,9 +1,6 @@
 name: SLO Probes
 
 on:
-  schedule:
-    # Run every 5 minutes on main to continuously validate SLO compliance
-    - cron: '*/5 * * * *'
   workflow_dispatch:
     inputs:
       base_url:

--- a/docs/development/testing-guide.md
+++ b/docs/development/testing-guide.md
@@ -171,8 +171,8 @@ The local commands above map to the GitHub Actions workflows in `.github/workflo
 
 | Workflow | What it covers | Local equivalent |
 | --- | --- | --- |
-| `.github/workflows/ci.yml` | Rust backend checks, frontend Vitest, visual regression, SDK checks | `cargo test`, `cargo fmt --check`, `cargo clippy`, `npm --prefix frontend test` |
-| `.github/workflows/gas-benchmarks.yml` | Soroban gas/benchmark checks for contract changes | `cargo test -p stellarroute-contracts` and benchmark-oriented contract runs |
+| `.github/workflows/ci.yml` | Rust backend checks, frontend Vitest, frontend production build, SDK checks | `cargo test`, `cargo fmt --check`, `cargo clippy`, `npm --prefix frontend test`, `npm --prefix frontend run build` |
+| `.github/workflows/gas-benchmarks.yml` | Soroban gas/benchmark checks for contract changes (main/develop pushes and manual runs) | `cargo test -p stellarroute-contracts` and benchmark-oriented contract runs |
 | `.github/workflows/verify-contracts.yml` | Contract bytecode verification and on-chain comparison | `cargo build --release --target wasm32-unknown-unknown` in `crates/contracts` |
 
 Use this mapping when you need to explain which CI path a test failure is likely coming from.


### PR DESCRIPTION
## Summary
- Remove Playwright visual regression from `ci.yml` (slow, flaky, and was updating snapshots in CI)
- Run gas benchmarks on main/develop contract pushes and manual dispatch only (not every contract PR)
- Make testnet deploy and SLO probes manual-only until hosted API/testnet secrets are stable

## What still runs on contributor PRs
- `ci.yml`: Rust fmt/clippy/tests, frontend Vitest, frontend production build, SDK build/test

## What moved off the PR path
- `frontend-visual-regression` job (removed from `ci.yml`)
- `gas-benchmarks.yml` PR trigger removed
- `deploy-testnet.yml` push trigger removed (manual only)
- `slo-probes.yml` 5-minute cron removed (manual only; API not live yet)

## Unchanged
- `verify-contracts.yml` (nightly schedule + manual)

## Test plan
- [x] Workflow YAML parses cleanly
- [ ] CI green on this PR with fewer jobs