### PR TITLE
fix: production-harden next.config, add API proxy, add perf CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,3 +40,8 @@ jobs:
         run: npm ci --prefix frontend
       - name: Build frontend
         run: npm --prefix frontend run build
+      - name: Performance budget check
+        run: npm --prefix frontend run perf:check:ci
+        continue-on-error: false
+        env:
+          CI: "true"

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -85,10 +85,9 @@ export class StellarRouteClient {
   private readonly retries: number = 2;
 
   constructor(baseUrl?: string) {
-    this.baseUrl =
-      (baseUrl ?? process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080')
-        // Strip trailing slash so we can always prepend / paths uniformly
-        .replace(/\/$/, '');
+    const proxyEnabled = process.env.NEXT_PUBLIC_API_PROXY === 'true';
+    const resolved = baseUrl ?? (proxyEnabled ? '' : (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080'));
+    this.baseUrl = resolved.replace(/\/$/, '');
   }
 
   // -------------------------------------------------------------------------

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -1,5 +1,9 @@
-export const API_BASE_URL =
-  process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api/v1';
+export const API_PROXY_ENABLED =
+  process.env.NEXT_PUBLIC_API_PROXY === 'true';
+
+export const API_BASE_URL = API_PROXY_ENABLED
+  ? '/api/v1'
+  : process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080/api/v1';
 
 export const APP_NAME = 'StellarRoute';
 export const APP_DESCRIPTION =

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,7 +1,26 @@
 import type { NextConfig } from "next";
+import bundleAnalyzer from "@next/bundle-analyzer";
+
+const withBundleAnalyzer = bundleAnalyzer({
+  enabled: process.env.ANALYZE === "true",
+});
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  reactStrictMode: true,
+  poweredByHeader: false,
+  images: {
+    remotePatterns: [],
+  },
+  async rewrites() {
+    const backendUrl = process.env.BACKEND_URL;
+    if (!backendUrl) return [];
+    return [
+      {
+        source: "/api/v1/:path*",
+        destination: `${backendUrl}/api/v1/:path*`,
+      },
+    ];
+  },
 };
 
-export default nextConfig;
+export default withBundleAnalyzer(nextConfig);

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,6 +16,7 @@
     "storybook": "ladle dev",
     "storybook:ci": "ladle build",
     "perf:check": "node scripts/check-perf-budget.mjs",
+    "perf:check:ci": "node scripts/check-perf-budget.mjs --bundle-only",
     "perf:baseline": "node scripts/check-perf-budget.mjs --update-baseline"
   },
   "dependencies": {

--- a/frontend/scripts/check-perf-budget.mjs
+++ b/frontend/scripts/check-perf-budget.mjs
@@ -165,6 +165,7 @@ function printSummary(results, baseline) {
 
 async function main(argv) {
   const updateBaseline = argv.includes("--update-baseline");
+  const bundleOnly = argv.includes("--bundle-only");
 
   // Load config (exits on error)
   const config = loadConfig(CONFIG_PATH);
@@ -176,9 +177,14 @@ async function main(argv) {
   console.log("[perf-budget] Measuring bundle size...");
   const bundleSizeKb = parseBundleSize(BUILD_DIR);
 
-  // Measure TTI
-  console.log("[perf-budget] Measuring TTI...");
-  const ttiMs = runTTIMeasurement();
+  // Measure TTI (skipped in bundle-only mode — CI environments cannot run a production server)
+  let ttiMs = 0;
+  if (bundleOnly) {
+    console.log("[perf-budget] Skipping TTI measurement (--bundle-only)");
+  } else {
+    console.log("[perf-budget] Measuring TTI...");
+    ttiMs = runTTIMeasurement();
+  }
 
   // --update-baseline: capture new baseline and exit 0
   if (updateBaseline) {
@@ -200,7 +206,7 @@ async function main(argv) {
 
   // Compare thresholds
   const bundleResult = compareThreshold(bundleSizeKb, config.bundleSizeKb);
-  const ttiResult = compareThreshold(ttiMs, config.ttiMs);
+  const ttiResult = bundleOnly ? { passed: true } : compareThreshold(ttiMs, config.ttiMs);
   const { overallPassed } = computeOverallResult(bundleResult.passed, ttiResult.passed);
 
   // Build results object


### PR DESCRIPTION
## Summary

- **#763** — Configure `next.config.ts` for production: `reactStrictMode: true`, `poweredByHeader: false`, `withBundleAnalyzer` gated on `ANALYZE=true`, and `images.remotePatterns` configured
- **#764** — Add Next.js API rewrites for same-origin proxy: when `BACKEND_URL` env var is set, `/api/v1/*` requests are proxied to the backend. When `NEXT_PUBLIC_API_PROXY=true`, the API client and constants use relative URLs, eliminating CORS/cookie issues on single-origin deploys. Local dev without proxy is unchanged
- **#766** — Add `perf:check:ci` script and CI step that runs bundle-size checks after the frontend build. Uses `--bundle-only` flag to skip TTI measurement in SSR-only CI environments (TTI requires a running production server)
- **#768** — Verified no duplicate devDependencies exist in `package.json`; each package is listed once with a single version

Closes #763, closes #764, closes #766, closes #768

## Files changed

- `frontend/next.config.ts` — Production hardening + API rewrites
- `frontend/lib/constants.ts` — Proxy-aware `API_BASE_URL`
- `frontend/lib/api/client.ts` — Proxy-aware `StellarRouteClient` constructor
- `.github/workflows/ci.yml` — Added perf budget check step
- `frontend/package.json` — Added `perf:check:ci` script
- `frontend/scripts/check-perf-budget.mjs` — Added `--bundle-only` flag support

## Test plan

- [ ] `npm --prefix frontend run build` succeeds with new next.config.ts
- [ ] `ANALYZE=true npm --prefix frontend run build` opens bundle analyzer
- [ ] Setting `BACKEND_URL=http://backend:3000` enables `/api/v1/*` rewrites
- [ ] Setting `NEXT_PUBLIC_API_PROXY=true` makes the API client use relative URLs
- [ ] Without proxy env vars, local dev behavior is unchanged
- [ ] `npm --prefix frontend run perf:check:ci` runs bundle-only check after build
- [ ] CI workflow runs performance budget check after frontend build

🤖 Generated with [Claude Code](https://claude.com/claude-code)