### PR TITLE
[906] [infra] Apply rustfmt to constant_product_adapter Soroban fixture

### DIFF
--- a/crates/contracts/src/constant_product_adapter.rs
+++ b/crates/contracts/src/constant_product_adapter.rs
@@ -104,7 +104,7 @@ mod tests {
 
     // Wire a constant-product adapter to a mock pool seeded with the given
     // reserves and return a client for issuing quotes against it.
-    fn setup(env: &Env, reserve_in: i128, reserve_out: i128) -> PoolAdapterClient {
+    fn setup(env: &Env, reserve_in: i128, reserve_out: i128) -> PoolAdapterClient<'_> {
         let pool_id = env.register_contract(None, MockPool);
         MockPoolClient::new(env, &pool_id).set_rsrvs(&reserve_in, &reserve_out);
 


### PR DESCRIPTION
## Summary
- Formatting-only update to `constant_product_adapter.rs` test fixture helpers (explicit lifetime on `PoolAdapterClient<'_>` for clippy compatibility).
- No functional contract behavior changes.

Closes #906

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p stellarroute-contracts constant_product_adapter`
- [x] `cargo clippy -p stellarroute-contracts --all-targets -- -D warnings`

Made with [Cursor](https://cursor.com)