### PR TITLE
docs(sdk-rust): document quote CLI flags in stellarroute binary --hel…

### DIFF
--- a/crates/sdk-rust/src/bin/stellarroute.rs
+++ b/crates/sdk-rust/src/bin/stellarroute.rs
@@ -60,7 +60,10 @@ enum Commands {
         #[arg(long, default_value_t = 10, help = "Maximum number of pairs to print")]
         limit: usize,
     },
-    #[command(about = "Get a price quote for a trading pair")]
+    #[command(
+        about = "Get a price quote for a trading pair",
+        after_help = "Examples:\n  # Sell 100 XLM for USDC (human output)\n  stellarroute quote native USDC --amount 100 --quote-type sell\n\n  # Buy 50 USDC worth of XLM, JSON output\n  stellarroute quote native USDC --amount 50 --quote-type buy --output json\n\n  # Indicative price with no amount (server defaults to 1 unit)\n  stellarroute quote native USDC\n\nSlippage tolerance is enforced server-side; use the REST API directly\nif you need to pass a custom slippage_bps value."
+    )]
     Quote {
         #[arg(
             value_parser = parse_asset,
@@ -75,14 +78,16 @@ enum Commands {
         #[arg(
             long,
             value_parser = PositiveAmountParser,
-            help = "Trade amount as a positive decimal string"
+            help = "Trade amount as a positive decimal string (e.g. 100, 0.5)",
+            long_help = "Amount of the base asset to trade, expressed as a positive decimal string.\n\nExamples: 100, 0.5, 1000.25\n\nWhen omitted the server uses a default of 1 unit, which is useful for\nchecking an indicative mid-market price without committing to a size.\n\nThe value is passed verbatim to the REST API as the `amount` query\nparameter; no rounding or truncation is applied by the CLI."
         )]
         amount: Option<String>,
         #[arg(
             long,
             value_enum,
             default_value_t = QuoteTypeArg::Sell,
-            help = "Whether the amount is for selling or buying the base asset"
+            help = "Direction of the quote: sell or buy the base asset (default: sell)",
+            long_help = "Controls which side of the trade `amount` describes:\n\n  sell  The caller wants to sell `amount` of the base asset and receive\n        as much of the quote asset as possible. The REST API returns the\n        best executable ask price.\n\n  buy   The caller wants to buy `amount` of the base asset by spending\n        quote-asset tokens. The REST API returns the best executable\n        bid price.\n\nMatches the `quote_type` query parameter on GET /api/v1/quote/{base}/{quote}.\nDefaults to sell."
         )]
         quote_type: QuoteTypeArg,
     },

--- a/docs/sdk-rust/README.md
+++ b/docs/sdk-rust/README.md
@@ -210,6 +210,39 @@ cargo run -p stellarroute-sdk --bin stellarroute -- orderbook native USDC --leve
 cargo run -p stellarroute-sdk --bin stellarroute -- pairs --limit 30
 ```
 
+### Quote flag reference
+
+| Flag | Default | Description |
+|---|---|---|
+| `--amount <decimal>` | _(omit for indicative price)_ | Amount of the base asset to trade. Positive decimal, e.g. `100` or `0.5`. When omitted the server uses `1` unit. |
+| `--quote-type <sell\|buy>` | `sell` | `sell` — spend base, receive quote. `buy` — spend quote, receive base. Maps to `quote_type` on `GET /api/v1/quote`. |
+
+Slippage tolerance (`slippage_bps`) is enforced server-side and is not
+exposed as a CLI flag. Use the REST API directly if you need a custom
+slippage value.
+
+### Copy-paste example against localhost
+
+```bash
+# Sell 100 XLM for USDC — human output
+cargo run -p stellarroute-sdk --bin stellarroute -- \
+  quote native USDC \
+  --amount 100 \
+  --quote-type sell
+
+# Buy 50 USDC worth of XLM — machine-readable JSON
+cargo run -p stellarroute-sdk --bin stellarroute -- \
+  --api-url http://127.0.0.1:3000 \
+  --output json \
+  quote native USDC \
+  --amount 50 \
+  --quote-type buy
+
+# Indicative mid-market price (no amount — server defaults to 1 unit)
+cargo run -p stellarroute-sdk --bin stellarroute -- \
+  quote native USDC
+```
+
 ### Output formats
 
 - `human` — friendly terminal output


### PR DESCRIPTION
…p (#831)

Improve clap help strings for the quote subcommand so that cargo run -p stellarroute-sdk -- quote --help fully documents all flags:

- --amount: expand help to explain default behaviour when omitted (server uses 1 unit, useful for indicative mid-market price), accepted format (positive decimal), and that the value is passed verbatim to the REST API amount query parameter.

- --quote-type: expand help to define sell vs buy semantics in terms of the REST API (sell = spend base asset, receive quote asset, best ask; buy = spend quote asset, receive base asset, best bid) and note it maps to the quote_type parameter on GET /api/v1/quote/{base}/{quote}. Default value (sell) is now stated explicitly in the short help.

- Add after_help to the Quote subcommand with three copy-paste examples (sell, buy, indicative) and a note that slippage_bps is server-side.

Add docs/sdk-rust/README.md:
- Quote flag reference table (--amount, --quote-type, defaults, meaning)
- Slippage note explaining server-side enforcement
- Copy-paste example block with three localhost commands (sell, buy, indicative price) using the full cargo run invocation form

No behavior change: all existing tests pass (21/21).
closes #831