### PR TITLE
Adds Prometheus metrics, SLO definitions, and alerting rules for the swap prepare/submit two-phase flow

### DIFF
--- a/config/slo.yaml
+++ b/config/slo.yaml
@@ -99,6 +99,36 @@ slos:
     target_threshold_value: 0       # must be >= 0 (not critical)
     compliance_target: 0.995
 
+  # SLO 7: Swap Prepare Success Rate > 99%
+  - name: swap_prepare_success_rate
+    description: "Swap prepare request success rate stays above 99% over a 5-minute window"
+    metric: stellarroute_swap_prepare_total
+    type: error_rate
+    window: 5m
+    target_threshold_ratio: 0.01
+    compliance_target: 0.999
+    error_label_values: ["error"]   # outcome="error"
+    ok_label_values: ["success"]    # outcome="success"
+    burn_rate:
+      warning: 2.0
+      critical: 4.0
+      window: 30m
+
+  # SLO 8: Swap Submit Success Rate > 99%
+  - name: swap_submit_success_rate
+    description: "Swap submit request success rate stays above 99% over a 5-minute window"
+    metric: stellarroute_swap_submit_total
+    type: error_rate
+    window: 5m
+    target_threshold_ratio: 0.01
+    compliance_target: 0.999
+    error_label_values: ["error"]   # outcome="error"
+    ok_label_values: ["success"]    # outcome="success"
+    burn_rate:
+      warning: 2.0
+      critical: 4.0
+      window: 30m
+
 # ── Synthetic probe definitions ──────────────────────────────────────────────
 # Probes that can be run from CI or synthetic monitoring systems.
 # The slo-probe binary reads these definitions to execute health checks.

--- a/crates/api/src/metrics.rs
+++ b/crates/api/src/metrics.rs
@@ -457,6 +457,131 @@ pub fn record_webhook_poll_cycle_duration(duration: Duration) {
         .observe(duration.as_secs_f64());
 }
 
