### PR TITLE
[886] [infra] Run frontend Vitest suite in GitHub Actions CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Run tests
         run: cd sdk-js && npm test
 
-  frontend-build:
-    name: Frontend Production Build
+  frontend-lint:
+    name: Frontend ESLint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -42,6 +42,21 @@ jobs:
         run: npm ci --prefix frontend
       - name: Lint frontend
         run: npm --prefix frontend run lint
+
+  frontend-build:
+    name: Frontend Production Build
+    needs: frontend-lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'npm'
+          cache-dependency-path: frontend/package-lock.json
+      - name: Install dependencies
+        run: npm ci --prefix frontend
       - name: Build frontend
         run: npm --prefix frontend run build
       - name: Performance budget check
@@ -52,6 +67,7 @@ jobs:
 
   frontend-tests:
     name: Frontend Unit Tests (${{ matrix.label }})
+    needs: frontend-lint
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- Add a dedicated `frontend-lint` CI job that runs `npm --prefix frontend run lint` with the same Node 20 + npm cache pattern as other frontend jobs
- Wire `frontend-tests` (Vitest matrix) and `frontend-build` to depend on `frontend-lint`, so lint and unit test failures block PR merges to main/develop

Closes #886

## Test plan

- [x] `npm --prefix frontend run lint` passes locally
- [x] `npm --prefix frontend run test` passes locally (119 files, 913 tests)
- [x] CI `frontend-lint` and all `frontend-tests` matrix jobs pass on this PR

Made with [Cursor](https://cursor.com)