### PR TITLE
fix(ci): split components tests into four Vitest shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,18 @@ jobs:
             suite: lib
           - label: app
             suite: app
-          - label: components (1/2)
+          - label: components (1/4)
             suite: components
-            shard: 1/2
-          - label: components (2/2)
+            shard: 1/4
+          - label: components (2/4)
             suite: components
-            shard: 2/2
+            shard: 2/4
+          - label: components (3/4)
+            suite: components
+            shard: 3/4
+          - label: components (4/4)
+            suite: components
+            shard: 4/4
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js


### PR DESCRIPTION
Quarter the components Vitest matrix after shard 2/2 still OOMed at 6 GiB.