### PR TITLE
feat(frontend): enforce stale-quote UX before Confirm is enabled

### DIFF
--- a/frontend/components/swap/SwapButton.tsx
+++ b/frontend/components/swap/SwapButton.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { Button } from "@/components/ui/button";
-import { Loader2, AlertCircle, Wallet, ShieldOff } from "lucide-react";
+import { Loader2, AlertCircle, Wallet, ShieldOff, RefreshCw } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { useSwapI18n } from "@/lib/swap-i18n";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
@@ -17,12 +17,15 @@ export type SwapButtonState =
   | "ready"
   | "executing"
   | "error"
+  | "stale_quote"
   | "permission_blocked";
 
 interface SwapButtonProps {
   state: SwapButtonState;
   onSwap: () => void;
   onConnectWallet?: () => void;
+  /** Called when the user clicks the "Update Quote" CTA in stale_quote state. */
+  onUpdateQuote?: () => void;
   isLoading?: boolean;
   className?: string;
 }
@@ -31,6 +34,7 @@ export function SwapButton({
   state,
   onSwap,
   onConnectWallet,
+  onUpdateQuote,
   isLoading = false,
   className,
 }: SwapButtonProps) {
@@ -111,6 +115,17 @@ export function SwapButton({
           disabled: true,
           variant: "outline" as const,
           className: "border-destructive/50 text-destructive",
+        };
+      case "stale_quote":
+        return {
+          label: t("swap.cta.updateQuote"),
+          onClick: onUpdateQuote,
+          disabled: isLoading,
+          variant: "outline" as const,
+          icon: isLoading
+            ? <Loader2 className={cn("mr-2 h-5 w-5", !prefersReducedMotion && "animate-spin")} />
+            : <RefreshCw className="mr-2 h-5 w-5" />,
+          className: "border-amber-500/60 text-amber-600 hover:bg-amber-500/10 hover:border-amber-500 hover:text-amber-700 dark:text-amber-400 dark:hover:text-amber-300",
         };
       case "permission_blocked":
         return {

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -12,6 +12,7 @@ import RouteDisplay from './RoutePanelAsync';
 import { MobileRouteBottomSheet } from './MobileRouteBottomSheet';
 import { BatchSwapPreview, type BatchSwapLeg } from './BatchSwapPreview';
 import { SwapButton, SwapButtonState } from './SwapButton';
+import { StaleQuoteBanner } from './StaleQuoteBanner';
 import { SettingsPanel } from '../settings/SettingsPanel';
 import { HighImpactConfirmModal } from './HighImpactConfirmModal';
 import { TransactionConfirmationModal } from './TransactionConfirmationModal';
@@ -19,6 +20,7 @@ import { QuoteStreamStatusIndicator } from './QuoteStreamStatusIndicator';
 import { SessionRecoveryModal } from './SessionRecoveryModal';
 import { useSwapState } from '@/hooks/useSwapState';
 import { useOptimisticSwap } from '@/hooks/useOptimisticSwap';
+import { useStaleQuote } from '@/hooks/useStaleQuote';
 import type { TradeParams } from '@/hooks/useTransactionLifecycle';
 import type { PreSubmitSnapshot } from '@/types/transaction';
 import { useOptionalTradingPair } from '@/contexts/TradingPairContext';
@@ -126,6 +128,14 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
   const [selectedRoute, setSelectedRoute] = useState<AlternativeRoute | null>(
     null
   );
+
+  // Stale-quote detection: disabled when expired OR price impact changed >0.5%
+  const staleQuote = useStaleQuote({
+    expiresAtMs: quote.data?.expires_at,
+    currentPriceImpact: quote.priceImpact,
+    isStale: quote.isStale,
+    lastQuotedAtMs: quote.lastQuotedAtMs,
+  });
 
   // Fetch ranked routes from /api/v1/routes
   const routesState = useRoutes(
@@ -587,7 +597,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
       return 'insufficient_balance';
     if (quote.priceImpact > 10) return 'high_impact_warning';
     if (quote.loading) return 'refreshing_quote';
-    if (quote.isStale) return 'error';
+    if (staleQuote.isQuoteStale) return 'stale_quote';
     return 'ready';
   }, [
     fromAmount,
@@ -597,7 +607,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
     capabilities,
     optimistic.submitLock,
     quote.error,
-    quote.isStale,
+    staleQuote.isQuoteStale,
     quote.loading,
     quote.priceImpact,
     requiresFreshQuote,
@@ -606,7 +616,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
 
   const displayButtonState = storyPresentation?.buttonState ?? buttonState;
   const displayQuoteLoading = storyPresentation?.quoteLoading ?? quote.loading;
-  const displayQuoteStale = storyPresentation?.quoteStale ?? quote.isStale;
+  const displayQuoteStale = storyPresentation?.quoteStale ?? staleQuote.isQuoteStale;
   const displayQuoteError = storyPresentation?.quoteError ?? quote.error;
   const displayQuotePriceImpact =
     storyPresentation?.quotePriceImpact ?? quote.priceImpact;
@@ -1267,12 +1277,22 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
               .join('. ')}
           </div>
 
+          {/* Stale Quote Banner */}
+          {staleQuote.isQuoteStale && (
+            <StaleQuoteBanner
+              isStale={staleQuote.isQuoteStale}
+              onRefresh={quote.refresh}
+              isLoading={displayQuoteLoading}
+            />
+          )}
+
           {/* Action Button */}
           <div className="pt-2">
             <SwapButton
               state={displayButtonState}
               onSwap={handleSwap}
               onConnectWallet={() => connect('freighter')} // Connection managed by WalletProvider
+              onUpdateQuote={quote.refresh}
               isLoading={displayQuoteLoading}
             />
           </div>

--- a/frontend/components/swap/stale-quote.test.tsx
+++ b/frontend/components/swap/stale-quote.test.tsx
@@ -1,0 +1,294 @@
+/**
+ * stale-quote.test.tsx
+ *
+ * Tests for Issue #1000 — Enforce stale-quote UX before Confirm is enabled.
+ *
+ * Coverage:
+ *  1. useStaleQuote hook — expired via expires_at
+ *  2. useStaleQuote hook — expired via isStale fallback
+ *  3. useStaleQuote hook — price impact changed > 0.5%
+ *  4. useStaleQuote hook — price impact changed exactly at threshold (boundary)
+ *  5. useStaleQuote hook — price impact change below threshold (fresh)
+ *  6. useStaleQuote hook — resets baseline when new quote arrives
+ *  7. SwapButton renders "Update Quote" CTA in stale_quote state (disabled = false)
+ *  8. SwapButton "Update Quote" is disabled while loading
+ *  9. SwapButton calls onUpdateQuote when clicked
+ * 10. SwapButton Confirm is NOT rendered in stale_quote state (only Update Quote)
+ * 11. SwapButton does NOT call onSwap in stale_quote state
+ */
+
+import {
+  act,
+  cleanup,
+  fireEvent,
+  render,
+  renderHook,
+  screen,
+} from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  STALE_QUOTE_PRICE_IMPACT_THRESHOLD_PCT,
+  useStaleQuote,
+} from '@/hooks/useStaleQuote';
+import { SwapButton } from './SwapButton';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Advance fake timers AND flush all pending React state updates in one shot.
+ * This avoids the waitFor + fake-timers deadlock (waitFor uses real setTimeout
+ * internally, which is shadowed by vi.useFakeTimers).
+ */
+function tickMs(ms: number) {
+  act(() => {
+    vi.advanceTimersByTime(ms);
+  });
+}
+
+// ---------------------------------------------------------------------------
+// useStaleQuote hook tests
+// ---------------------------------------------------------------------------
+
+describe('useStaleQuote', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+  });
+
+  it('reports expired when now >= expires_at', () => {
+    const expiresAtMs = Date.now() + 3_000; // expires 3s from now
+
+    const { result } = renderHook(() =>
+      useStaleQuote({
+        expiresAtMs,
+        currentPriceImpact: 1.0,
+        isStale: false,
+        lastQuotedAtMs: Date.now(),
+      }),
+    );
+
+    // Before expiry — fresh
+    expect(result.current.isExpired).toBe(false);
+    expect(result.current.isQuoteStale).toBe(false);
+
+    // Advance past expiry (hook ticks every 1 000ms)
+    tickMs(4_000);
+
+    expect(result.current.isExpired).toBe(true);
+    expect(result.current.isQuoteStale).toBe(true);
+  });
+
+  it('falls back to isStale flag when expires_at is not provided', () => {
+    const { result, rerender } = renderHook(
+      ({ isStale }: { isStale: boolean }) =>
+        useStaleQuote({
+          expiresAtMs: undefined,
+          currentPriceImpact: 1.0,
+          isStale,
+          lastQuotedAtMs: Date.now(),
+        }),
+      { initialProps: { isStale: false } },
+    );
+
+    expect(result.current.isExpired).toBe(false);
+    expect(result.current.isQuoteStale).toBe(false);
+
+    act(() => {
+      rerender({ isStale: true });
+    });
+
+    expect(result.current.isExpired).toBe(true);
+    expect(result.current.isQuoteStale).toBe(true);
+  });
+
+  it('reports stale when price impact changes more than 0.5%', () => {
+    const now = Date.now();
+    const { result, rerender } = renderHook(
+      ({ currentPriceImpact }: { currentPriceImpact: number }) =>
+        useStaleQuote({
+          expiresAtMs: now + 60_000, // far in future — not expired
+          currentPriceImpact,
+          isStale: false,
+          lastQuotedAtMs: now,
+        }),
+      { initialProps: { currentPriceImpact: 1.0 } },
+    );
+
+    // Baseline set on first mount
+    expect(result.current.baselinePriceImpact).toBe(1.0);
+
+    // Simulate market movement: impact jumps by > 0.5%
+    act(() => {
+      rerender({ currentPriceImpact: 1.0 + STALE_QUOTE_PRICE_IMPACT_THRESHOLD_PCT + 0.01 });
+    });
+
+    expect(result.current.isPriceImpactChanged).toBe(true);
+    expect(result.current.isQuoteStale).toBe(true);
+  });
+
+  it('treats a change exactly equal to the threshold (0.5%) as NOT stale', () => {
+    const now = Date.now();
+    const { result, rerender } = renderHook(
+      ({ currentPriceImpact }: { currentPriceImpact: number }) =>
+        useStaleQuote({
+          expiresAtMs: now + 60_000,
+          currentPriceImpact,
+          isStale: false,
+          lastQuotedAtMs: now,
+        }),
+      { initialProps: { currentPriceImpact: 1.0 } },
+    );
+
+    expect(result.current.baselinePriceImpact).toBe(1.0);
+
+    // Change exactly equal to threshold — should NOT be stale (strictly greater than)
+    act(() => {
+      rerender({ currentPriceImpact: 1.0 + STALE_QUOTE_PRICE_IMPACT_THRESHOLD_PCT });
+    });
+
+    expect(result.current.isPriceImpactChanged).toBe(false);
+    expect(result.current.isQuoteStale).toBe(false);
+  });
+
+  it('remains fresh when price impact change is below threshold', () => {
+    const now = Date.now();
+    const { result, rerender } = renderHook(
+      ({ currentPriceImpact }: { currentPriceImpact: number }) =>
+        useStaleQuote({
+          expiresAtMs: now + 60_000,
+          currentPriceImpact,
+          isStale: false,
+          lastQuotedAtMs: now,
+        }),
+      { initialProps: { currentPriceImpact: 1.0 } },
+    );
+
+    expect(result.current.baselinePriceImpact).toBe(1.0);
+
+    act(() => {
+      rerender({ currentPriceImpact: 1.3 }); // delta = 0.3 < 0.5
+    });
+
+    expect(result.current.isPriceImpactChanged).toBe(false);
+    expect(result.current.isQuoteStale).toBe(false);
+  });
+
+  it('resets the baseline when a new quote arrives (lastQuotedAtMs advances)', () => {
+    const t0 = Date.now();
+    const t1 = t0 + 10_000;
+
+    const { result, rerender } = renderHook(
+      ({
+        currentPriceImpact,
+        lastQuotedAtMs,
+      }: {
+        currentPriceImpact: number;
+        lastQuotedAtMs: number;
+      }) =>
+        useStaleQuote({
+          expiresAtMs: t0 + 60_000,
+          currentPriceImpact,
+          isStale: false,
+          lastQuotedAtMs,
+        }),
+      { initialProps: { currentPriceImpact: 1.0, lastQuotedAtMs: t0 } },
+    );
+
+    // First baseline
+    expect(result.current.baselinePriceImpact).toBe(1.0);
+
+    // New quote arrived at t1 with a higher impact — baseline should update
+    act(() => {
+      rerender({ currentPriceImpact: 2.0, lastQuotedAtMs: t1 });
+    });
+
+    expect(result.current.baselinePriceImpact).toBe(2.0);
+    // isPriceImpactChanged should be false because baseline was just reset
+    expect(result.current.isPriceImpactChanged).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// SwapButton stale_quote state tests
+// ---------------------------------------------------------------------------
+
+describe('SwapButton stale_quote state', () => {
+  afterEach(() => cleanup());
+
+  it('renders an "Update Quote" button that is enabled', () => {
+    render(
+      <SwapButton
+        state="stale_quote"
+        onSwap={() => {}}
+        onUpdateQuote={() => {}}
+      />,
+    );
+
+    const btn = screen.getByRole('button', { name: /update quote/i });
+    expect(btn).toBeInTheDocument();
+    expect(btn).not.toBeDisabled();
+  });
+
+  it('disables "Update Quote" while isLoading=true', () => {
+    render(
+      <SwapButton
+        state="stale_quote"
+        onSwap={() => {}}
+        onUpdateQuote={() => {}}
+        isLoading
+      />,
+    );
+
+    expect(screen.getByRole('button', { name: /update quote/i })).toBeDisabled();
+  });
+
+  it('calls onUpdateQuote when the button is clicked', () => {
+    const onUpdateQuote = vi.fn();
+    render(
+      <SwapButton
+        state="stale_quote"
+        onSwap={() => {}}
+        onUpdateQuote={onUpdateQuote}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: /update quote/i }));
+    expect(onUpdateQuote).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT render a "Review Swap" / Confirm button in stale_quote state', () => {
+    render(
+      <SwapButton
+        state="stale_quote"
+        onSwap={() => {}}
+        onUpdateQuote={() => {}}
+      />,
+    );
+
+    expect(screen.queryByRole('button', { name: /review swap/i })).toBeNull();
+    expect(screen.queryByRole('button', { name: /confirm/i })).toBeNull();
+  });
+
+  it('does NOT call onSwap when in stale_quote state', () => {
+    const onSwap = vi.fn();
+    render(
+      <SwapButton
+        state="stale_quote"
+        onSwap={onSwap}
+        onUpdateQuote={() => {}}
+      />,
+    );
+
+    // Click the Update Quote button — onSwap should never fire
+    fireEvent.click(screen.getByRole('button', { name: /update quote/i }));
+    expect(onSwap).not.toHaveBeenCalled();
+  });
+});

--- a/frontend/hooks/useStaleQuote.ts
+++ b/frontend/hooks/useStaleQuote.ts
@@ -1,0 +1,97 @@
+'use client';
+
+import { useEffect, useRef, useState } from 'react';
+
+export const STALE_QUOTE_PRICE_IMPACT_THRESHOLD_PCT = 0.5;
+
+export interface UseStaleQuoteOptions {
+  /**
+   * Unix timestamp (ms) when the current quote expires, as provided by the
+   * server `expires_at` field.  When present this is the authoritative source
+   * of expiry; when absent the caller's `isStale` flag is used instead.
+   */
+  expiresAtMs?: number;
+  /**
+   * Most-recent price-impact percentage (e.g. 1.23 for 1.23 %).
+   * Tracked against the value that was recorded at the last fetch; when the
+   * absolute difference exceeds {@link STALE_QUOTE_PRICE_IMPACT_THRESHOLD_PCT}
+   * the quote is considered stale regardless of its expiry timestamp.
+   */
+  currentPriceImpact: number;
+  /**
+   * Falls back to this when `expiresAtMs` is not provided.
+   * This is the value emitted by `useQuoteRefresh` / `useQuote`.
+   */
+  isStale: boolean;
+  /** Signals that a successful fresh quote has just been received. */
+  lastQuotedAtMs: number | null;
+}
+
+export interface UseStaleQuoteResult {
+  /** True when the quote is expired OR price impact moved > threshold. */
+  isQuoteStale: boolean;
+  /** True specifically because `now >= expires_at`. */
+  isExpired: boolean;
+  /** True specifically because price impact changed > 0.5 % since last fetch. */
+  isPriceImpactChanged: boolean;
+  /** The baseline price-impact recorded at the last successful fetch. */
+  baselinePriceImpact: number | null;
+}
+
+/**
+ * Determines whether the swap Confirm button should be disabled due to a
+ * stale quote condition:
+ *
+ *  - The server-provided `expires_at` has been exceeded (authoritative), OR
+ *  - The polling-derived `isStale` flag is true (fallback), OR
+ *  - The price impact has shifted by more than 0.5 % since the last fetch.
+ *
+ * Resets the baseline whenever `lastQuotedAtMs` advances (i.e. a fresh quote
+ * was received).
+ */
+export function useStaleQuote({
+  expiresAtMs,
+  currentPriceImpact,
+  isStale,
+  lastQuotedAtMs,
+}: UseStaleQuoteOptions): UseStaleQuoteResult {
+  const [nowMs, setNowMs] = useState(() => Date.now());
+  const [baselinePriceImpact, setBaselinePriceImpact] = useState<number | null>(null);
+
+  // Tick every second to re-evaluate expiry.
+  useEffect(() => {
+    const id = setInterval(() => setNowMs(Date.now()), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Track the previous lastQuotedAtMs so we can detect when it advances.
+  const prevLastQuotedAtMsRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (
+      lastQuotedAtMs !== null &&
+      lastQuotedAtMs !== prevLastQuotedAtMsRef.current
+    ) {
+      // Fresh quote arrived — record the new baseline.
+      setBaselinePriceImpact(currentPriceImpact);
+      prevLastQuotedAtMsRef.current = lastQuotedAtMs;
+    }
+  }, [lastQuotedAtMs, currentPriceImpact]);
+
+  const isExpired =
+    expiresAtMs != null ? nowMs >= expiresAtMs : isStale;
+
+  const isPriceImpactChanged =
+    baselinePriceImpact !== null &&
+    Math.abs(currentPriceImpact - baselinePriceImpact) >
+      STALE_QUOTE_PRICE_IMPACT_THRESHOLD_PCT;
+
+  const isQuoteStale = isExpired || isPriceImpactChanged;
+
+  return {
+    isQuoteStale,
+    isExpired,
+    isPriceImpactChanged,
+    baselinePriceImpact,
+  };
+}

--- a/frontend/lib/swap-i18n.ts
+++ b/frontend/lib/swap-i18n.ts
@@ -91,6 +91,8 @@ export type SwapTranslationKey =
   | "swap.cta.swapAnyway"
   | "swap.cta.swapping"
   | "swap.cta.errorFetchingQuote"
+  | "swap.cta.updateQuote"
+  | "swap.cta.quoteExpired"
   | "swap.card.refreshQuote"
   | "swap.card.diagnostics"
   | "swap.card.outdated"
@@ -334,6 +336,8 @@ const SWAP_TRANSLATIONS_BASE: Record<
     "swap.cta.swapAnyway": "Swap Anyway",
     "swap.cta.swapping": "Swapping...",
     "swap.cta.errorFetchingQuote": "Error fetching quote",
+    "swap.cta.updateQuote": "Update Quote",
+    "swap.cta.quoteExpired": "Quote expired — update to continue",
     "swap.card.refreshQuote": "Refresh quote",
     "swap.card.diagnostics": "View quote diagnostics",
     "swap.card.outdated": "Quote outdated — refresh for latest price",
@@ -572,6 +576,8 @@ const SWAP_TRANSLATIONS_BASE: Record<
     "swap.cta.swapAnyway": "Intercambiar de todos modos",
     "swap.cta.swapping": "Intercambiando...",
     "swap.cta.errorFetchingQuote": "Error al obtener cotización",
+    "swap.cta.updateQuote": "Actualizar cotización",
+    "swap.cta.quoteExpired": "Cotización expirada — actualice para continuar",
     "swap.card.refreshQuote": "Actualizar cotización",
     "swap.card.diagnostics": "View quote diagnostics",
     "swap.card.outdated": "Cotización desactualizada — actualiza para obtener el precio más reciente",
@@ -813,6 +819,8 @@ const SWAP_TRANSLATIONS_BASE: Record<
     "swap.cta.swapAnyway": "仍要兑换",
     "swap.cta.swapping": "兑换中...",
     "swap.cta.errorFetchingQuote": "获取报价失败",
+    "swap.cta.updateQuote": "更新报价",
+    "swap.cta.quoteExpired": "报价已过期 — 请更新以继续",
     "swap.card.refreshQuote": "刷新报价",
     "swap.card.diagnostics": "查看报价诊断信息",
     "swap.card.outdated": "报价已过期——请刷新获取最新价格",


### PR DESCRIPTION
## Summary

Implements the stale-quote enforcement spec from `docs/swap-e2e-flow.md` (Issue #1000).

### What was changed

| File | Change |
|------|--------|
| `frontend/hooks/useStaleQuote.ts` | New hook: tracks quote expiry (`expires_at`) and >0.5 % price-impact change since last fetch |
| `frontend/components/swap/SwapButton.tsx` | Added `'stale_quote'` to `SwapButtonState`; renders amber-styled **Update Quote** CTA that calls `onUpdateQuote` |
| `frontend/components/swap/SwapCard.tsx` | Wires `useStaleQuote`, fixes `buttonState` (was returning `'error'` for stale quotes), passes `onUpdateQuote={quote.refresh}`, renders `StaleQuoteBanner` |
| `frontend/lib/swap-i18n.ts` | Added `swap.cta.updateQuote` and `swap.cta.quoteExpired` keys (en-US, es-ES, zh-CN; de-DE/fr-FR/ja-JP inherit) |
| `frontend/components/swap/stale-quote.test.tsx` | 11 new tests |

### Acceptance criteria

- [x] **Confirm disabled when expired/stale** — `buttonState` becomes `'stale_quote'` (button disabled) when `now >= expires_at` OR price impact changes > 0.5 %
- [x] **Update Quote CTA restores enablement** — clicking **Update Quote** calls `quote.refresh()`; once a fresh quote arrives the hook resets its baseline and `buttonState` returns to `'ready'`
- [x] **Tests for expiry and >0.5% impact change** — 6 hook tests + 5 SwapButton interaction tests, all passing

### Testing

```
npm --prefix frontend run test -- stale-quote
# → 11 passed

npm --prefix frontend run test
# → 933 passed (123 files)

npm --prefix frontend run lint
# → 0 errors, 88 pre-existing warnings
```

Closes #1000