### PR TITLE
[790] [frontend] Add Ladle stories for SwapCard state matrix

### DIFF
--- a/frontend/.ladle/config.mjs
+++ b/frontend/.ladle/config.mjs
@@ -1,0 +1,10 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+/** @type {import('@ladle/react').UserConfig} */
+export default {
+  stories: 'components/**/*.stories.{tsx,jsx,ts,js}',
+  viteConfig: path.resolve(dirname, '..', 'ladle-vite.config.ts'),
+};

--- a/frontend/STORYBOOK.md
+++ b/frontend/STORYBOOK.md
@@ -3,6 +3,7 @@
 This repository uses Ladle to render component stories for core swap primitives.
 
 ## Available stories
+- `SwapCard` state matrix (`components/swap/SwapCard.stories.tsx`) — idle, quoting, stale, confirming, and error fixtures
 - `Swap primitives` (Core components in `components/swap/`)
 - `TokenSelector` (Shared component)
 - `QuoteCard` (Shared component)

--- a/frontend/__mocks__/@stellar/freighter-api.browser.ts
+++ b/frontend/__mocks__/@stellar/freighter-api.browser.ts
@@ -1,0 +1,22 @@
+const MOCK_ADDRESS =
+  'GABC123DEFGHIJKLMNOPQRSTUVWXYZ456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+export const isAllowed = async () => ({ isAllowed: true });
+export const requestAccess = async () => ({ address: MOCK_ADDRESS });
+export const getAddress = async () => ({ address: MOCK_ADDRESS });
+export const getNetworkDetails = async () => ({
+  network: 'testnet',
+  networkUrl: 'https://horizon-testnet.stellar.org',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+});
+export const signTransaction = async () => ({
+  signedTxXdr: '',
+  signerAddress: MOCK_ADDRESS,
+});
+export const isConnected = async () => ({ isConnected: true });
+export const getNetwork = async () => ({
+  network: 'testnet',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+});
+export const setAllowed = async () => ({ isAllowed: true });
+export const WatchWalletChanges = () => {};

--- a/frontend/__mocks__/next-dynamic.tsx
+++ b/frontend/__mocks__/next-dynamic.tsx
@@ -1,0 +1,17 @@
+import type { ComponentType } from 'react';
+
+export default function dynamic<P extends object>(
+  loader: () => Promise<{ default: ComponentType<P> } | ComponentType<P>>,
+) {
+  let Component: ComponentType<P> | null = null;
+  loader().then((mod) => {
+    Component = ('default' in mod ? mod.default : mod) as ComponentType<P>;
+  });
+
+  return function DynamicComponent(props: P) {
+    if (!Component) {
+      return null;
+    }
+    return <Component {...props} />;
+  };
+}

--- a/frontend/__mocks__/next-navigation.ts
+++ b/frontend/__mocks__/next-navigation.ts
@@ -1,0 +1,11 @@
+export function useRouter() {
+  return { push: () => {}, replace: () => {}, back: () => {} };
+}
+
+export function useSearchParams() {
+  return new URLSearchParams();
+}
+
+export function usePathname() {
+  return '/swap';
+}

--- a/frontend/app/orderbook/layout.tsx
+++ b/frontend/app/orderbook/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Orderbook | StellarRoute',
+  description: 'Live order book and market depth for Stellar trading pairs.',
+  openGraph: {
+    title: 'Orderbook | StellarRoute',
+    description:
+      'Real-time market depth and order book data for Stellar DEX pairs.',
+    type: 'website',
+  },
+};
+
+export default function OrderbookLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/frontend/app/orderbook/page.tsx
+++ b/frontend/app/orderbook/page.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { Metadata } from "next";
 import { MarketDepthChart } from "./MarketDepthChart";
 import { useEffect, useMemo, useState, useRef } from "react";
 import { Button } from "@/components/ui/button";
@@ -11,16 +10,6 @@ import { useOptionalTradingPair } from "@/contexts/TradingPairContext";
 import { useVirtualWindow } from "@/hooks/useVirtualWindow";
 import type { OrderbookEntry, TradingPair } from "@/types";
 import { cn } from "@/lib/utils";
