### PR TITLE
[backend] Swap submit audit log with retention and account redaction (#1018)

### DIFF
--- a/config/slo.yaml
+++ b/config/slo.yaml
@@ -99,6 +99,36 @@ slos:
     target_threshold_value: 0       # must be >= 0 (not critical)
     compliance_target: 0.995
 
+  # SLO 7: Swap Prepare Success Rate > 99%
+  - name: swap_prepare_success_rate
+    description: "Swap prepare request success rate stays above 99% over a 5-minute window"
+    metric: stellarroute_swap_prepare_total
+    type: error_rate
+    window: 5m
+    target_threshold_ratio: 0.01
+    compliance_target: 0.999
+    error_label_values: ["error"]   # outcome="error"
+    ok_label_values: ["success"]    # outcome="success"
+    burn_rate:
+      warning: 2.0
+      critical: 4.0
+      window: 30m
+
+  # SLO 8: Swap Submit Success Rate > 99%
+  - name: swap_submit_success_rate
+    description: "Swap submit request success rate stays above 99% over a 5-minute window"
+    metric: stellarroute_swap_submit_total
+    type: error_rate
+    window: 5m
+    target_threshold_ratio: 0.01
+    compliance_target: 0.999
+    error_label_values: ["error"]   # outcome="error"
+    ok_label_values: ["success"]    # outcome="success"
+    burn_rate:
+      warning: 2.0
+      critical: 4.0
+      window: 30m
+
 # ── Synthetic probe definitions ──────────────────────────────────────────────
 # Probes that can be run from CI or synthetic monitoring systems.
 # The slo-probe binary reads these definitions to execute health checks.

--- a/crates/api/migrations/0012_swap_submit_audit_log.sql
+++ b/crates/api/migrations/0012_swap_submit_audit_log.sql
@@ -1,0 +1,221 @@
+-- Swap submit audit log
+--
+-- Stores a structured, privacy-safe record of every swap prepare/submit
+-- attempt.  Sensitive account information is redacted by the application
+-- before insertion; the raw public key or secret is never written here.
+--
+-- ── Schema notes ─────────────────────────────────────────────────────────────
+--
+-- • `quote_id`    – client-provided quote identifier; used for idempotency
+--                    lookups and correlating prepare/submit pairs.
+-- • `tx_hash`     – on-chain transaction hash, available once a submit has
+--                    reached the network (NULL on prepare / failure).
+-- • `account`     – redacted account identifier; stored as a hash-prefix
+--                    fingerprint, never the raw public key.
+-- • `request_id`  – correlates with the HTTP `x-request-id` header.
+-- • `trace_id`    – W3C traceparent trace ID (hex, 32 chars); empty string
+--                    when no distributed trace is active.
+-- • `outcome`     – one of: 'prepared', 'submitted', 'failed'.
+-- • `error_class` – machine-readable failure class (empty string on success).
+-- • `metadata`    – JSONB extensibility bucket for route, amount, fee, etc.
+--
+-- ── Retention policy ─────────────────────────────────────────────────────────
+--
+-- Default retention: 30 days.
+-- Entries older than `retained_until` are eligible for pruning.
+-- The `prune_swap_submit_audit_log_older_than` function (below) should be
+-- called by the application purger or a scheduled job (e.g. pg_cron).
+--
+-- For high-throughput deployments the same tuning options as
+-- `route_audit_log` apply; see docs/audit-log-retention.md.
+
+CREATE TABLE IF NOT EXISTS swap_submit_audit_log (
+    id              BIGSERIAL   PRIMARY KEY,
+
+    -- Business correlation
+    quote_id        TEXT        NOT NULL,
+    tx_hash         TEXT,                       -- NULL until submitted / on failure
+    account         TEXT        NOT NULL,       -- redacted hash-prefix; never raw key
+
+    -- Request correlation
+    request_id      TEXT        NOT NULL,
+    trace_id        TEXT        NOT NULL DEFAULT '',
+
+    -- Timing
+    logged_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    latency_ms      INTEGER     NOT NULL DEFAULT 0,
+
+    -- Outcome
+    outcome         TEXT        NOT NULL
+                    CHECK (outcome IN ('prepared', 'submitted', 'failed')),
+    error_class     TEXT        NOT NULL DEFAULT '',
+
+    -- Extensibility
+    metadata        JSONB       NOT NULL DEFAULT '{}'::jsonb,
+
+    -- Retention
+    retained_until  TIMESTAMPTZ NOT NULL
+                    GENERATED ALWAYS AS (logged_at + INTERVAL '30 days') STORED
+);
+
+-- ── Indexes ───────────────────────────────────────────────────────────────────
+
+-- Primary idempotency/correlation lookup by quote_id
+CREATE INDEX IF NOT EXISTS idx_swap_submit_audit_quote_id
+    ON swap_submit_audit_log(quote_id);
+
+-- Transaction correlation (only when tx_hash is set)
+CREATE INDEX IF NOT EXISTS idx_swap_submit_audit_tx_hash
+    ON swap_submit_audit_log(tx_hash)
+    WHERE tx_hash IS NOT NULL;
+
+-- Time-range queries
+CREATE INDEX IF NOT EXISTS idx_swap_submit_audit_logged_at
+    ON swap_submit_audit_log(logged_at DESC);
+
+-- Retention pruning (partial index — only rows eligible for deletion)
+CREATE INDEX IF NOT EXISTS idx_swap_submit_audit_retention
+    ON swap_submit_audit_log(retained_until)
+    WHERE retained_until <= NOW();
+
+-- Outcome-based filtering (e.g. "show me all failed submits in the last hour")
+CREATE INDEX IF NOT EXISTS idx_swap_submit_audit_outcome_time
+    ON swap_submit_audit_log(outcome, logged_at DESC);
+
+-- ── Comments ──────────────────────────────────────────────────────────────────
+
+COMMENT ON TABLE swap_submit_audit_log IS
+    'Privacy-safe structured audit log for swap prepare/submit attempts. '
+    'Account identifiers are redacted to a hash-prefix fingerprint before insertion. '
+    'Default retention: 30 days. See docs/audit-log-retention.md for tuning guidance.';
+
+COMMENT ON COLUMN swap_submit_audit_log.quote_id IS
+    'Client-provided quote identifier; ties prepare and submit attempts together.';
+COMMENT ON COLUMN swap_submit_audit_log.tx_hash IS
+    'On-chain transaction hash. NULL for prepare records or failed submissions.';
+COMMENT ON COLUMN swap_submit_audit_log.account IS
+    'Redacted account fingerprint (prefix + hash). The raw public key is never stored.';
+COMMENT ON COLUMN swap_submit_audit_log.outcome IS
+    'prepared | submitted | failed';
+COMMENT ON COLUMN swap_submit_audit_log.error_class IS
+    'Machine-readable failure class when outcome = failed; empty otherwise.';
+COMMENT ON COLUMN swap_submit_audit_log.metadata IS
+    'Extensible JSONB payload for route, amount, fee estimate, etc.';
+COMMENT ON COLUMN swap_submit_audit_log.retained_until IS
+    'Computed retention deadline (logged_at + 30 days). Rows past this date are prunable.';
+
+-- ── Purge function ────────────────────────────────────────────────────────────
+--
+-- Mirrors purge_route_audit_log_older_than (0005_quote_purger.sql) but targets
+-- swap_submit_audit_log.
+
+CREATE OR REPLACE FUNCTION purge_swap_submit_audit_log_older_than(
+    p_retention_days     INTEGER DEFAULT 30,
+    p_batch_size         INTEGER DEFAULT 5000,
+    p_max_iterations     INTEGER DEFAULT 100
+)
+RETURNS TABLE (
+    deleted_count       BIGINT,
+    total_scanned       BIGINT,
+    rows_retained       BIGINT,
+    age_min_days        NUMERIC,
+    age_max_days        NUMERIC,
+    age_p50_days        NUMERIC,
+    age_p95_days        NUMERIC,
+    age_p99_days        NUMERIC,
+    was_rate_limited    BOOLEAN,
+    duration_ms         INTEGER
+) AS $$
+DECLARE
+    v_total_deleted     BIGINT := 0;
+    v_total_scanned     BIGINT := 0;
+    v_iteration         INTEGER := 0;
+    v_batch_deleted     BIGINT;
+    v_start_time        TIMESTAMPTZ := NOW();
+    v_age_min           NUMERIC;
+    v_age_max           NUMERIC;
+    v_age_p50           NUMERIC;
+    v_age_p95           NUMERIC;
+    v_age_p99           NUMERIC;
+    v_rows_retained     BIGINT;
+    v_was_rate_limited  BOOLEAN := FALSE;
+BEGIN
+    -- Calculate age distribution BEFORE deletion
+    SELECT
+        ROUND(MIN(EXTRACT(EPOCH FROM (NOW() - logged_at)) / 86400), 2),
+        ROUND(MAX(EXTRACT(EPOCH FROM (NOW() - logged_at)) / 86400), 2),
+        ROUND(PERCENTILE_CONT(0.50) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (NOW() - logged_at)) / 86400), 2),
+        ROUND(PERCENTILE_CONT(0.95) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (NOW() - logged_at)) / 86400), 2),
+        ROUND(PERCENTILE_CONT(0.99) WITHIN GROUP (ORDER BY EXTRACT(EPOCH FROM (NOW() - logged_at)) / 86400), 2)
+    INTO v_age_min, v_age_max, v_age_p50, v_age_p95, v_age_p99
+    FROM swap_submit_audit_log
+    WHERE retained_until <= NOW();
+
+    -- Batch deletion loop with iteration limit
+    LOOP
+        v_iteration := v_iteration + 1;
+
+        IF v_iteration > p_max_iterations THEN
+            v_was_rate_limited := TRUE;
+            EXIT;
+        END IF;
+
+        DELETE FROM swap_submit_audit_log
+        WHERE id IN (
+            SELECT id FROM swap_submit_audit_log
+            WHERE retained_until <= NOW()
+            ORDER BY id
+            LIMIT p_batch_size
+        );
+
+        GET DIAGNOSTICS v_batch_deleted = ROW_COUNT;
+        v_total_deleted := v_total_deleted + v_batch_deleted;
+        v_total_scanned := v_total_scanned + p_batch_size;
+
+        EXIT WHEN v_batch_deleted = 0;
+
+        IF v_iteration % 10 = 0 THEN
+            PERFORM pg_sleep(0.1);
+        END IF;
+    END LOOP;
+
+    SELECT COUNT(*) INTO v_rows_retained FROM swap_submit_audit_log;
+
+    RETURN QUERY SELECT
+        v_total_deleted,
+        v_total_scanned,
+        v_rows_retained,
+        v_age_min,
+        v_age_max,
+        v_age_p50,
+        v_age_p95,
+        v_age_p99,
+        v_was_rate_limited,
+        CAST(EXTRACT(EPOCH FROM (NOW() - v_start_time)) * 1000 AS INTEGER);
+
+    INSERT INTO quote_purge_metrics (
+        purge_type, deleted_count, scanned_count, duration_ms,
+        age_min_days, age_max_days, age_p50_days, age_p95_days, age_p99_days,
+        rows_retained, batch_size_used, was_rate_limited, status, completed_at
+    ) VALUES (
+        'swap_submit_audit_log',
+        v_total_deleted,
+        v_total_scanned,
+        CAST(EXTRACT(EPOCH FROM (NOW() - v_start_time)) * 1000 AS INTEGER),
+        v_age_min,
+        v_age_max,
+        v_age_p50,
+        v_age_p95,
+        v_age_p99,
+        v_rows_retained,
+        p_batch_size,
+        v_was_rate_limited,
+        CASE WHEN v_was_rate_limited THEN 'partial' ELSE 'success' END,
+        NOW()
+    );
+END;
+$$ LANGUAGE plpgsql;
+
+COMMENT ON FUNCTION purge_swap_submit_audit_log_older_than IS
+    'Batch-deletes swap_submit_audit_log rows past their retention deadline. '
+    'Mirrors purge_route_audit_log_older_than; called by the quote purger.';