+// ── Swap prepare/submit metrics ─────────────────────────────────────────────
+
+lazy_static! {
+    /// Swap prepare request counter.
+    ///
+    /// Labels:
+    /// - `outcome`: "success" or "error"
+    /// - `error_class`: machine-readable error category (or "none" on success)
+    ///
+    /// Error classes:
+    /// - `none`                 — successful prepare
+    /// - `validation`           — request validation failed
+    /// - `quote_expired`        — the referenced quote is stale/expired
+    /// - `quote_not_found`      — referenced quote_id does not exist
+    /// - `simulation_failed`    — Soroban simulation failed
+    /// - `build_failed`         — transaction build failed
+    /// - `timeout`              — upstream Soroban/Horizon timeout
+    /// - `rpc_error`            — generic Soroban RPC error
+    /// - `internal`             — internal/unexpected error
+    pub static ref SWAP_PREPARE_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "stellarroute_swap_prepare_total",
+        "Total number of swap prepare requests",
+        &["outcome", "error_class"]
+    )
+    .expect("Can't create SWAP_PREPARE_REQUESTS counter");
+
+    /// Swap prepare latency histogram.
+    ///
+    /// Label: `outcome` ("success" or "error")
+    pub static ref SWAP_PREPARE_LATENCY: HistogramVec = register_histogram_vec!(
+        "stellarroute_swap_prepare_duration_seconds",
+        "Swap prepare request duration in seconds",
+        &["outcome"],
+        vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+    )
+    .expect("Can't create SWAP_PREPARE_LATENCY histogram");
+
+    /// Swap submit request counter.
+    ///
+    /// Labels:
+    /// - `outcome`: "success" or "error"
+    /// - `error_class`: machine-readable error category (or "none" on success)
+    ///
+    /// Error classes:
+    /// - `none`                 — successful submission
+    /// - `validation`           — request validation failed
+    /// - `duplicate_quote`      — quote_id already submitted (idempotency violation)
+    /// - `bad_signature`        — supplied signature is invalid
+    /// - `insufficient_fee`     — transaction fee too low
+    /// - `insufficient_balance` — source account lacks funds
+    /// - `slippage_exceeded`    — on-chain execution exceeded slippage
+    /// - `timeout`              — upstream Soroban/Horizon timeout
+    /// - `rpc_error`            — generic RPC error
+    /// - `internal`             — internal/unexpected error
+    pub static ref SWAP_SUBMIT_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "stellarroute_swap_submit_total",
+        "Total number of swap submit requests",
+        &["outcome", "error_class"]
+    )
+    .expect("Can't create SWAP_SUBMIT_REQUESTS counter");
+
+    /// Swap submit latency histogram.
+    ///
+    /// Label: `outcome` ("success" or "error")
+    pub static ref SWAP_SUBMIT_LATENCY: HistogramVec = register_histogram_vec!(
+        "stellarroute_swap_submit_duration_seconds",
+        "Swap submit request duration in seconds",
+        &["outcome"],
+        vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+    )
+    .expect("Can't create SWAP_SUBMIT_LATENCY histogram");
+
+    /// Number of swap requests currently in flight.
+    ///
+    /// Label: `phase` ("prepare" or "submit")
+    pub static ref SWAP_INFLIGHT: IntGaugeVec = register_int_gauge_vec!(
+        "stellarroute_swap_inflight",
+        "Current number of in-flight swap requests by phase",
+        &["phase"]
+    )
+    .expect("Can't create SWAP_INFLIGHT gauge");
+}
+
+/// Record a swap prepare outcome.
+///
+/// `error_class` should be `"none"` for success; any other value maps to
+/// `outcome="error"` and the literal class is preserved as a label.
+pub fn record_swap_prepare(duration: Duration, error_class: &str) {
+    let outcome_label = if error_class == "none" { "success" } else { "error" };
+
+    SWAP_PREPARE_LATENCY
+        .with_label_values(&[outcome_label])
+        .observe(duration.as_secs_f64());
+
+    SWAP_PREPARE_REQUESTS
+        .with_label_values(&[outcome_label, error_class])
+        .inc();
+}
+
+/// Record a swap submit outcome.
+///
+/// `error_class` should be `"none"` for success; any other value maps to
+/// `outcome="error"` and the literal class is preserved as a label.
+pub fn record_swap_submit(duration: Duration, error_class: &str) {
+    let outcome_label = if error_class == "none" { "success" } else { "error" };
+
+    SWAP_SUBMIT_LATENCY
+        .with_label_values(&[outcome_label])
+        .observe(duration.as_secs_f64());
+
+    SWAP_SUBMIT_REQUESTS
+        .with_label_values(&[outcome_label, error_class])
+        .inc();
+}
+
+/// Increment the in-flight swap gauge for a phase.
+pub fn swap_inflight_inc(phase: &str) {
+    SWAP_INFLIGHT.with_label_values(&[phase]).inc();
+}
+
+/// Decrement the in-flight swap gauge for a phase.
+pub fn swap_inflight_dec(phase: &str) {
+    SWAP_INFLIGHT.with_label_values(&[phase]).dec();
+}
+
 /// Get cache hit ratio for a given cache type
 pub fn get_cache_hit_ratio(cache_type: &str) -> f64 {
     let hits = CACHE_HITS.with_label_values(&[cache_type]).get() as f64;

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -46,6 +46,37 @@ StellarRoute exposes Prometheus metrics for monitoring system performance and he
   - `cache_hit`: "true" or "false"
 - **Description**: Total number of quote requests
 
+### Swap Prepare / Submit
+
+- **Metrics**:
+  - `stellarroute_swap_prepare_total` (counter)
+  - `stellarroute_swap_submit_total` (counter)
+  - `stellarroute_swap_prepare_duration_seconds` (histogram)
+  - `stellarroute_swap_submit_duration_seconds` (histogram)
+  - `stellarroute_swap_inflight` (gauge)
+- **Labels**:
+  - `outcome`: "success" or "error"
+  - `error_class`: machine-readable error category (e.g. `none`, `validation`, `simulation_failed`, `bad_signature`, `timeout`, `rpc_error`, `internal`)
+  - `phase`: "prepare" or "submit" (on the `stellarroute_swap_inflight` gauge)
+- **Description**: Outcomes, latency, and concurrency of the two-phase swap flow (`POST /swap/prepare` and `POST /swap/submit`).
+
+| Error Class | Phase | Meaning |
+|-------------|-------|---------|
+| `none` | both | Request succeeded |
+| `validation` | both | Request validation failed |
+| `quote_expired` | prepare | Referenced quote is stale/expired |
+| `quote_not_found` | prepare | Referenced `quote_id` does not exist |
+| `simulation_failed` | prepare | Soroban simulation failed |
+| `build_failed` | prepare | Transaction build failed |
+| `duplicate_quote` | submit | `quote_id` was already submitted |
+| `bad_signature` | submit | Supplied signature is invalid |
+| `insufficient_fee` | submit | Transaction fee too low |
+| `insufficient_balance` | submit | Source account lacks funds |
+| `slippage_exceeded` | submit | On-chain execution exceeded slippage |
+| `timeout` | both | Upstream Soroban/Horizon timeout |
+| `rpc_error` | both | Generic RPC error |
+| `internal` | both | Internal/unexpected error |
+
 ### Indexer Lag
 
 See [indexer-lag-monitoring.md](indexer-lag-monitoring.md) for full documentation of indexer lag metrics (`stellarroute_indexer_lag_ledgers`, `stellarroute_indexer_lag_seconds`, `stellarroute_indexer_sync_status`, etc.).
@@ -81,6 +112,8 @@ SLO definitions are maintained as code in [`config/slo.yaml`](../config/slo.yaml
 | Route Compute P95 | < 1s | 5m | 99.0% | 2x over 30m | 4x over 30m |
 | Cache Hit Ratio | > 70% | 10m | 99.0% | 2x over 30m | 4x over 30m |
 | Indexer Sync Health | >= 0 | 5m | 99.5% | — | — |
+| Swap Prepare Success Rate | > 99% | 5m | 99.9% | 2x over 30m | 4x over 30m |
+| Swap Submit Success Rate | > 99% | 5m | 99.9% | 2x over 30m | 4x over 30m |
 
 ### Burn-Rate Alerting Strategy
 
@@ -108,6 +141,10 @@ Alerting rules are defined in [`monitoring/prometheus/slo-alerts.yml`](../monito
 | `SLORouteComputeP95LatencyBurnWarning` | warning | P95 > 1s (1m & 30m windows) | 1m |
 | `SLOCacheHitRatioBurnWarning` | warning | hit ratio < 70% (1m & 10m windows) | 2m |
 | `SLOIndexerSyncCritical` | critical | sync_status < 0 | 2m |
+| `SLOSwapPrepareFailureRateBurnWarning` | warning | prepare failure rate > 1% (1m & 30m windows) | 1m |
+| `SLOSwapPrepareFailureRateBurnCritical` | critical | prepare failure rate > 1% (5m & 30m windows) | 1m |
+| `SLOSwapSubmitFailureRateBurnWarning` | warning | submit failure rate > 1% (1m & 30m windows) | 1m |
+| `SLOSwapSubmitFailureRateBurnCritical` | critical | submit failure rate > 1% (5m & 30m windows) | 1m |
 
 ### Direct Threshold Alerts (`stellarroute_direct_alerts`)
 
@@ -115,6 +152,8 @@ Alerting rules are defined in [`monitoring/prometheus/slo-alerts.yml`](../monito
 |-------|----------|-----------|-----|
 | `HighQuoteLatency` | warning | P95 > 1s over 5m | 5m |
 | `LowCacheHitRatio` | warning | hit ratio < 50% over 5m | 10m |
+| `HighSwapPrepareFailureRate` | warning | prepare failure rate > 5% over 5m | 5m |
+| `HighSwapSubmitFailureRate` | warning | submit failure rate > 5% over 5m | 5m |
 
 ## Synthetic Probes
 
@@ -183,6 +222,21 @@ rate(stellarroute_cache_hits_total[5m]) / (rate(stellarroute_cache_hits_total[5m
 **Quote Error Rate:**
 ```promql
 rate(stellarroute_quote_requests_total{outcome="error"}[5m]) / rate(stellarroute_quote_requests_total[5m])
+```
+
+**Swap Prepare Failure Rate:**
+```promql
+rate(stellarroute_swap_prepare_total{outcome="error"}[5m]) / rate(stellarroute_swap_prepare_total[5m])
+```
+
+**Swap Submit Failure Rate:**
+```promql
+rate(stellarroute_swap_submit_total{outcome="error"}[5m]) / rate(stellarroute_swap_submit_total[5m])
+```
+
+**Swap Failure Rate by Error Class:**
+```promql
+sum by (error_class) (rate(stellarroute_swap_prepare_total{outcome="error"}[5m]))
 ```
 
 ## Alerting

--- a/monitoring/prometheus/slo-alerts.yml
+++ b/monitoring/prometheus/slo-alerts.yml
@@ -13,6 +13,8 @@
 #   - Quote error rate   < 1%
 #   - Route compute P95  < 1s
 #   - Cache hit ratio    > 70%
+#   - Swap prepare success rate > 99%
+#   - Swap submit success rate  > 99%
 
 groups:
   - name: stellarroute_slo_alerts
@@ -238,6 +240,124 @@ groups:
             Indexer sync status for {{ $labels.source }} is critical (value={{ $value }}).
             Data freshness guarantees are compromised.
 
+      # ── Swap Prepare Success Rate SLO (> 99%) ─────────────────────────────
+      - alert: SLOSwapPrepareFailureRateBurnWarning
+        expr: |
+          (
+            (
+              rate(stellarroute_swap_prepare_total{outcome="error"}[1m])
+              /
+              rate(stellarroute_swap_prepare_total[1m])
+            )
+            > 0.01
+          )
+          and
+          (
+            (
+              rate(stellarroute_swap_prepare_total{outcome="error"}[30m])
+              /
+              rate(stellarroute_swap_prepare_total[30m])
+            )
+            > 0.01
+          )
+        for: 1m
+        labels:
+          severity: warning
+          slo: swap_prepare_success_rate
+        annotations:
+          summary: "SLO burn rate warning: Swap prepare failure rate exceeded 1%"
+          description: >
+            Swap prepare failure rate is {{ $value | humanizePercentage }} over the last 30m.
+            This exceeds the 1% SLO target.
+
+      - alert: SLOSwapPrepareFailureRateBurnCritical
+        expr: |
+          (
+            (
+              rate(stellarroute_swap_prepare_total{outcome="error"}[5m])
+              /
+              rate(stellarroute_swap_prepare_total[5m])
+            )
+            > 0.01
+          )
+          and
+          (
+            (
+              rate(stellarroute_swap_prepare_total{outcome="error"}[30m])
+              /
+              rate(stellarroute_swap_prepare_total[30m])
+            )
+            > 0.01
+          )
+        for: 1m
+        labels:
+          severity: critical
+          slo: swap_prepare_success_rate
+        annotations:
+          summary: "SLO burn rate critical: Swap prepare failure rate exceeded 1%"
+          description: >
+            Swap prepare failure rate is {{ $value | humanizePercentage }} over the last 30m.
+            Error budget is being depleted rapidly. Immediate investigation required.
+
+      # ── Swap Submit Success Rate SLO (> 99%) ──────────────────────────────
+      - alert: SLOSwapSubmitFailureRateBurnWarning
+        expr: |
+          (
+            (
+              rate(stellarroute_swap_submit_total{outcome="error"}[1m])
+              /
+              rate(stellarroute_swap_submit_total[1m])
+            )
+            > 0.01
+          )
+          and
+          (
+            (
+              rate(stellarroute_swap_submit_total{outcome="error"}[30m])
+              /
+              rate(stellarroute_swap_submit_total[30m])
+            )
+            > 0.01
+          )
+        for: 1m
+        labels:
+          severity: warning
+          slo: swap_submit_success_rate
+        annotations:
+          summary: "SLO burn rate warning: Swap submit failure rate exceeded 1%"
+          description: >
+            Swap submit failure rate is {{ $value | humanizePercentage }} over the last 30m.
+            This exceeds the 1% SLO target.
+
+      - alert: SLOSwapSubmitFailureRateBurnCritical
+        expr: |
+          (
+            (
+              rate(stellarroute_swap_submit_total{outcome="error"}[5m])
+              /
+              rate(stellarroute_swap_submit_total[5m])
+            )
+            > 0.01
+          )
+          and
+          (
+            (
+              rate(stellarroute_swap_submit_total{outcome="error"}[30m])
+              /
+              rate(stellarroute_swap_submit_total[30m])
+            )
+            > 0.01
+          )
+        for: 1m
+        labels:
+          severity: critical
+          slo: swap_submit_success_rate
+        annotations:
+          summary: "SLO burn rate critical: Swap submit failure rate exceeded 1%"
+          description: >
+            Swap submit failure rate is {{ $value | humanizePercentage }} over the last 30m.
+            Error budget is being depleted rapidly. Immediate investigation required.
+
   # ── Direct threshold alerts (non-SLO) ───────────────────────────────────
   - name: stellarroute_direct_alerts
     interval: 30s
@@ -259,3 +379,21 @@ groups:
         annotations:
           summary: "Cache hit ratio is low"
           description: "Cache hit ratio dropped below 50%"
+
+      - alert: HighSwapPrepareFailureRate
+        expr: rate(stellarroute_swap_prepare_total{outcome="error"}[5m]) / rate(stellarroute_swap_prepare_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Swap prepare failure rate is high"
+          description: "Swap prepare failure rate is {{ $value | humanizePercentage }} over the last 5m"
+
+      - alert: HighSwapSubmitFailureRate
+        expr: rate(stellarroute_swap_submit_total{outcome="error"}[5m]) / rate(stellarroute_swap_submit_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Swap submit failure rate is high"
+          description: "Swap submit failure rate is {{ $value | humanizePercentage }} over the last 5m"


### PR DESCRIPTION
## Summary

Adds Prometheus metrics, SLO definitions, and alerting rules for the swap prepare/submit two-phase flow, satisfying the M5 Ops requirement to track success/failure rates with error-class labels.

## What changed

- `crates/api/src/metrics.rs`
  - New metrics:
    - `stellarroute_swap_prepare_total` (counter, labels: `outcome`, `error_class`)
    - `stellarroute_swap_submit_total` (counter, labels: `outcome`, `error_class`)
    - `stellarroute_swap_prepare_duration_seconds` (histogram, label: `outcome`)
    - `stellarroute_swap_submit_duration_seconds` (histogram, label: `outcome`)
    - `stellarroute_swap_inflight` (gauge, label: `phase`)
  - Typed helper functions:
    - `record_swap_prepare(duration, error_class)`
    - `record_swap_submit(duration, error_class)`
    - `swap_inflight_inc(phase)` / `swap_inflight_dec(phase)`
  - Error class `"none"` maps to `outcome="success"`; all other classes map to `outcome="error"` while preserving the class label.

- `monitoring/prometheus/slo-alerts.yml`
  - SLO burn-rate alerts (warning/critical) for prepare and submit failure rates exceeding 1%.
  - Direct failure-rate-spike alerts for short-term breaches > 5%.

- `config/slo.yaml`
  - New SLOs: `swap_prepare_success_rate` and `swap_submit_success_rate` (target > 99%).

- `docs/monitoring.md`
  - Documented all new metrics, the error-class taxonomy, new SLO rows, alert rule entries, and PromQL examples.

## Out of scope

This PR intentionally does not implement the swap route handlers (`POST /swap/prepare`, `POST /swap/submit`). The metrics infrastructure is now in place so the future swap implementation can record outcomes by calling the helpers added here.

## Acceptance criteria

- [x] Prometheus metrics for prepare/submit outcomes
- [x] Labels for error class
- [x] Alert on failure rate spike

Closes #1017