-
-export const metadata: Metadata = {
-  title: "Orderbook | StellarRoute",
-  description: "Live order book and market depth for Stellar trading pairs.",
-  openGraph: {
-    title: "Orderbook | StellarRoute",
-    description: "Real-time market depth and order book data for Stellar DEX pairs.",
-    type: "website",
-  },
-};
 
 const ROW_HEIGHT = 36;
 const OVERSCAN = 5;

--- a/frontend/app/quote-inspector/layout.tsx
+++ b/frontend/app/quote-inspector/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Quote Inspector | StellarRoute',
+  description:
+    'Reconcile and compare quotes from multiple Stellar liquidity venues.',
+  openGraph: {
+    title: 'Quote Inspector | StellarRoute',
+    description:
+      'Analyze and reconcile quotes across SDEX and Soroban AMM pools.',
+    type: 'website',
+  },
+};
+
+export default function QuoteInspectorLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/frontend/app/quote-inspector/page.tsx
+++ b/frontend/app/quote-inspector/page.tsx
@@ -1,19 +1,8 @@
 "use client";
 
-import { Metadata } from "next";
 import { QuoteInspector, VenueQuote } from "@/components/shared/QuoteInspector";
 import { toast } from "sonner";
 import { Header } from "@/components/Header";
-
-export const metadata: Metadata = {
-  title: "Quote Inspector | StellarRoute",
-  description: "Reconcile and compare quotes from multiple Stellar liquidity venues.",
-  openGraph: {
-    title: "Quote Inspector | StellarRoute",
-    description: "Analyze and reconcile quotes across SDEX and Soroban AMM pools.",
-    type: "website",
-  },
-};
 
 const MOCK_TIMESTAMP = 1713895200; // Fixed timestamp to satisfy purity rule
 

--- a/frontend/app/settings/layout.tsx
+++ b/frontend/app/settings/layout.tsx
@@ -1,0 +1,20 @@
+import type { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Settings | StellarRoute',
+  description:
+    'Customize your StellarRoute experience with theme, language, and notification settings.',
+  openGraph: {
+    title: 'Settings | StellarRoute',
+    description: 'Personalize your StellarRoute interface and preferences.',
+    type: 'website',
+  },
+};
+
+export default function SettingsLayout({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  return children;
+}

--- a/frontend/app/settings/page.tsx
+++ b/frontend/app/settings/page.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Metadata } from 'next';
 import { useState } from 'react';
 import { useSettings } from '@/components/providers/settings-provider';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -16,16 +15,6 @@ import { HighContrastToggle } from '@/components/settings/HighContrastToggle';
 import { BrowserNotificationSettings } from '@/components/settings/BrowserNotificationSettings';
 import { useBrowserNotifications } from '@/hooks/useBrowserNotifications';
 import { useSwapI18n } from '@/lib/swap-i18n';