--- a/crates/api/src/audit/mod.rs
+++ b/crates/api/src/audit/mod.rs
@@ -1,4 +1,4 @@
-//! Route decision audit log with privacy-safe field redaction.
+//! Route decision and swap submit audit logs with privacy-safe field redaction.
 //!
 //! # Overview
 //!
@@ -7,11 +7,16 @@
 //! reasons, latency, and outcome — while stripping all sensitive fields before
 //! persistence.
 //!
+//! Swap prepare/submit attempts are logged separately via
+//! [`SwapSubmitAuditEntry`]; the account field is redacted to a hash-prefix
+//! fingerprint and the raw public key is never stored.
+//!
 //! # Components
 //!
-//! - [`schema`]   – [`RouteAuditEntry`] data types and PostgreSQL persistence.
+//! - [`schema`]   – [`RouteAuditEntry`] and [`SwapSubmitAuditEntry`] data types.
 //! - [`redactor`] – Privacy-safe field redaction (extends the replay redactor).
-//! - [`writer`]   – Non-blocking fire-and-forget writer for the quote pipeline.
+//! - [`store`]    – PostgreSQL persistence for both audit log tables.
+//! - [`writer`]   – Non-blocking fire-and-forget writers.
 //!
 //! # Correlation
 //!
@@ -22,7 +27,7 @@
 //! # Retention
 //!
 //! Default retention is **30 days**, enforced by the `retained_until` generated
-//! column in the `route_audit_log` table.  See
+//! column in the `route_audit_log` and `swap_submit_audit_log` tables.  See
 //! [`store::AuditStore::prune_older_than`] and `docs/audit-log-retention.md`
 //! for tuning guidance.
 
@@ -34,6 +39,7 @@ pub mod writer;
 pub use redactor::AuditRedactor;
 pub use schema::{
     AuditExclusion, AuditInputs, AuditOutcome, AuditPathStep, AuditSelected, RouteAuditEntry,
+    SwapSubmitAuditEntry, SwapSubmitOutcome,
 };
 pub use store::AuditStore;
 pub use writer::AuditWriter;

--- a/crates/api/src/audit/redactor.rs
+++ b/crates/api/src/audit/redactor.rs
@@ -40,6 +40,35 @@ impl AuditRedactor {
             redact_selected(selected);
         }
     }
+
+    /// Redact a Stellar account public key to a non-reversible fingerprint.
+    ///
+    /// The raw key is never stored.  The result keeps the first 4 and last 4
+    /// characters for operator correlation, separated by `...`, and appends the
+    /// first 8 hex characters of a SHA-256 hash so that identical accounts still
+    /// group together in queries while remaining computationally infeasible to
+    /// reverse.
+    ///
+    /// Examples:
+    /// - `"GABC...LA5#deadbeef"` (typical Stellar address)
+    /// - `"native"` is returned unchanged (used for issuing account sentinel).
+    /// - Short / malformed inputs are fully replaced with `[REDACTED]`.
+    pub fn redact_account(account: &str) -> String {
+        if account == "native" {
+            return account.to_string();
+        }
+
+        // Stellar public keys are 56 characters.  Be defensive with malformed input.
+        if account.len() < 12 {
+            return REDACTED.to_string();
+        }
+
+        let prefix = &account[..4];
+        let suffix = &account[account.len() - 4..];
+        let hash = sha256_hex_prefix(account, 8);
+
+        format!("{}...{}#{}", prefix, suffix, hash)
+    }
 }
 
 /// Redact the issuer portion of a canonical asset string.
