### PR TITLE
[infra] Remove Backend Rust and Frontend Next.js PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,49 +6,7 @@ on:
   pull_request:
     branches: [ main, develop ]
 
-env:
-  CARGO_TERM_COLOR: always
-  RUST_BACKTRACE: 1
-
 jobs:
-  backend-checks:
-    name: Backend Checks (Rust)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install Rust toolchain
-        uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt, clippy
-      - name: Rust Cache
-        uses: Swatinem/rust-cache@v2
-      - name: Cargo check workspace
-        run: cargo check --workspace
-      - name: Check formatting
-        run: cargo fmt --all -- --check
-      - name: Clippy
-        run: cargo clippy --all-targets --all-features -- -D warnings
-      - name: Run unit tests
-        run: cargo test
-      - name: Contract Clippy
-        run: cargo clippy -p stellarroute-contracts --all-targets -- -D warnings
-
-  frontend-checks:
-    name: Frontend Checks (Next.js)
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          cache: 'npm'
-          cache-dependency-path: frontend/package-lock.json
-      - name: Install dependencies
-        run: cd frontend && npm ci --legacy-peer-deps
-      - name: Run tests
-        run: cd frontend && NODE_OPTIONS=--max-old-space-size=8192 npm test -- --maxWorkers=1 --exclude hooks/useQuoteRefresh.test.ts
-
   sdk-checks:
     name: JS SDK Checks
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- Removes **Backend Checks (Rust)** (`backend-checks`) from `.github/workflows/ci.yml`
- Removes **Frontend Checks (Next.js)** (`frontend-checks`) from `.github/workflows/ci.yml`
- Drops unused Rust `env` vars (`CARGO_TERM_COLOR`, `RUST_BACKTRACE`)
- PR #803 was already merged; this continues CI simplification on a fresh branch

## Remaining PR checks (CI workflow)
- **JS SDK Checks** — build + test `sdk-js`
- **Frontend Production Build** — `npm run build` for `frontend`

## Test plan
- [x] YAML syntax validated locally
- [ ] Confirm PR checks no longer include Backend Checks (Rust) or Frontend Checks (Next.js)
- [ ] Confirm remaining SDK and frontend build jobs pass on this PR