### PR TITLE
fix(ci): quarter-shard components Vitest job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,12 +63,18 @@ jobs:
             suite: lib
           - label: app
             suite: app
-          - label: components (1/2)
+          - label: components (1/4)
             suite: components
-            shard: 1/2
-          - label: components (2/2)
+            shard: 1/4
+          - label: components (2/4)
             suite: components
-            shard: 2/2
+            shard: 2/4
+          - label: components (3/4)
+            suite: components
+            shard: 3/4
+          - label: components (4/4)
+            suite: components
+            shard: 4/4
     steps:
       - uses: actions/checkout@v4
       - name: Setup Node.js
@@ -87,7 +93,7 @@ jobs:
             npm --prefix frontend run test -- ${{ matrix.suite }}
           fi
         env:
-          NODE_OPTIONS: --max-old-space-size=6144
+          NODE_OPTIONS: --max-old-space-size=8192
           CI: "true"
 
   frontend-storybook:

--- a/frontend/vitest.config.ts
+++ b/frontend/vitest.config.ts
@@ -20,7 +20,9 @@ export default defineConfig({
       "**/account-switcher.test.tsx",
     ],
     setupFiles: ["./vitest.setup.ts"],
-    maxWorkers: 2,
+    pool: process.env.CI ? "forks" : "threads",
+    maxWorkers: process.env.CI ? 1 : 2,
+    fileParallelism: !process.env.CI,
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## Summary
- Split the components Vitest matrix from 2 shards to 4 after shard 2/2 still OOM'd at 6GB on main (#942).
- Raise `NODE_OPTIONS` heap to 8GB for frontend unit test jobs.
- Run Vitest in CI with `pool: forks`, `maxWorkers: 1`, and `fileParallelism: false`.

## Test plan
- [x] hooks + lib suites pass locally with `CI=true`
- [ ] CI green on all frontend unit test matrix jobs after merge