### PR TITLE
[904] [backend] Fix LiquidityAnomalyDetector unit test compilation in anomaly.rs

### DIFF
--- a/crates/routing/src/health/anomaly.rs
+++ b/crates/routing/src/health/anomaly.rs
@@ -258,12 +258,8 @@ mod tests {
             stale_read_is_anomaly: false,
             ..Default::default()
         };
-<<<<<<< HEAD
         let alert_threshold = config.alert_threshold;
         let mut detector = LiquidityAnomalyDetector::new(config);
-=======
-        let mut detector = LiquidityAnomalyDetector::new(config.clone());
->>>>>>> origin/main
 
         // Initial update
         let _ = detector.update_and_detect("amm:drain", Some((1000, 1000)), None, Some(Utc::now()));
@@ -283,12 +279,8 @@ mod tests {
             alert_threshold: 0.7,
             ..Default::default()
         };
-<<<<<<< HEAD
         let alert_threshold = config.alert_threshold;
         let mut detector = LiquidityAnomalyDetector::new(config);
-=======
-        let mut detector = LiquidityAnomalyDetector::new(config.clone());
->>>>>>> origin/main
 
         // Initial update
         let _ = detector.update_and_detect(


### PR DESCRIPTION
## Summary
- Resolve merge conflict markers in `health/anomaly.rs` unit tests.
- Fix E0382 move-after-use by capturing `alert_threshold` before moving `config` into `LiquidityAnomalyDetector::new`.
- Preserve existing threshold assertions for drain and stale-read detection.

Closes #904

## Validation
- `cargo test -p stellarroute-routing health::anomaly`
- `cargo test -p stellarroute-routing --test anomaly_tests`
- `cargo clippy -p stellarroute-routing --all-targets --all-features -- -D warnings`