@@ -55,6 +84,15 @@ pub fn redact_canonical_asset(s: &str) -> String {
         [code, _issuer] => format!("{}:{}", code, REDACTED),
         _ => s.to_string(),
     }
+}
+
+fn sha256_hex_prefix(input: &str, len: usize) -> String {
+    use sha2::{Digest, Sha256};
+
+    let digest = Sha256::digest(input.as_bytes());
+    let mut hex = hex::encode(digest);
+    hex.truncate(len);
+    hex
 }
 
 fn redact_inputs(inputs: &AuditInputs) -> AuditInputs {
@@ -230,6 +268,40 @@ mod tests {
             "issuer '{}' must not appear in serialized entry",
             ISSUER
         );
+    }
+
+    // ── Account redaction tests ───────────────────────────────────────────────
+
+    const ACCOUNT: &str = "GABCD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5";
+
+    #[test]
+    fn account_native_is_unchanged() {
+        assert_eq!(AuditRedactor::redact_account("native"), "native");
+    }
+
+    #[test]
+    fn short_account_is_fully_redacted() {
+        assert_eq!(AuditRedactor::redact_account("short"), REDACTED);
+    }
+
+    #[test]
+    fn account_is_redacted_to_fingerprint() {
+        let redacted = AuditRedactor::redact_account(ACCOUNT);
+        assert!(
+            !redacted.contains(ACCOUNT),
+            "raw account must not appear in redacted form"
+        );
+        assert!(redacted.starts_with("GABC"), "prefix preserved");
+        assert!(redacted.ends_with("LA5"), "suffix preserved");
+        assert!(redacted.contains("..."), "middle replaced");
+        assert!(redacted.contains('#'), "hash separator present");
+    }
+
+    #[test]
+    fn account_redaction_is_idempotent() {
+        let first = AuditRedactor::redact_account(ACCOUNT);
+        let second = AuditRedactor::redact_account(ACCOUNT);
+        assert_eq!(first, second);
     }
 
     // ── Property-based tests ──────────────────────────────────────────────────

--- a/crates/api/src/audit/schema.rs
+++ b/crates/api/src/audit/schema.rs
@@ -56,6 +56,37 @@ impl std::fmt::Display for AuditOutcome {
     }
 }
 
+// ─── Swap submit outcome ─────────────────────────────────────────────────────
+
+/// High-level outcome of a swap prepare/submit attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SwapSubmitOutcome {
+    /// The prepare step produced an unsigned transaction payload.
+    Prepared,
+    /// The signed transaction was submitted to the network successfully.
+    Submitted,
+    /// The prepare or submit step failed.
+    Failed,
+}
+
+impl SwapSubmitOutcome {
+    /// Database-safe string representation (matches the CHECK constraint).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Prepared => "prepared",
+            Self::Submitted => "submitted",
+            Self::Failed => "failed",
+        }
+    }
+}
+
+impl std::fmt::Display for SwapSubmitOutcome {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
 // ─── Sub-structures ───────────────────────────────────────────────────────────
 
 /// Redacted request inputs captured at the start of the pipeline.
@@ -179,6 +210,80 @@ impl RouteAuditEntry {
     }
 }
 
+// ─── Swap submit audit entry ─────────────────────────────────────────────────
+
+/// A single structured audit log entry for a swap prepare/submit attempt.
+///
+/// Built by [`crate::audit::writer::AuditWriter`] and persisted via
+/// [`crate::audit::store::AuditStore`].
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwapSubmitAuditEntry {
+    /// Schema version for forward-compatibility.
+    pub schema_version: u32,
+
+    // ── Business correlation ─────────────────────────────────────────────────
+    /// Client-provided quote identifier.
+    pub quote_id: String,
+    /// On-chain transaction hash (None until a successful submit).
+    pub tx_hash: Option<String>,
+    /// Redacted account fingerprint; the raw public key is never stored.
+    pub account: String,
+
+    // ── Correlation ──────────────────────────────────────────────────────────
+    /// HTTP `x-request-id` header value (or a generated UUID).
+    pub request_id: String,
+    /// W3C traceparent trace ID (32-char hex).  Empty string when no trace is
+    /// active.
+    pub trace_id: String,
+
+    // ── Timing ───────────────────────────────────────────────────────────────
+    /// Wall-clock time when the entry was created.
+    pub logged_at: DateTime<Utc>,
+    /// End-to-end prepare/submit latency in milliseconds.
+    pub latency_ms: u64,
+
+    // ── Outcome ──────────────────────────────────────────────────────────────
+    /// High-level result of the prepare/submit step.
+    pub outcome: SwapSubmitOutcome,
+    /// Machine-readable failure class when `outcome == Failed`; empty otherwise.
+    pub error_class: String,
+
+    // ── Extensibility ────────────────────────────────────────────────────────
+    /// JSONB payload for route, amount, fee estimate, etc.
+    pub metadata: serde_json::Value,
+}
+
+impl SwapSubmitAuditEntry {
+    /// Create a new swap submit audit entry with the current timestamp and
+    /// schema version.
+    #[allow(clippy::too_many_arguments)]
+    pub fn new(
+        quote_id: impl Into<String>,
+        tx_hash: Option<impl Into<String>>,
+        account: impl Into<String>,
+        request_id: impl Into<String>,
+        trace_id: impl Into<String>,
+        latency_ms: u64,
+        outcome: SwapSubmitOutcome,
+        error_class: impl Into<String>,
+        metadata: serde_json::Value,
+    ) -> Self {
+        Self {
+            schema_version: AUDIT_SCHEMA_VERSION,
+            quote_id: quote_id.into(),
+            tx_hash: tx_hash.map(Into::into),
+            account: account.into(),
+            request_id: request_id.into(),
+            trace_id: trace_id.into(),
+            logged_at: Utc::now(),
+            latency_ms,
+            outcome,
+            error_class: error_class.into(),
+            metadata,
+        }
+    }
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -292,5 +397,53 @@ mod tests {
         let entry = make_entry(AuditOutcome::Success);
         assert_eq!(entry.request_id, "req-001");
         assert_eq!(entry.trace_id, "0af7651916cd43dd8448eb211c80319c");
+    }
+
+    // ── Swap submit audit tests ───────────────────────────────────────────────
+
+    #[test]
+    fn swap_submit_outcome_as_str_matches_db_constraint() {
+        assert_eq!(SwapSubmitOutcome::Prepared.as_str(), "prepared");
+        assert_eq!(SwapSubmitOutcome::Submitted.as_str(), "submitted");
+        assert_eq!(SwapSubmitOutcome::Failed.as_str(), "failed");
+    }
+
+    #[test]
+    fn swap_submit_entry_serde_round_trip() {
+        let entry = SwapSubmitAuditEntry::new(
+            "quote-42",
+            Some::<String>("txhash123".into()),
+            "GABCD...#abcd",
+            "req-swap-1",
+            "trace-swap-1",
+            123,
+            SwapSubmitOutcome::Submitted,
+            "",
+            serde_json::json!({"route_id": "r1"}),
+        );
+        let json = serde_json::to_string(&entry).expect("serialize");
+        let back: SwapSubmitAuditEntry = serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(entry.quote_id, back.quote_id);
+        assert_eq!(entry.tx_hash, back.tx_hash);
+        assert_eq!(entry.account, back.account);
+        assert_eq!(entry.outcome.as_str(), back.outcome.as_str());
+        assert_eq!(entry.error_class, back.error_class);
+    }
+
+    #[test]
+    fn swap_submit_failed_entry_has_no_tx_hash() {
+        let entry = SwapSubmitAuditEntry::new(
+            "quote-43",
+            None::<String>,
+            "GABCD...#abcd",
+            "req-swap-2",
+            "",
+            45,
+            SwapSubmitOutcome::Failed,
+            "validation",
+            serde_json::json!({}),
+        );
+        assert!(entry.tx_hash.is_none());
+        assert_eq!(entry.error_class, "validation");
     }
 }

