### PR TITLE
fix(ci): shard components Vitest job to avoid heap OOM

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,12 +51,24 @@ jobs:
           CI: "true"
 
   frontend-tests:
-    name: Frontend Unit Tests (${{ matrix.suite }})
+    name: Frontend Unit Tests (${{ matrix.label }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        suite: [components, hooks, lib, app]
+        include:
+          - label: hooks
+            suite: hooks
+          - label: lib
+            suite: lib
+          - label: app
+            suite: app
+          - label: components (1/2)
+            suite: components
+            shard: 1/2
+          - label: components (2/2)
+            suite: components
+            shard: 2/2
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -70,7 +82,7 @@ jobs:
       - name: Run frontend tests
         run: |
           if [ "${{ matrix.suite }}" = "components" ]; then
-            npm --prefix frontend run test -- components --pool=forks --maxWorkers=2
+            npm --prefix frontend run test -- components --pool=forks --maxWorkers=1 --shard=${{ matrix.shard }}
           else
             npm --prefix frontend run test -- ${{ matrix.suite }}
           fi


### PR DESCRIPTION
## Summary
- Split the `components` frontend test matrix job into two Vitest shards (`1/2`, `2/2`).
- Keep fork pool with `maxWorkers=1` per shard to prevent the post-#941 heap OOM.

## Test plan
- [ ] CI green on main after merge (hooks/lib/app already passing; components shards complete)