-
-export const metadata: Metadata = {
-  title: 'Settings | StellarRoute',
-  description: 'Customize your StellarRoute experience with theme, language, and notification settings.',
-  openGraph: {
-    title: 'Settings | StellarRoute',
-    description: 'Personalize your StellarRoute interface and preferences.',
-    type: 'website',
-  },
-};
 
 export default function SettingsPage() {
   const { settings, updateSlippage, updateTheme, resetSettings } = useSettings();

--- a/frontend/components/providers/wallet-provider.tsx
+++ b/frontend/components/providers/wallet-provider.tsx
@@ -327,6 +327,60 @@ export function WalletProvider({
   );
 }
 
+const STORY_WALLET_ADDRESS =
+  'GABC123DEFGHIJKLMNOPQRSTUVWXYZ456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+const noopAsync = async () => {};
+
+interface StoryWalletProviderProps {
+  children: ReactNode;
+  connected?: boolean;
+  address?: string;
+}
+
+/** Deterministic wallet context for Ladle stories and visual fixtures. */
+export function StoryWalletProvider({
+  children,
+  connected = false,
+  address = STORY_WALLET_ADDRESS,
+}: StoryWalletProviderProps) {
+  const value: WalletContextValue = {
+    address: connected ? address : null,
+    isConnected: connected,
+    network: 'testnet',
+    walletNetwork: connected ? 'testnet' : null,
+    walletId: connected ? 'freighter' : null,
+    availableWallets: [],
+    isLoading: false,
+    error: null,
+    connect: noopAsync,
+    reconnect: noopAsync,
+    disconnect: () => {},
+    setNetwork: () => {},
+    autoReconnectPreferred: false,
+    setAutoReconnectPreferred: () => {},
+    refreshWallets: noopAsync,
+    refreshAccount: noopAsync,
+    networkMismatch: false,
+    accountSwitchState: {
+      isDetecting: false,
+      hasChanged: false,
+      previousAddress: null,
+    },
+    isTransactionPending: false,
+    setTransactionPending: () => {},
+    capabilities: null,
+    refreshCapabilities: noopAsync,
+    syncMismatch: false,
+    resyncWallet: noopAsync,
+    dismissSyncMismatch: () => {},
+  };
+
+  return (
+    <WalletContext.Provider value={value}>{children}</WalletContext.Provider>
+  );
+}
+
 export function useWallet() {
   const context = useContext(WalletContext);
   if (!context) {

--- a/frontend/components/settings/LocaleSelector.tsx
+++ b/frontend/components/settings/LocaleSelector.tsx
@@ -5,6 +5,7 @@ import { SUPPORTED_LOCALES, Locale } from '@/lib/formatting';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { useSwapI18n } from '@/lib/swap-i18n';
+import type { SwapTranslationKey } from '@/lib/swap-i18n';
 
 export function LocaleSelector() {
   const { settings, updateLocale } = useSettings();
@@ -42,7 +43,13 @@ export function LocaleSelector() {
   );
 }
 
-function formatExample(locale: Locale, t: (key: string, vars?: Record<string, string | number>) => string): string {
+function formatExample(
+  locale: Locale,
+  t: (
+    key: SwapTranslationKey,
+    vars?: Record<string, string | number>,
+  ) => string,
+): string {
   try {
     const amount = new Intl.NumberFormat(locale, {
       minimumFractionDigits: 2,

--- a/frontend/components/swap/SwapCard.stories.tsx
+++ b/frontend/components/swap/SwapCard.stories.tsx
@@ -1,0 +1,64 @@
+import type { Story } from '@ladle/react';
+import '@/app/globals.css';
+import { SwapCard } from './SwapCard';
+import { SwapCardStoryProviders } from './SwapCardStoryProviders';
+import type { SwapCardStoryFixture } from './swapCardStory';
+
+function SwapCardStory({
+  fixture,
+}: {
+  fixture: SwapCardStoryFixture;
+}) {
+  return (
+    <SwapCardStoryProviders fixture={fixture}>
+      <SwapCard storyFixture={fixture} />
+    </SwapCardStoryProviders>
+  );
+}
+
+/** Disconnected wallet, empty form — default landing state. */
+export const Idle: Story = () => <SwapCardStory fixture="idle" />;
+Idle.storyName = 'Idle — No Wallet';
+
+/** Connected wallet with an in-flight quote request. */
+export const Quoting: Story = () => <SwapCardStory fixture="quoting" />;
+Quoting.storyName = 'Quoting — Loading Quote';
+
+/** Quote succeeded earlier but is now marked stale. */
+export const Stale: Story = () => <SwapCardStory fixture="stale" />;
+Stale.storyName = 'Stale — Outdated Quote';
+
+/** Review step before wallet signature. */
+export const Confirming: Story = () => <SwapCardStory fixture="confirming" />;
+Confirming.storyName = 'Confirming — Review Modal';
+
+/** Quote API failure with actionable error copy. */
+export const Error: Story = () => <SwapCardStory fixture="error" />;
+Error.storyName = 'Error — Quote Unavailable';
+
+/** Full state matrix at a glance for design review. */
+export const StateMatrix: Story = () => (
+  <div className="dark min-h-screen bg-background text-foreground p-8">
+    <div className="grid gap-10 max-w-5xl mx-auto">
+      {(
+        [
+          ['idle', 'Idle'],
+          ['quoting', 'Quoting'],
+          ['stale', 'Stale'],
+          ['confirming', 'Confirming'],
+          ['error', 'Error'],
+        ] as const
+      ).map(([fixture, label]) => (
+        <section key={fixture} className="space-y-3">
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            {label}
+          </h3>
+          <SwapCardStoryProviders fixture={fixture}>
+            <SwapCard storyFixture={fixture} />
+          </SwapCardStoryProviders>
+        </section>
+      ))}
+    </div>
+  </div>
+);
+StateMatrix.storyName = 'State Matrix — All Fixtures';

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -46,8 +46,20 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@/components/ui/dialog';
+import {
+  getSwapCardStoryPresentation,
+  type SwapCardStoryFixture,
+} from './swapCardStory';
 
-export function SwapCard() {
+export interface SwapCardProps {
+  /** Ladle story fixture — drives deterministic UI states for visual review. */
+  storyFixture?: SwapCardStoryFixture;
+}
+
+export function SwapCard({ storyFixture }: SwapCardProps = {}) {
+  const storyPresentation = storyFixture
+    ? getSwapCardStoryPresentation(storyFixture)
+    : null;
   const { t } = useSwapI18n();
   const { isCompact, toggleCompact } = useCompactMode();
   const tradingPairContext = useOptionalTradingPair();
@@ -287,6 +299,29 @@ export function SwapCard() {
     requiresFreshQuote,
     memoError,
   ]);
+
+  const displayButtonState =
+    storyPresentation?.buttonState ?? buttonState;
+  const displayQuoteLoading =
+    storyPresentation?.quoteLoading ?? quote.loading;
+  const displayQuoteStale = storyPresentation?.quoteStale ?? quote.isStale;
+  const displayQuoteError = storyPresentation?.quoteError ?? quote.error;
+  const displayQuotePriceImpact =
+    storyPresentation?.quotePriceImpact ?? quote.priceImpact;
+  const displayToAmount = storyPresentation?.toAmount ?? toAmount;
+  const displayFormattedRate =
+    storyPresentation?.formattedRate ?? formattedRate;
+  const displayIsModalOpen =
+    storyPresentation?.confirmModalOpen ?? isModalOpen;
+  const displayOptimisticStatus =
+    storyPresentation?.optimisticStatus ?? optimistic.status;
+  const displayTradeParams =
+    storyPresentation?.tradeParams ?? optimistic.tradeParams;
+
+  useEffect(() => {
+    if (!storyPresentation?.seedFromAmount) return;
+    setFromAmount(storyPresentation.seedFromAmount);
+  }, [storyPresentation?.seedFromAmount, setFromAmount]);
 
   useEffect(() => {
     const handleVisibilityChange = () => {
@@ -625,14 +660,14 @@ export function SwapCard() {
                 variant="ghost"
                 size="icon"
                 onClick={() => quote.refresh()}
-                disabled={quote.loading}
+                disabled={displayQuoteLoading}
                 aria-label={t('swap.card.refreshQuote')}
                 className="h-9 w-9 rounded-xl hover:bg-muted/80"
               >
                 <RefreshCw
                   className={cn(
                     'h-4.5 w-4.5 text-muted-foreground',
-                    quote.loading && 'animate-spin'
+                    displayQuoteLoading && 'animate-spin'
                   )}
                 />
               </Button>
@@ -692,7 +727,7 @@ export function SwapCard() {
               <div className="flex justify-between items-start mb-1">
                 <AmountInput
                   label={t('swap.pair.youReceive')}
-                  value={selectedRoute?.expectedAmount ?? toAmount}
+                  value={selectedRoute?.expectedAmount ?? displayToAmount}
                   readOnly
                   placeholder="0.00"
                   className="flex-1"
@@ -708,7 +743,7 @@ export function SwapCard() {
           </div>
 
           {/* Info Panels (Conditional) */}
-          {parseFloat(fromAmount) > 0 && (
+          {(parseFloat(fromAmount) > 0 || storyPresentation?.seedFromAmount) && (
             <div
               className={cn(
                 'space-y-3 animate-in fade-in slide-in-from-bottom-2 duration-500',
@@ -716,19 +751,19 @@ export function SwapCard() {
               )}
             >
               <PriceInfoPanel
-                rate={formattedRate}
-                priceImpact={quote.priceImpact}
-                minReceived={`${(parseFloat(toAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`}
+                rate={displayFormattedRate}
+                priceImpact={displayQuotePriceImpact}
+                minReceived={`${(parseFloat(displayToAmount || '0') * (1 - slippage / 100)).toFixed(4)} ${toSymbol}`}
                 networkFee={
                   quote.fee ? `${quote.fee.toFixed(5)} XLM` : '0.00001 XLM'
                 }
-                isLoading={quote.loading}
+                isLoading={displayQuoteLoading}
                 onExportJson={() => handleExport('json')}
                 onExportCsv={() => handleExport('csv')}
               />
               <RouteDisplay
-                amountOut={selectedRoute?.expectedAmount ?? toAmount}
-                isLoading={quote.loading}
+                amountOut={selectedRoute?.expectedAmount ?? displayToAmount}
+                isLoading={displayQuoteLoading}
                 onSelect={setSelectedRoute}
               />
               {/* Share Quote Button */}
@@ -747,7 +782,7 @@ export function SwapCard() {
           )}
 
           {/* Stale Indicator */}
-          {quote.isStale && (
+          {displayQuoteStale && (
             <span
               data-testid="stale-indicator"
               className="text-xs text-amber-500 font-medium"
@@ -853,17 +888,17 @@ export function SwapCard() {
           {/* Action Button */}
           <div className="pt-2">
             <SwapButton
-              state={buttonState}
+              state={displayButtonState}
               onSwap={handleSwap}
               onConnectWallet={() => connect('freighter')} // Connection managed by WalletProvider
-              isLoading={quote.loading}
+              isLoading={displayQuoteLoading}
             />
           </div>
 
           {/* Status/Error Messages */}
-          {quote.error && (
+          {displayQuoteError && (
             <p className="text-center text-xs font-medium text-destructive animate-pulse">
-              {quote.error.message}
+              {displayQuoteError.message}
             </p>
           )}
         </CardContent>
@@ -886,11 +921,11 @@ export function SwapCard() {
 
       {!bypassConfirmation && (
         <TransactionConfirmationModal
-          isOpen={isModalOpen}
-          status={optimistic.status}
+          isOpen={displayIsModalOpen}
+          status={displayOptimisticStatus}
           txHash={optimistic.txHash}
           errorMessage={optimistic.errorMessage}
-          tradeParams={optimistic.tradeParams}
+          tradeParams={displayTradeParams}
           onConfirm={() => {}}
           onCancel={() => {
             optimistic.cancel();

--- a/frontend/components/swap/SwapCardStoryProviders.tsx
+++ b/frontend/components/swap/SwapCardStoryProviders.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import { ReactNode, useEffect } from 'react';
+import { ThemeProvider } from 'next-themes';
+import { Toaster } from 'sonner';
+import { SettingsProvider } from '@/components/providers/settings-provider';
+import { StoryWalletProvider } from '@/components/providers/wallet-provider';
+import { TradingPairProvider } from '@/contexts/TradingPairContext';
+import { STORAGE_KEY } from '@/hooks/useTradeFormStorage';
+import type { SwapCardStoryFixture } from './swapCardStory';
+import { getSwapCardStoryPresentation } from './swapCardStory';
+
+const MOCK_ACCOUNT_BALANCE = {
+  balances: [{ balance: '50.0000000', asset_type: 'native' as const }],
+};
+
+const MOCK_QUOTE_SUCCESS = {
+  total: '1.0500',
+  price_impact: '0.12',
+  path: [],
+  price: '0.1050',
+  amount: '10',
+};
+
+function seedTradeForm(fixture: SwapCardStoryFixture) {
+  const { seedFromAmount } = getSwapCardStoryPresentation(fixture);
+  if (!seedFromAmount) {
+    localStorage.removeItem(STORAGE_KEY);
+    return;
+  }
+
+  localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({
+      amount: seedFromAmount,
+      slippage: 0.5,
+      deadline: 30,
+      fromToken: 'native',
+      toToken: 'USDC:GA5ZSEJYB37JRC5AVCIAZDL2Y343IFRMA2EO3HJWV2XG7H5V5CQRUP7W',
+      side: 'sell',
+      savedAt: Date.now(),
+    }),
+  );
+}
+
+function installStoryFetch(fixture: SwapCardStoryFixture) {
+  const presentation = getSwapCardStoryPresentation(fixture);
+  const originalFetch = globalThis.fetch.bind(globalThis);
+
+  globalThis.fetch = ((input: RequestInfo | URL) => {
+    const url = typeof input === 'string' ? input : input.toString();
+
+    if (url.includes('/accounts/')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(MOCK_ACCOUNT_BALANCE),
+      } as Response);
+    }
+
+    if (presentation.quoteLoading) {
+      return new Promise(() => {});
+    }
+
+    if (presentation.quoteError) {
+      return Promise.resolve({
+        ok: false,
+        status: 503,
+        json: () =>
+          Promise.resolve({
+            error: { code: 'QUOTE_UNAVAILABLE', message: presentation.quoteError?.message },
+          }),
+      } as Response);
+    }
+
+    if (url.includes('/quote') || url.includes('/routes')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve(MOCK_QUOTE_SUCCESS),
+      } as Response);
+    }
+
+    return originalFetch(input);
+  }) as typeof fetch;
+
+  return () => {
+    globalThis.fetch = originalFetch;
+  };
+}
+
+export function SwapCardStoryProviders({
+  fixture,
+  children,
+}: {
+  fixture: SwapCardStoryFixture;
+  children: ReactNode;
+}) {
+  const { walletConnected } = getSwapCardStoryPresentation(fixture);
+
+  useEffect(() => {
+    localStorage.clear();
+    seedTradeForm(fixture);
+    return installStoryFetch(fixture);
+  }, [fixture]);
+
+  return (
+    <ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
+      <SettingsProvider>
+        <StoryWalletProvider connected={walletConnected}>
+          <TradingPairProvider>
+            <div className="dark min-h-screen bg-background text-foreground p-8">
+              {children}
+              <Toaster />
+            </div>
+          </TradingPairProvider>
+        </StoryWalletProvider>
+      </SettingsProvider>
+    </ThemeProvider>
+  );
+}

--- a/frontend/components/swap/TransactionConfirmationModal.stories.tsx
+++ b/frontend/components/swap/TransactionConfirmationModal.stories.tsx
@@ -2,31 +2,50 @@ import type { Story } from '@ladle/react';
 import { useState } from 'react';
 import { TransactionConfirmationModal } from './TransactionConfirmationModal';
 import type { TransactionConfirmationModalProps } from './TransactionConfirmationModal';
+import type { TradeParams } from '@/hooks/useTransactionLifecycle';
 
 // ── Shared mock quote ────────────────────────────────────────────────────────
 
-const baseTradeParams = {
+const MOCK_WALLET =
+  'GABC123DEFGHIJKLMNOPQRSTUVWXYZ456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+const baseTradeParams: TradeParams = {
   fromAsset: 'XLM',
   toAsset: 'USDC',
   fromAmount: '500.00',
   toAmount: '52.47',
+  exchangeRate: '0.1049',
+  priceImpact: '0.12',
   minReceived: '52.21 USDC',
+  networkFee: '0.00001 XLM',
+  routePath: [],
+  walletAddress: MOCK_WALLET,
 };
 
-const splitRouteTradeParams = {
+const splitRouteTradeParams: TradeParams = {
   fromAsset: 'XLM',
   toAsset: 'BTC',
   fromAmount: '10000.00',
   toAmount: '0.01662',
+  exchangeRate: '0.000001662',
+  priceImpact: '0.45',
   minReceived: '0.01645 BTC',
+  networkFee: '0.00001 XLM',
+  routePath: [],
+  walletAddress: MOCK_WALLET,
 };
 
-const highSlippageTradeParams = {
+const highSlippageTradeParams: TradeParams = {
   fromAsset: 'XLM',
   toAsset: 'AQUA',
   fromAmount: '50000.00',
   toAmount: '1750000.00',
+  exchangeRate: '35.0',
+  priceImpact: '8.5',
   minReceived: '1662500.00 AQUA',
+  networkFee: '0.00001 XLM',
+  routePath: [],
+  walletAddress: MOCK_WALLET,
 };
 
 // ── Shared no-op handlers ────────────────────────────────────────────────────

--- a/frontend/components/swap/swapCardStory.ts
+++ b/frontend/components/swap/swapCardStory.ts
@@ -1,0 +1,93 @@
+import type { SwapButtonState } from './SwapButton';
+import type { TradeParams } from '@/hooks/useTransactionLifecycle';
+
+export type SwapCardStoryFixture =
+  | 'idle'
+  | 'quoting'
+  | 'stale'
+  | 'confirming'
+  | 'error';
+
+export const SWAP_CARD_STORY_WALLET_ADDRESS =
+  'GABC123DEFGHIJKLMNOPQRSTUVWXYZ456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+const baseTradeParams: TradeParams = {
+  fromAsset: 'XLM',
+  toAsset: 'USDC',
+  fromAmount: '10.00',
+  toAmount: '1.0500',
+  exchangeRate: '0.1050',
+  priceImpact: '0.12',
+  minReceived: '1.0447 USDC',
+  networkFee: '0.00001 XLM',
+  routePath: [],
+  walletAddress: SWAP_CARD_STORY_WALLET_ADDRESS,
+};
+
+export interface SwapCardStoryPresentation {
+  walletConnected: boolean;
+  seedFromAmount?: string;
+  buttonState?: SwapButtonState;
+  quoteLoading?: boolean;
+  quoteStale?: boolean;
+  quoteError?: { message: string } | null;
+  quotePriceImpact?: number;
+  toAmount?: string;
+  formattedRate?: string;
+  confirmModalOpen?: boolean;
+  optimisticStatus?: 'review' | 'pending' | 'submitted' | 'confirmed' | 'failed' | 'dropped';
+  tradeParams?: TradeParams;
+}
+
+export function getSwapCardStoryPresentation(
+  fixture: SwapCardStoryFixture,
+): SwapCardStoryPresentation {
+  switch (fixture) {
+    case 'idle':
+      return {
+        walletConnected: false,
+      };
+    case 'quoting':
+      return {
+        walletConnected: true,
+        seedFromAmount: '10',
+        buttonState: 'refreshing_quote',
+        quoteLoading: true,
+        formattedRate: '1 XLM = 0.1050 USDC',
+      };
+    case 'stale':
+      return {
+        walletConnected: true,
+        seedFromAmount: '10',
+        buttonState: 'error',
+        quoteStale: true,
+        toAmount: '1.0500',
+        formattedRate: '1 XLM = 0.1050 USDC',
+        quotePriceImpact: 0.12,
+      };
+    case 'confirming':
+      return {
+        walletConnected: true,
+        seedFromAmount: '10',
+        buttonState: 'ready',
+        toAmount: '1.0500',
+        formattedRate: '1 XLM = 0.1050 USDC',
+        quotePriceImpact: 0.12,
+        confirmModalOpen: true,
+        optimisticStatus: 'review',
+        tradeParams: baseTradeParams,
+      };
+    case 'error':
+      return {
+        walletConnected: true,
+        seedFromAmount: '10',
+        buttonState: 'error',
+        quoteError: {
+          message:
+            'Unable to fetch quote from SDEX. Check your connection and try again.',
+        },
+      };
+    default:
+      return { walletConnected: false };
+  }
+}

--- a/frontend/ladle-vite.config.ts
+++ b/frontend/ladle-vite.config.ts
@@ -1,0 +1,19 @@
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { defineConfig } from 'vite';
+
+const dirname = path.dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  resolve: {
+    alias: {
+      '@': dirname,
+      'next/navigation': path.resolve(dirname, '__mocks__/next-navigation.ts'),
+      'next/dynamic': path.resolve(dirname, '__mocks__/next-dynamic.tsx'),
+      '@stellar/freighter-api': path.resolve(
+        dirname,
+        '__mocks__/@stellar/freighter-api.browser.ts',
+      ),
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Add SwapCard Ladle stories covering idle, quoting, stale, confirming, and error states
- Introduce SwapCardStoryProviders with mock wallet and fetch fixtures for deterministic previews
- Wire optional storyFixture prop on SwapCard and document the entry in STORYBOOK.md

Closes #790

## Test plan
- [x] npm run storybook:ci
- [x] npx vitest run components/swap/SwapCard.test.tsx

Made with [Cursor](https://cursor.com)