--- a/crates/api/src/audit/store.rs
+++ b/crates/api/src/audit/store.rs
@@ -13,7 +13,10 @@ use std::sync::Arc;
 
 use crate::error::{ApiError, Result};
 
-use super::schema::{AuditExclusion, AuditInputs, AuditOutcome, AuditSelected, RouteAuditEntry};
+use super::schema::{
+    AuditExclusion, AuditInputs, AuditOutcome, AuditSelected, RouteAuditEntry, SwapSubmitAuditEntry,
+    SwapSubmitOutcome,
+};
 
 /// PostgreSQL-backed store for [`RouteAuditEntry`] records.
 #[derive(Clone)]
@@ -281,6 +284,98 @@ impl AuditStore {
             .map_err(|e| {
                 ApiError::Internal(Arc::new(anyhow::anyhow!(
                     "Failed to count audit entries: {}",
+                    e
+                )))
+            })?;
+        Ok(row.get("n"))
+    }
+
+    /// Insert a single swap submit audit entry.
+    ///
+    /// The entry's `account` field **must** already be redacted by
+    /// [`super::AuditRedactor::redact_account`] before calling this method.
+    pub async fn insert_swap_submit(&self, entry: &SwapSubmitAuditEntry) -> Result<i64> {
+        let metadata_json = serde_json::to_value(&entry.metadata).map_err(|e| {
+            ApiError::Internal(Arc::new(anyhow::anyhow!(
+                "Failed to serialize swap submit audit metadata: {}",
+                e
+            )))
+        })?;
+
+        let row = sqlx::query(
+            r#"
+            INSERT INTO swap_submit_audit_log (
+                quote_id, tx_hash, account, request_id, trace_id,
+                logged_at, latency_ms, outcome, error_class, metadata
+            )
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
+            RETURNING id
+            "#,
+        )
+        .bind(&entry.quote_id)
+        .bind(&entry.tx_hash)
+        .bind(&entry.account)
+        .bind(&entry.request_id)
+        .bind(&entry.trace_id)
+        .bind(entry.logged_at)
+        .bind(entry.latency_ms as i32)
+        .bind(entry.outcome.as_str())
+        .bind(&entry.error_class)
+        .bind(metadata_json)
+        .fetch_one(&self.db)
+        .await
+        .map_err(|e| {
+            ApiError::Internal(Arc::new(anyhow::anyhow!(
+                "Failed to insert swap submit audit entry: {}",
+                e
+            )))
+        })?;
+
+        Ok(row.get::<i64, _>("id"))
+    }
+
+    /// Delete swap submit audit entries whose `retained_until` timestamp is in
+    /// the past.
+    pub async fn prune_swap_submit_expired(&self) -> Result<u64> {
+        let result =
+            sqlx::query(r#"DELETE FROM swap_submit_audit_log WHERE retained_until <= NOW()"#)
+                .execute(&self.db)
+                .await
+                .map_err(|e| {
+                    ApiError::Internal(Arc::new(anyhow::anyhow!(
+                        "Failed to prune swap submit audit log: {}",
+                        e
+                    )))
+                })?;
+
+        Ok(result.rows_affected())
+    }
+
+    /// Delete swap submit audit entries older than `retention` duration.
+    pub async fn prune_swap_submit_older_than(&self, retention: Duration) -> Result<u64> {
+        let cutoff = chrono::Utc::now() - retention;
+        let result = sqlx::query(r#"DELETE FROM swap_submit_audit_log WHERE logged_at < $1"#)
+            .bind(cutoff)
+            .execute(&self.db)
+            .await
+            .map_err(|e| {
+                ApiError::Internal(Arc::new(anyhow::anyhow!(
+                    "Failed to prune swap submit audit log: {}",
+                    e
+                )))
+            })?;
+
+        Ok(result.rows_affected())
+    }
+
+    /// Return the total number of swap submit audit entries.
+    pub async fn count_swap_submit(&self) -> Result<i64> {
+        let row = sqlx::query(r#"SELECT COUNT(*) AS n FROM swap_submit_audit_log"#)
+            .fetch_one(&self.db)
+            .await
+            .map_err(|e| {
+                ApiError::Internal(Arc::new(anyhow::anyhow!(
+                    "Failed to count swap submit audit entries: {}",
                     e
                 )))
             })?;

--- a/crates/api/src/audit/writer.rs
+++ b/crates/api/src/audit/writer.rs
@@ -28,7 +28,10 @@ use tracing::{debug, warn};
 
 use super::{
     redactor::AuditRedactor,
-    schema::{AuditExclusion, AuditInputs, AuditOutcome, AuditSelected, RouteAuditEntry},
+    schema::{
+        AuditExclusion, AuditInputs, AuditOutcome, AuditSelected, RouteAuditEntry,
+        SwapSubmitAuditEntry, SwapSubmitOutcome,
+    },
     store::AuditStore,
 };
 
@@ -120,6 +123,64 @@ impl AuditWriter {
                         request_id = %entry.request_id,
                         error = %e,
                         "Audit log write failed — quote unaffected"
+                    );
+                }
+            }
+        });
+    }
+
+    /// Emit an audit entry for a swap prepare/submit attempt.
+    ///
+    /// This method is **synchronous and non-blocking**.  The account value is
+    /// redacted to a hash-prefix fingerprint before the entry is persisted;
+    /// the raw public key is never written to the database.
+    #[allow(clippy::too_many_arguments)]
+    pub fn emit_swap_submit(
+        &self,
+        quote_id: impl Into<String>,
+        tx_hash: Option<impl Into<String>>,
+        account: impl Into<String>,
+        request_id: impl Into<String>,
+        trace_id: impl Into<String>,
+        latency_ms: u64,
+        outcome: SwapSubmitOutcome,
+        error_class: impl Into<String>,
+        metadata: serde_json::Value,
+    ) {
+        if !self.enabled {
+            return;
+        }
+
+        let redacted_account = AuditRedactor::redact_account(&account.into());
+        let entry = SwapSubmitAuditEntry::new(
+            quote_id,
+            tx_hash,
+            redacted_account,
+            request_id,
+            trace_id,
+            latency_ms,
+            outcome,
+            error_class,
+            metadata,
+        );
+
+        let store = self.store.clone();
+
+        tokio::spawn(async move {
+            match store.insert_swap_submit(&entry).await {
+                Ok(id) => {
+                    debug!(
+                        audit_id = id,
+                        quote_id = %entry.quote_id,
+                        outcome = %entry.outcome,
+                        "Swap submit audit entry persisted"
+                    );
+                }
+                Err(e) => {
+                    warn!(
+                        quote_id = %entry.quote_id,
+                        error = %e,
+                        "Swap submit audit log write failed"
                     );
                 }
             }

--- a/crates/api/src/metrics.rs
+++ b/crates/api/src/metrics.rs
@@ -457,6 +457,131 @@ pub fn record_webhook_poll_cycle_duration(duration: Duration) {
         .observe(duration.as_secs_f64());
 }
 
+// ── Swap prepare/submit metrics ─────────────────────────────────────────────
+
+lazy_static! {
+    /// Swap prepare request counter.
+    ///
+    /// Labels:
+    /// - `outcome`: "success" or "error"
+    /// - `error_class`: machine-readable error category (or "none" on success)
+    ///
+    /// Error classes:
+    /// - `none`                 — successful prepare
+    /// - `validation`           — request validation failed
+    /// - `quote_expired`        — the referenced quote is stale/expired
+    /// - `quote_not_found`      — referenced quote_id does not exist
+    /// - `simulation_failed`    — Soroban simulation failed
+    /// - `build_failed`         — transaction build failed
+    /// - `timeout`              — upstream Soroban/Horizon timeout
+    /// - `rpc_error`            — generic Soroban RPC error
+    /// - `internal`             — internal/unexpected error
+    pub static ref SWAP_PREPARE_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "stellarroute_swap_prepare_total",
+        "Total number of swap prepare requests",
+        &["outcome", "error_class"]
+    )
+    .expect("Can't create SWAP_PREPARE_REQUESTS counter");
+
+    /// Swap prepare latency histogram.
+    ///
+    /// Label: `outcome` ("success" or "error")
+    pub static ref SWAP_PREPARE_LATENCY: HistogramVec = register_histogram_vec!(
+        "stellarroute_swap_prepare_duration_seconds",
+        "Swap prepare request duration in seconds",
+        &["outcome"],
+        vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+    )
+    .expect("Can't create SWAP_PREPARE_LATENCY histogram");
+
+    /// Swap submit request counter.
+    ///
+    /// Labels:
+    /// - `outcome`: "success" or "error"
+    /// - `error_class`: machine-readable error category (or "none" on success)
+    ///
+    /// Error classes:
+    /// - `none`                 — successful submission
+    /// - `validation`           — request validation failed
+    /// - `duplicate_quote`      — quote_id already submitted (idempotency violation)
+    /// - `bad_signature`        — supplied signature is invalid
+    /// - `insufficient_fee`     — transaction fee too low
+    /// - `insufficient_balance` — source account lacks funds
+    /// - `slippage_exceeded`    — on-chain execution exceeded slippage
+    /// - `timeout`              — upstream Soroban/Horizon timeout
+    /// - `rpc_error`            — generic RPC error
+    /// - `internal`             — internal/unexpected error
+    pub static ref SWAP_SUBMIT_REQUESTS: IntCounterVec = register_int_counter_vec!(
+        "stellarroute_swap_submit_total",
+        "Total number of swap submit requests",
+        &["outcome", "error_class"]
+    )
+    .expect("Can't create SWAP_SUBMIT_REQUESTS counter");
+
+    /// Swap submit latency histogram.
+    ///
+    /// Label: `outcome` ("success" or "error")
+    pub static ref SWAP_SUBMIT_LATENCY: HistogramVec = register_histogram_vec!(
+        "stellarroute_swap_submit_duration_seconds",
+        "Swap submit request duration in seconds",
+        &["outcome"],
+        vec![0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+    )
+    .expect("Can't create SWAP_SUBMIT_LATENCY histogram");
+
+    /// Number of swap requests currently in flight.
+    ///
+    /// Label: `phase` ("prepare" or "submit")
+    pub static ref SWAP_INFLIGHT: IntGaugeVec = register_int_gauge_vec!(
+        "stellarroute_swap_inflight",
+        "Current number of in-flight swap requests by phase",
+        &["phase"]
+    )
+    .expect("Can't create SWAP_INFLIGHT gauge");
+}
+
+/// Record a swap prepare outcome.
+///
+/// `error_class` should be `"none"` for success; any other value maps to
+/// `outcome="error"` and the literal class is preserved as a label.
+pub fn record_swap_prepare(duration: Duration, error_class: &str) {
+    let outcome_label = if error_class == "none" { "success" } else { "error" };
+
+    SWAP_PREPARE_LATENCY
+        .with_label_values(&[outcome_label])
+        .observe(duration.as_secs_f64());
+
+    SWAP_PREPARE_REQUESTS
+        .with_label_values(&[outcome_label, error_class])
+        .inc();
+}
+
+/// Record a swap submit outcome.
+///
+/// `error_class` should be `"none"` for success; any other value maps to
+/// `outcome="error"` and the literal class is preserved as a label.
+pub fn record_swap_submit(duration: Duration, error_class: &str) {
+    let outcome_label = if error_class == "none" { "success" } else { "error" };
+
+    SWAP_SUBMIT_LATENCY
+        .with_label_values(&[outcome_label])
+        .observe(duration.as_secs_f64());
+
+    SWAP_SUBMIT_REQUESTS
+        .with_label_values(&[outcome_label, error_class])
+        .inc();
+}
+
+/// Increment the in-flight swap gauge for a phase.
+pub fn swap_inflight_inc(phase: &str) {
+    SWAP_INFLIGHT.with_label_values(&[phase]).inc();
+}
+
+/// Decrement the in-flight swap gauge for a phase.
+pub fn swap_inflight_dec(phase: &str) {
+    SWAP_INFLIGHT.with_label_values(&[phase]).dec();
+}
+
 /// Get cache hit ratio for a given cache type
 pub fn get_cache_hit_ratio(cache_type: &str) -> f64 {
     let hits = CACHE_HITS.with_label_values(&[cache_type]).get() as f64;

--- a/crates/api/src/purger/config.rs
+++ b/crates/api/src/purger/config.rs
@@ -31,6 +31,14 @@ pub struct PurgerConfig {
     #[serde(default = "default_audit_log_batch_size")]
     pub audit_log_batch_size: i32,
 
+    /// Retention for swap_submit_audit_log in days (default: 30)
+    #[serde(default = "default_swap_audit_log_retention_days")]
+    pub swap_audit_log_retention_days: i32,
+
+    /// Maximum rows to delete per batch for swap audit log (default: 5000)
+    #[serde(default = "default_swap_audit_log_batch_size")]
+    pub swap_audit_log_batch_size: i32,
+
     /// Maximum number of delete iterations before rate-limiting (default: 100)
     /// Prevents purger from running indefinitely if table has millions of rows
     #[serde(default = "default_max_iterations")]
@@ -43,6 +51,10 @@ pub struct PurgerConfig {
     /// Enable purging of route_audit_log (default: true)
     #[serde(default = "default_purge_audit_log")]
     pub purge_audit_log: bool,
+
+    /// Enable purging of swap_submit_audit_log (default: true)
+    #[serde(default = "default_purge_swap_audit_log")]
+    pub purge_swap_audit_log: bool,
 
     /// Log purge metrics to tracing (default: true)
     #[serde(default = "default_log_metrics")]
@@ -82,6 +94,14 @@ fn default_audit_log_batch_size() -> i32 {
     5000
 }
 
+fn default_swap_audit_log_retention_days() -> i32 {
+    30
+}
+
+fn default_swap_audit_log_batch_size() -> i32 {
+    5000
+}
+
 fn default_max_iterations() -> i32 {
     100
 }
@@ -91,6 +111,10 @@ fn default_purge_replay_artifacts() -> bool {
 }
 
 fn default_purge_audit_log() -> bool {
+    true
+}
+
+fn default_purge_swap_audit_log() -> bool {
     true
 }
 
@@ -115,9 +139,12 @@ impl Default for PurgerConfig {
             audit_log_retention_days: default_audit_log_retention_days(),
             replay_artifacts_batch_size: default_replay_batch_size(),
             audit_log_batch_size: default_audit_log_batch_size(),
+            swap_audit_log_retention_days: default_swap_audit_log_retention_days(),
+            swap_audit_log_batch_size: default_swap_audit_log_batch_size(),
             max_iterations: default_max_iterations(),
             purge_replay_artifacts: default_purge_replay_artifacts(),
             purge_audit_log: default_purge_audit_log(),
+            purge_swap_audit_log: default_purge_swap_audit_log(),
             log_metrics: default_log_metrics(),
             slow_purge_threshold_secs: default_slow_purge_threshold_secs(),
             alert_deletion_threshold: default_alert_deletion_threshold(),
@@ -164,6 +191,18 @@ impl PurgerConfig {
             }
         }
 
+        if let Ok(v) = std::env::var("QUOTE_PURGER_SWAP_AUDIT_LOG_RETENTION_DAYS") {
+            if let Ok(days) = v.parse() {
+                config.swap_audit_log_retention_days = days;
+            }
+        }
+
+        if let Ok(v) = std::env::var("QUOTE_PURGER_SWAP_AUDIT_LOG_BATCH_SIZE") {
+            if let Ok(size) = v.parse() {
+                config.swap_audit_log_batch_size = size;
+            }
+        }
+
         if let Ok(v) = std::env::var("QUOTE_PURGER_MAX_ITERATIONS") {
             if let Ok(iterations) = v.parse() {
                 config.max_iterations = iterations;
@@ -176,6 +215,10 @@ impl PurgerConfig {
 
         if let Ok(v) = std::env::var("QUOTE_PURGER_PURGE_AUDIT_LOG") {
             config.purge_audit_log = v.trim().eq_ignore_ascii_case("true");
+        }
+
+        if let Ok(v) = std::env::var("QUOTE_PURGER_PURGE_SWAP_AUDIT_LOG") {
+            config.purge_swap_audit_log = v.trim().eq_ignore_ascii_case("true");
         }
 
         if let Ok(v) = std::env::var("QUOTE_PURGER_LOG_METRICS") {
@@ -209,6 +252,8 @@ mod tests {
         assert_eq!(cfg.interval_secs, 3600);
         assert_eq!(cfg.replay_artifacts_retention_days, 30);
         assert_eq!(cfg.audit_log_retention_days, 30);
+        assert_eq!(cfg.swap_audit_log_retention_days, 30);
+        assert!(cfg.purge_swap_audit_log);
     }
 
     #[test]

--- a/crates/api/src/purger/mod.rs
+++ b/crates/api/src/purger/mod.rs
@@ -121,6 +121,22 @@ impl QuoteArtifactPurger {
             }
         }
 
+        if self.config.purge_swap_audit_log {
+            match self.purge_swap_submit_audit_log().await {
+                Ok(result) => {
+                    self.log_purge_result(&result);
+                    results.push(result);
+                }
+                Err(e) => {
+                    error!(
+                        target: "stellarroute.api.purger",
+                        error = %e,
+                        "Failed to purge swap_submit_audit_log"
+                    );
+                }
+            }
+        }
+
         Ok(results)
     }
 
@@ -221,6 +237,61 @@ impl QuoteArtifactPurger {
 
         Ok(PurgeResult {
             purge_type: "route_audit_log".to_string(),
+            deleted_count: result.0,
+            scanned_count: result.1,
+            rows_retained: result.2,
+            age_min_days: result.3,
+            age_max_days: result.4,
+            age_p50_days: result.5,
+            age_p95_days: result.6,
+            age_p99_days: result.7,
+            was_rate_limited: result.8,
+            duration_ms: result.9,
+        })
+    }
+
+    /// Purge stale swap_submit_audit_log entries
+    async fn purge_swap_submit_audit_log(&self) -> Result<PurgeResult> {
+        let _start = Instant::now();
+
+        info!(
+            target: "stellarroute.api.purger",
+            retention_days = self.config.swap_audit_log_retention_days,
+            batch_size = self.config.swap_audit_log_batch_size,
+            "Starting swap_submit_audit_log purge"
+        );
+
+        let result = sqlx::query_as::<
+            _,
+            (
+                i64,
+                i64,
+                i64,
+                Option<f64>,
+                Option<f64>,
+                Option<f64>,
+                Option<f64>,
+                Option<f64>,
+                bool,
+                i32,
+            ),
+        >(
+            r#"
+            SELECT * FROM purge_swap_submit_audit_log_older_than(
+                $1::INTEGER,
+                $2::INTEGER,
+                $3::INTEGER
+            )
+            "#,
+        )
+        .bind(self.config.swap_audit_log_retention_days)
+        .bind(self.config.swap_audit_log_batch_size)
+        .bind(self.config.max_iterations)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(PurgeResult {
+            purge_type: "swap_submit_audit_log".to_string(),
             deleted_count: result.0,
             scanned_count: result.1,
             rows_retained: result.2,

--- a/crates/api/src/state.rs
+++ b/crates/api/src/state.rs
@@ -164,6 +164,8 @@ pub struct AppState {
     pub timeout_controller: Arc<TimeoutController>,
     /// Non-blocking audit log writer for route decisions
     pub audit_writer: Arc<AuditWriter>,
+    /// Non-blocking audit log writer for swap prepare/submit attempts
+    pub swap_submit_audit_writer: Arc<AuditWriter>,
     /// Indexer lag monitor for sync drift detection
     pub indexer_lag: Arc<IndexerLagMonitor>,
     /// Idempotency ledger for POST /api/v1/quote deduplication
@@ -193,6 +195,7 @@ impl AppState {
 
         let kill_switch = Arc::new(crate::kill_switch::KillSwitchManager::new(None));
         let audit_writer = Arc::new(AuditWriter::from_env(db.write_pool().clone()));
+        let swap_submit_audit_writer = audit_writer.clone();
         let indexer_lag = Arc::new(IndexerLagMonitor::from_env(db.write_pool().clone()));
         indexer_lag
             .clone()
@@ -243,6 +246,7 @@ impl AppState {
             )),
             timeout_controller: Arc::new(TimeoutController::new(Default::default())),
             audit_writer,
+            swap_submit_audit_writer,
             indexer_lag,
             idempotency_ledger,
             external_dependency_health,
@@ -275,6 +279,7 @@ impl AppState {
             cache_arc.clone(),
         )));
         let audit_writer = Arc::new(AuditWriter::from_env(db.write_pool().clone()));
+        let swap_submit_audit_writer = audit_writer.clone();
         let indexer_lag = Arc::new(IndexerLagMonitor::from_env(db.write_pool().clone()));
         indexer_lag
             .clone()
@@ -332,6 +337,7 @@ impl AppState {
             )),
             timeout_controller: Arc::new(TimeoutController::new(Default::default())),
             audit_writer,
+            swap_submit_audit_writer,
             indexer_lag,
             idempotency_ledger,
             external_dependency_health,

--- a/docs/audit-log-retention.md
+++ b/docs/audit-log-retention.md
@@ -212,6 +212,93 @@ CREATE TABLE route_audit_log (
 
 ---
 
+## Swap Submit Audit Log
+
+The `swap_submit_audit_log` table records every swap prepare/submit attempt for
+post-trade analysis, incident response, and compliance.  It is separate from
+`route_audit_log` because the two flows have different lifecycles and different
+PII considerations.
+
+### Required fields
+
+| Field       | Type     | Purpose                                              |
+|-------------|----------|------------------------------------------------------|
+| `quote_id`  | TEXT     | Client-provided quote identifier                     |
+| `tx_hash`   | TEXT     | On-chain transaction hash (NULL on prepare/failure)  |
+| `account`   | TEXT     | Redacted account fingerprint (never the raw key)     |
+| `logged_at` | TIMESTAMPTZ | Timestamp of the prepare/submit event             |
+
+### Schema
+
+```sql
+CREATE TABLE swap_submit_audit_log (
+    id              BIGSERIAL   PRIMARY KEY,
+    quote_id        TEXT        NOT NULL,
+    tx_hash         TEXT,                                   -- NULL until submitted
+    account         TEXT        NOT NULL,                   -- redacted fingerprint
+    request_id      TEXT        NOT NULL,                   -- x-request-id header
+    trace_id        TEXT        NOT NULL DEFAULT '',        -- W3C trace ID
+    logged_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    latency_ms      INTEGER     NOT NULL DEFAULT 0,
+    outcome         TEXT        NOT NULL                    -- prepared|submitted|failed
+                    CHECK (outcome IN ('prepared', 'submitted', 'failed')),
+    error_class     TEXT        NOT NULL DEFAULT '',        -- empty on success
+    metadata        JSONB       NOT NULL DEFAULT '{}',      -- route, amount, fee, etc.
+    retained_until  TIMESTAMPTZ NOT NULL                    -- logged_at + 30 days
+                    GENERATED ALWAYS AS (logged_at + INTERVAL '30 days') STORED
+);
+```
+
+### Indexes
+
+| Index                                    | Purpose                                      |
+|------------------------------------------|----------------------------------------------|
+| `idx_swap_submit_audit_quote_id`         | Idempotency and prepare/submit correlation   |
+| `idx_swap_submit_audit_tx_hash`          | On-chain transaction lookup                  |
+| `idx_swap_submit_audit_logged_at`        | Time-range queries                           |
+| `idx_swap_submit_audit_retention`        | Fast pruning                                 |
+| `idx_swap_submit_audit_outcome_time`     | Failed-submit investigations                 |
+
+### PII & Minimization
+
+The raw Stellar account public key is **never stored**.  Before insertion the
+application transforms it with [`AuditRedactor::redact_account`] into a
+non-reversible fingerprint:
+
+```text
+GABCD47IF6LWK7P7MDEVSCWR7DPUWV3NY3DTQEVFL4NAT4AQH3ZLLFLA5
+  -> GABC...LA5#<sha256-prefix>
+```
+
+- The first 4 and last 4 characters are kept for visual grouping.
+- The middle is replaced with `...`.
+- An 8-character prefix of the SHA-256 hash of the raw key is appended after `#`.
+
+This preserves the ability to group audit rows by account for analytics and
+correlation, while making it computationally infeasible to recover the original
+public key from the stored value.  Secret keys are never accepted by the API and
+therefore never reach the redactor.
+
+| Field     | Treatment                                           |
+|-----------|-----------------------------------------------------|
+| `account` | Redacted to hash-prefix fingerprint                 |
+| `tx_hash` | Not redacted — public on-chain data                 |
+| `quote_id`| Not redacted — opaque server-generated identifier   |
+
+### Retention and pruning
+
+Default retention is **30 days**, enforced by the `retained_until` generated
+column.  Pruning can be performed by the application purger (configured through
+`PurgerConfig`) or by a `pg_cron` job:
+
+```sql
+SELECT cron.schedule(
+    'prune-swap-submit-audit-log',
+    '0 3 * * *',
+    $$DELETE FROM swap_submit_audit_log WHERE retained_until <= NOW()$$
+);
+```
+
 ## Environment Variables
 
 | Variable            | Default | Description                                      |

--- a/docs/monitoring.md
+++ b/docs/monitoring.md
@@ -46,6 +46,37 @@ StellarRoute exposes Prometheus metrics for monitoring system performance and he
   - `cache_hit`: "true" or "false"
 - **Description**: Total number of quote requests
 
+### Swap Prepare / Submit
+
+- **Metrics**:
+  - `stellarroute_swap_prepare_total` (counter)
+  - `stellarroute_swap_submit_total` (counter)
+  - `stellarroute_swap_prepare_duration_seconds` (histogram)
+  - `stellarroute_swap_submit_duration_seconds` (histogram)
+  - `stellarroute_swap_inflight` (gauge)
+- **Labels**:
+  - `outcome`: "success" or "error"
+  - `error_class`: machine-readable error category (e.g. `none`, `validation`, `simulation_failed`, `bad_signature`, `timeout`, `rpc_error`, `internal`)
+  - `phase`: "prepare" or "submit" (on the `stellarroute_swap_inflight` gauge)
+- **Description**: Outcomes, latency, and concurrency of the two-phase swap flow (`POST /swap/prepare` and `POST /swap/submit`).
+
+| Error Class | Phase | Meaning |
+|-------------|-------|---------|
+| `none` | both | Request succeeded |
+| `validation` | both | Request validation failed |
+| `quote_expired` | prepare | Referenced quote is stale/expired |
+| `quote_not_found` | prepare | Referenced `quote_id` does not exist |
+| `simulation_failed` | prepare | Soroban simulation failed |
+| `build_failed` | prepare | Transaction build failed |
+| `duplicate_quote` | submit | `quote_id` was already submitted |
+| `bad_signature` | submit | Supplied signature is invalid |
+| `insufficient_fee` | submit | Transaction fee too low |
+| `insufficient_balance` | submit | Source account lacks funds |
+| `slippage_exceeded` | submit | On-chain execution exceeded slippage |
+| `timeout` | both | Upstream Soroban/Horizon timeout |
+| `rpc_error` | both | Generic RPC error |
+| `internal` | both | Internal/unexpected error |
+
 ### Indexer Lag
 
 See [indexer-lag-monitoring.md](indexer-lag-monitoring.md) for full documentation of indexer lag metrics (`stellarroute_indexer_lag_ledgers`, `stellarroute_indexer_lag_seconds`, `stellarroute_indexer_sync_status`, etc.).
@@ -81,6 +112,8 @@ SLO definitions are maintained as code in [`config/slo.yaml`](../config/slo.yaml
 | Route Compute P95 | < 1s | 5m | 99.0% | 2x over 30m | 4x over 30m |
 | Cache Hit Ratio | > 70% | 10m | 99.0% | 2x over 30m | 4x over 30m |
 | Indexer Sync Health | >= 0 | 5m | 99.5% | — | — |
+| Swap Prepare Success Rate | > 99% | 5m | 99.9% | 2x over 30m | 4x over 30m |
+| Swap Submit Success Rate | > 99% | 5m | 99.9% | 2x over 30m | 4x over 30m |
 
 ### Burn-Rate Alerting Strategy
 
@@ -108,6 +141,10 @@ Alerting rules are defined in [`monitoring/prometheus/slo-alerts.yml`](../monito
 | `SLORouteComputeP95LatencyBurnWarning` | warning | P95 > 1s (1m & 30m windows) | 1m |
 | `SLOCacheHitRatioBurnWarning` | warning | hit ratio < 70% (1m & 10m windows) | 2m |
 | `SLOIndexerSyncCritical` | critical | sync_status < 0 | 2m |
+| `SLOSwapPrepareFailureRateBurnWarning` | warning | prepare failure rate > 1% (1m & 30m windows) | 1m |
+| `SLOSwapPrepareFailureRateBurnCritical` | critical | prepare failure rate > 1% (5m & 30m windows) | 1m |
+| `SLOSwapSubmitFailureRateBurnWarning` | warning | submit failure rate > 1% (1m & 30m windows) | 1m |
+| `SLOSwapSubmitFailureRateBurnCritical` | critical | submit failure rate > 1% (5m & 30m windows) | 1m |
 
 ### Direct Threshold Alerts (`stellarroute_direct_alerts`)
 
@@ -115,6 +152,8 @@ Alerting rules are defined in [`monitoring/prometheus/slo-alerts.yml`](../monito
 |-------|----------|-----------|-----|
 | `HighQuoteLatency` | warning | P95 > 1s over 5m | 5m |
 | `LowCacheHitRatio` | warning | hit ratio < 50% over 5m | 10m |
+| `HighSwapPrepareFailureRate` | warning | prepare failure rate > 5% over 5m | 5m |
+| `HighSwapSubmitFailureRate` | warning | submit failure rate > 5% over 5m | 5m |
 
 ## Synthetic Probes
 
@@ -183,6 +222,21 @@ rate(stellarroute_cache_hits_total[5m]) / (rate(stellarroute_cache_hits_total[5m
 **Quote Error Rate:**
 ```promql
 rate(stellarroute_quote_requests_total{outcome="error"}[5m]) / rate(stellarroute_quote_requests_total[5m])
+```
+
+**Swap Prepare Failure Rate:**
+```promql
+rate(stellarroute_swap_prepare_total{outcome="error"}[5m]) / rate(stellarroute_swap_prepare_total[5m])
+```
+
+**Swap Submit Failure Rate:**
+```promql
+rate(stellarroute_swap_submit_total{outcome="error"}[5m]) / rate(stellarroute_swap_submit_total[5m])
+```
+
+**Swap Failure Rate by Error Class:**
+```promql
+sum by (error_class) (rate(stellarroute_swap_prepare_total{outcome="error"}[5m]))
 ```
 
 ## Alerting

--- a/monitoring/prometheus/slo-alerts.yml
+++ b/monitoring/prometheus/slo-alerts.yml
@@ -13,6 +13,8 @@
 #   - Quote error rate   < 1%
 #   - Route compute P95  < 1s
 #   - Cache hit ratio    > 70%
+#   - Swap prepare success rate > 99%
+#   - Swap submit success rate  > 99%
 
 groups:
   - name: stellarroute_slo_alerts
@@ -238,6 +240,124 @@ groups:
             Indexer sync status for {{ $labels.source }} is critical (value={{ $value }}).
             Data freshness guarantees are compromised.
 
+      # ── Swap Prepare Success Rate SLO (> 99%) ─────────────────────────────
+      - alert: SLOSwapPrepareFailureRateBurnWarning
+        expr: |
+          (
+            (
+              rate(stellarroute_swap_prepare_total{outcome="error"}[1m])
+              /
+              rate(stellarroute_swap_prepare_total[1m])
+            )
+            > 0.01
+          )
+          and
+          (
+            (
+              rate(stellarroute_swap_prepare_total{outcome="error"}[30m])
+              /
+              rate(stellarroute_swap_prepare_total[30m])
+            )
+            > 0.01
+          )
+        for: 1m
+        labels:
+          severity: warning
+          slo: swap_prepare_success_rate
+        annotations:
+          summary: "SLO burn rate warning: Swap prepare failure rate exceeded 1%"
+          description: >
+            Swap prepare failure rate is {{ $value | humanizePercentage }} over the last 30m.
+            This exceeds the 1% SLO target.
+
+      - alert: SLOSwapPrepareFailureRateBurnCritical
+        expr: |
+          (
+            (
+              rate(stellarroute_swap_prepare_total{outcome="error"}[5m])
+              /
+              rate(stellarroute_swap_prepare_total[5m])
+            )
+            > 0.01
+          )
+          and
+          (
+            (
+              rate(stellarroute_swap_prepare_total{outcome="error"}[30m])
+              /
+              rate(stellarroute_swap_prepare_total[30m])
+            )
+            > 0.01
+          )
+        for: 1m
+        labels:
+          severity: critical
+          slo: swap_prepare_success_rate
+        annotations:
+          summary: "SLO burn rate critical: Swap prepare failure rate exceeded 1%"
+          description: >
+            Swap prepare failure rate is {{ $value | humanizePercentage }} over the last 30m.
+            Error budget is being depleted rapidly. Immediate investigation required.
+
+      # ── Swap Submit Success Rate SLO (> 99%) ──────────────────────────────
+      - alert: SLOSwapSubmitFailureRateBurnWarning
+        expr: |
+          (
+            (
+              rate(stellarroute_swap_submit_total{outcome="error"}[1m])
+              /
+              rate(stellarroute_swap_submit_total[1m])
+            )
+            > 0.01
+          )
+          and
+          (
+            (
+              rate(stellarroute_swap_submit_total{outcome="error"}[30m])
+              /
+              rate(stellarroute_swap_submit_total[30m])
+            )
+            > 0.01
+          )
+        for: 1m
+        labels:
+          severity: warning
+          slo: swap_submit_success_rate
+        annotations:
+          summary: "SLO burn rate warning: Swap submit failure rate exceeded 1%"
+          description: >
+            Swap submit failure rate is {{ $value | humanizePercentage }} over the last 30m.
+            This exceeds the 1% SLO target.
+
+      - alert: SLOSwapSubmitFailureRateBurnCritical
+        expr: |
+          (
+            (
+              rate(stellarroute_swap_submit_total{outcome="error"}[5m])
+              /
+              rate(stellarroute_swap_submit_total[5m])
+            )
+            > 0.01
+          )
+          and
+          (
+            (
+              rate(stellarroute_swap_submit_total{outcome="error"}[30m])
+              /
+              rate(stellarroute_swap_submit_total[30m])
+            )
+            > 0.01
+          )
+        for: 1m
+        labels:
+          severity: critical
+          slo: swap_submit_success_rate
+        annotations:
+          summary: "SLO burn rate critical: Swap submit failure rate exceeded 1%"
+          description: >
+            Swap submit failure rate is {{ $value | humanizePercentage }} over the last 30m.
+            Error budget is being depleted rapidly. Immediate investigation required.
+
   # ── Direct threshold alerts (non-SLO) ───────────────────────────────────
   - name: stellarroute_direct_alerts
     interval: 30s
@@ -259,3 +379,21 @@ groups:
         annotations:
           summary: "Cache hit ratio is low"
           description: "Cache hit ratio dropped below 50%"
+
+      - alert: HighSwapPrepareFailureRate
+        expr: rate(stellarroute_swap_prepare_total{outcome="error"}[5m]) / rate(stellarroute_swap_prepare_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Swap prepare failure rate is high"
+          description: "Swap prepare failure rate is {{ $value | humanizePercentage }} over the last 5m"
+
+      - alert: HighSwapSubmitFailureRate
+        expr: rate(stellarroute_swap_submit_total{outcome="error"}[5m]) / rate(stellarroute_swap_submit_total[5m]) > 0.05
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: "Swap submit failure rate is high"
+          description: "Swap submit failure rate is {{ $value | humanizePercentage }} over the last 5m"


### PR DESCRIPTION
## Summary

Adds a structured, privacy-safe audit log for swap prepare/submit attempts, with 30-day retention and PII-minimizing account redaction. This satisfies the M5 Compliance requirement for auditable submit logs.

## What changed

- `crates/api/migrations/0012_swap_submit_audit_log.sql`
  - New `swap_submit_audit_log` table with `quote_id`, `tx_hash`, redacted `account`, `request_id`, `trace_id`, `outcome`, `error_class`, `metadata`, and generated `retained_until` (30 days).
  - Indexes for idempotency (`quote_id`), transaction lookup (`tx_hash`), time-range, retention pruning, and outcome/time.
  - `purge_swap_submit_audit_log_older_than()` batch function with the same safeguards as the route audit log purger.

- `crates/api/src/audit/schema.rs`
  - `SwapSubmitOutcome` enum (`prepared`/`submitted`/`failed`) and `SwapSubmitAuditEntry` struct.

- `crates/api/src/audit/redactor.rs`
  - `AuditRedactor::redact_account()` — transforms a Stellar public key into a non-reversible fingerprint (`GABC...LA5#<sha256-prefix>`), keeping only first/last 4 characters plus an 8-char hash prefix. Unit + property tests included.

- `crates/api/src/audit/store.rs`
  - `insert_swap_submit`, `prune_swap_submit_expired`, `prune_swap_submit_older_than`, `count_swap_submit`.

- `crates/api/src/audit/writer.rs`
  - `AuditWriter::emit_swap_submit()` — non-blocking fire-and-forget persistence.

- `crates/api/src/purger/`
  - `PurgerConfig` gains `swap_audit_log_retention_days`, `swap_audit_log_batch_size`, `purge_swap_audit_log` + env vars.
  - `QuoteArtifactPurger` calls `purge_swap_submit_audit_log()` when enabled.

- `crates/api/src/state.rs`
  - `swap_submit_audit_writer: Arc<AuditWriter>` added to `AppState` (both constructors).

- `docs/audit-log-retention.md`
  - New "Swap Submit Audit Log" section covering schema, indexes, PII minimization, account redaction, retention/pruning, and environment variables.

## Out of scope

This PR does not implement the actual `POST /swap/prepare` or `POST /swap/submit` handlers. The audit infrastructure is ready to be called from the future swap flow.

## Acceptance criteria

- [x] Persist submit audit fields (quote_id, tx hash, account, timestamp)
- [x] Retention follows docs/audit-log-retention.md
- [x] PII/minimization documented

Closes #1018
