### PR TITLE
[1021] [documentation] User guide: first live swap on StellarRoute

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -77,10 +77,14 @@ This directory is the documentation hub for StellarRoute. It organizes design, d
 - [Performance budget](performance_budget.md) — frontend and API performance targets.
 - [Readiness](readiness/M2_GUIDE.md) — readiness and runbook content.
 
+### User guides
+
+- [First live swap](user-guide-first-live-swap.md) — wallet, trustline, slippage, and confirm for non-developer traders (also `/guide` in the app).
+
 ### Design
 
 - [Information architecture](design/information-architecture.md) — sitemap, navigation hierarchy, and UX structure.
-- [Empty states spec](design/empty-states-spec.md) — design specification for empty and error states.
+- [Empty states spec](design/empty-states-spec.md) — design specification for empty and error states (links the first-swap guide from swap empty state).
 - [Accessibility contrast audit](design/accessibility-contrast-audit.md) — WCAG colour contrast audit results.
 
 ### Frontend documentation

--- a/docs/design/empty-states-spec.md
+++ b/docs/design/empty-states-spec.md
@@ -54,7 +54,8 @@ interface ViewStateProps {
 
 **CTA:** 
 - **Primary:** "Browse pairs" → Opens token selector for base asset
-- **Secondary:** Link to docs: "Learn about asset formats"
+- **Secondary:** Link to first-swap user guide: "First live swap guide" → `/guide` (see [docs/user-guide-first-live-swap.md](../user-guide-first-live-swap.md))
+- **Also:** Swap onboarding checklist and keyboard help drawer (`?`) link to the same guide
 
 **Variant:** `empty`
 
@@ -65,9 +66,14 @@ interface ViewStateProps {
   title="Select a trading pair"
   description="Choose from available base and quote assets to get started."
   action={
-    <Button onClick={openPairSelector} variant="default">
-      Browse pairs
-    </Button>
+    <>
+      <Button onClick={openPairSelector} variant="default">
+        Browse pairs
+      </Button>
+      <a href="/guide" className="text-sm text-muted-foreground underline">
+        First live swap guide
+      </a>
+    </>
   }
 />
 ```

--- a/docs/user-guide-first-live-swap.md
+++ b/docs/user-guide-first-live-swap.md
@@ -1,0 +1,134 @@
+# User Guide: Your First Live Swap on StellarRoute
+
+**Issue:** #1021  
+**Audience:** Non-developer traders  
+**App path:** [/guide](https://stellarroute.vercel.app/guide) (also available in the swap help drawer via `?`)  
+**Related:** [Empty states spec](./design/empty-states-spec.md), [Swap E2E flow](./swap-e2e-flow.md), [Risk disclosure](./risk-disclosure.md)
+
+This short guide walks you through your **first live swap**: connect a wallet, set trustlines, pick a pair, set slippage, and confirm.
+
+> **Network tip:** Confirm the footer network badge shows **Testnet** or **Mainnet** as intended before you swap. Testnet funds have no real value; mainnet swaps use real assets.
+
+---
+
+## Annotated steps (quick map)
+
+```text
+┌─────────────────────────────────────────────────────────────┐
+│  StellarRoute Swap                                          │
+│  ┌──────────────┐                                           │
+│  │ [Connect] ①  │  ← Connect Freighter / xBull              │
+│  └──────────────┘                                           │
+│  ┌────────────────────────────┐                             │
+│  │ Pay:    [ XLM ▼ ]  10  ②   │  ← Choose asset + amount    │
+│  │ Receive:[ USDC▼ ]  …   ③   │  ← Quote fills automatically│
+│  └────────────────────────────┘                             │
+│  Slippage: 0.5%  ④   Route preview  ⑤                       │
+│  [ Review & Swap ]  ⑥                                       │
+└─────────────────────────────────────────────────────────────┘
+```
+
+| Step | What you do | Why it matters |
+|------|-------------|----------------|
+| ① | Connect wallet | Signs the Stellar transaction; StellarRoute never holds your keys |
+| ② | Pick pay asset + amount | Starts the quote request across SDEX + AMM venues |
+| ③ | Confirm receive asset | May require a **trustline** for non-XLM assets |
+| ④ | Set slippage | Caps how much worse the fill can be vs the quote |
+| ⑤ | Review route | Multi-hop paths can improve price but add complexity |
+| ⑥ | Confirm in wallet | Final authorization happens in your wallet extension |
+
+*(Screenshot placeholders: capture Connect → Quote → Confirm once UI is frozen for launch, and drop images into `docs/assets/first-swap/` as `01-connect.png` … `06-confirm.png`.)*
+
+---
+
+## Step-by-step
+
+### 1. Install and fund a wallet
+
+1. Install [Freighter](https://www.freighter.app/) or [xBull](https://xbull.app/).
+2. Create or import an account.
+3. **Testnet:** fund via [Friendbot](https://friendbot.stellar.org/) (needs your public address).  
+   **Mainnet:** deposit XLM (and any assets you will sell) from an exchange or another wallet.
+4. Keep a small XLM reserve for fees and base reserves (Stellar accounts need a minimum balance).
+
+### 2. Connect on StellarRoute
+
+1. Open the [Swap](/swap) page (home redirects here).
+2. Click **Connect wallet** (onboarding checklist step 1, or the wallet control in the header).
+3. Approve the connection in your wallet.
+4. If you see a **network mismatch** banner, switch the wallet network to match the app footer.
+
+### 3. Add a trustline (non-XLM receive assets)
+
+Stellar requires a **trustline** before your account can hold most non-XLM assets (for example USDC).
+
+1. Choose a receive asset that is not native XLM.
+2. If the UI prompts you to **Create trustline**, review the asset code + issuer and confirm in your wallet.
+3. Wait for confirmation, then return to the swap form.
+
+Without a trustline, the receive leg can fail even when the quote looks fine.
+
+### 4. Select a pair and enter an amount
+
+1. Use the **Pay** selector to choose what you sell.
+2. Use the **Receive** selector for what you want.
+3. Enter a **small amount** for your first live swap.
+4. Wait for the quote (“Finding best route…”). Review **price impact** and estimated receive amount.
+
+If you see **No liquidity for this pair**, try another pair or a smaller size (see [empty states](./design/empty-states-spec.md)).
+
+### 5. Set slippage tolerance
+
+1. Open slippage settings on the swap card (or Settings).
+2. Start with a modest default (for example **0.5%**). Use higher only if quotes fail due to movement.
+3. Read any **high slippage** warnings carefully — higher tolerance increases the chance of a worse fill.
+
+### 6. Review route and confirm
+
+1. Expand the route preview if shown (hops, venues, fees).
+2. Click **Review & Swap** / **Confirm**.
+3. In your wallet, verify amounts, destination, and fees, then **sign**.
+4. Track status in the UI; use the explorer link when a transaction hash appears.
+
+---
+
+## Checklist before your first live swap
+
+- [ ] Wallet connected and on the correct network  
+- [ ] Enough XLM for fees + reserves  
+- [ ] Trustline set for the receive asset (if not XLM)  
+- [ ] Slippage reviewed  
+- [ ] Amount is intentionally small for a first try  
+- [ ] You understand [aggregator risks](./risk-disclosure.md) (slippage, routing, smart contracts)
+
+---
+
+## Help from the product UI
+
+| Surface | How to open the guide |
+|---------|------------------------|
+| Swap onboarding checklist | “First swap guide” link under the checklist |
+| Keyboard help drawer | Press `?` on the swap card → “First live swap guide” |
+| In-app page | `/guide` |
+| Docs hub | Linked from `/docs` and this repository `docs/` index |
+
+---
+
+## Troubleshooting
+
+| Symptom | What to try |
+|---------|-------------|
+| Wallet won’t connect | Refresh; unlock extension; check supported wallet list |
+| Network mismatch | Align wallet network with app footer (Testnet vs Mainnet) |
+| Trustline errors | Confirm asset issuer; ensure you can pay the trustline reserve |
+| Quote errors / timeouts | Retry; check [/status](/status); try a smaller amount |
+| Transaction fails after sign | Read wallet / Horizon error; check balance, trustlines, and slippage |
+
+---
+
+## Verify
+
+```bash
+ls docs | head
+# expect user-guide-first-live-swap.md among docs entries
+```

--- a/frontend/app/docs/page.tsx
+++ b/frontend/app/docs/page.tsx
@@ -1,28 +1,39 @@
 import { ExternalLink } from "lucide-react";
 import type { Metadata } from "next";
+import Link from "next/link";
 
 const docsLinks = [
+  {
+    title: "First Live Swap Guide",
+    description: "Trader walkthrough: connect a wallet, set trustlines, set slippage, and confirm your first swap.",
+    href: "/guide",
+    external: false,
+  },
   {
     title: "Documentation Index",
     description: "Browse the main StellarRoute documentation directory.",
     href: "https://github.com/StellarRoute/StellarRoute/tree/main/docs",
+    external: true,
   },
   {
     title: "API Reference",
     description: "Review REST API routes, schemas, websocket docs, and integration guidance.",
     href: "https://github.com/StellarRoute/StellarRoute/tree/main/docs/api",
+    external: true,
   },
   {
     title: "Developer Guide",
     description: "Set up the frontend, indexer, testing flow, and wallet integration locally.",
     href: "https://github.com/StellarRoute/StellarRoute/tree/main/docs/development",
+    external: true,
   },
   {
     title: "Contract Docs",
     description: "Read contract deployment, testing, router interface, and gas benchmark notes.",
     href: "https://github.com/StellarRoute/StellarRoute/tree/main/docs/contracts",
+    external: true,
   },
-];
+] as const;
 
 export const metadata: Metadata = {
   title: "Docs | StellarRoute",
@@ -47,23 +58,43 @@ export default function DocsPage() {
         </div>
 
         <div className="grid gap-4 sm:grid-cols-2">
-          {docsLinks.map((link) => (
-            <a
-              key={link.href}
-              href={link.href}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="rounded-lg border bg-card p-5 text-card-foreground transition-colors hover:border-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
-            >
-              <span className="mb-3 flex items-center justify-between gap-3">
-                <span className="text-base font-semibold">{link.title}</span>
-                <ExternalLink className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
-              </span>
-              <span className="block text-sm leading-6 text-muted-foreground">
-                {link.description}
-              </span>
-            </a>
-          ))}
+          {docsLinks.map((link) => {
+            const className =
+              "rounded-lg border bg-card p-5 text-card-foreground transition-colors hover:border-primary/60 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2";
+            const content = (
+              <>
+                <span className="mb-3 flex items-center justify-between gap-3">
+                  <span className="text-base font-semibold">{link.title}</span>
+                  {link.external ? (
+                    <ExternalLink className="h-4 w-4 text-muted-foreground" aria-hidden="true" />
+                  ) : null}
+                </span>
+                <span className="block text-sm leading-6 text-muted-foreground">
+                  {link.description}
+                </span>
+              </>
+            );
+
+            if (link.external) {
+              return (
+                <a
+                  key={link.href}
+                  href={link.href}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className={className}
+                >
+                  {content}
+                </a>
+              );
+            }
+
+            return (
+              <Link key={link.href} href={link.href} className={className}>
+                {content}
+              </Link>
+            );
+          })}
         </div>
       </div>
     </main>

--- a/frontend/app/guide/page.tsx
+++ b/frontend/app/guide/page.tsx
@@ -1,0 +1,112 @@
+import type { Metadata } from "next";
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+
+export const metadata: Metadata = {
+  title: "First Live Swap Guide | StellarRoute",
+  description:
+    "Step-by-step guide for your first StellarRoute swap: wallet, trustline, slippage, and confirm.",
+};
+
+const steps = [
+  {
+    title: "Connect your wallet",
+    body: "Use Freighter or xBull. Match the network badge in the footer (Testnet vs Mainnet) before you trade.",
+  },
+  {
+    title: "Fund and reserve XLM",
+    body: "Keep enough XLM for network fees and Stellar base reserves. On testnet, Friendbot can fund a new account.",
+  },
+  {
+    title: "Add a trustline if needed",
+    body: "Non-XLM receive assets usually need a trustline. Approve the trustline transaction in your wallet when prompted.",
+  },
+  {
+    title: "Pick a pair and enter a small amount",
+    body: "Choose pay/receive assets, enter a modest size for your first live swap, and wait for the best-route quote.",
+  },
+  {
+    title: "Set slippage and review the route",
+    body: "Start near 0.5% slippage unless markets are moving quickly. Read high-impact warnings before confirming.",
+  },
+  {
+    title: "Confirm in your wallet",
+    body: "Review amounts in the wallet prompt, sign, then track status in the app. StellarRoute never holds your keys.",
+  },
+] as const;
+
+export default function FirstSwapGuidePage() {
+  return (
+    <main className="min-h-[calc(100vh-80px)] px-4 py-10 sm:px-6 lg:px-8">
+      <div className="container mx-auto max-w-3xl space-y-8">
+        <header className="space-y-3">
+          <p className="text-sm font-medium uppercase text-muted-foreground">
+            User guide
+          </p>
+          <h1 className="text-3xl font-extrabold tracking-tight sm:text-4xl">
+            Your first live swap
+          </h1>
+          <p className="max-w-2xl text-lg text-muted-foreground">
+            A short path for traders: wallet → trustline → quote → slippage →
+            confirm. For the full annotated write-up, see the repository guide.
+          </p>
+          <div className="flex flex-wrap gap-3 pt-1">
+            <Link
+              href="/swap"
+              className="inline-flex h-10 items-center rounded-md bg-primary px-4 text-sm font-medium text-primary-foreground hover:bg-primary/90 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              Open swap
+            </Link>
+            <a
+              href="https://github.com/StellarRoute/StellarRoute/blob/main/docs/user-guide-first-live-swap.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex h-10 items-center gap-1.5 rounded-md border px-4 text-sm font-medium hover:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
+            >
+              Full guide on GitHub
+              <ExternalLink className="h-3.5 w-3.5" aria-hidden="true" />
+            </a>
+          </div>
+        </header>
+
+        <ol className="space-y-4">
+          {steps.map((step, index) => (
+            <li
+              key={step.title}
+              className="rounded-xl border bg-card p-5 text-card-foreground"
+            >
+              <p className="text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+                Step {index + 1}
+              </p>
+              <h2 className="mt-1 text-lg font-semibold">{step.title}</h2>
+              <p className="mt-2 text-sm leading-6 text-muted-foreground">
+                {step.body}
+              </p>
+            </li>
+          ))}
+        </ol>
+
+        <aside className="rounded-xl border border-dashed p-5 text-sm text-muted-foreground">
+          <p className="font-medium text-foreground">Before you confirm</p>
+          <p className="mt-2 leading-6">
+            Aggregated routes can still slip, fail, or traverse multiple hops.
+            Read the{" "}
+            <a
+              href="https://github.com/StellarRoute/StellarRoute/blob/main/docs/risk-disclosure.md"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="font-medium text-foreground underline-offset-4 hover:underline"
+            >
+              risk disclosure
+            </a>{" "}
+            and start with a small amount. Press{" "}
+            <kbd className="rounded border bg-muted px-1.5 py-0.5 font-mono text-xs">
+              ?
+            </kbd>{" "}
+            on the swap card anytime for shortcuts and a link back here.
+          </p>
+        </aside>
+      </div>
+    </main>
+  );
+}

--- a/frontend/app/sitemap.ts
+++ b/frontend/app/sitemap.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from "next";
 
 const DEFAULT_SITE_URL = "https://stellarroute.app";
 
-const PUBLIC_MARKETING_ROUTES = ["/", "/swap", "/orderbook", "/status"] as const;
+const PUBLIC_MARKETING_ROUTES = ["/", "/swap", "/orderbook", "/status", "/guide", "/docs"] as const;
 
 function getSiteUrl(): string {
   const configured = process.env.NEXT_PUBLIC_SITE_URL?.trim();

--- a/frontend/components/swap/OnboardingChecklist.test.tsx
+++ b/frontend/components/swap/OnboardingChecklist.test.tsx
@@ -41,6 +41,12 @@ describe("OnboardingChecklist", () => {
     expect(screen.getByLabelText(/connect your wallet \(completed\)/i)).toBeInTheDocument();
   });
 
+  it("links to the first swap guide from the checklist", () => {
+    render(<OnboardingChecklist />);
+    const guideLink = screen.getByRole("link", { name: /first swap guide/i });
+    expect(guideLink).toHaveAttribute("href", "/guide");
+  });
+
   it("has accessible section label", () => {
     render(<OnboardingChecklist />);
     expect(screen.getByRole("region", { name: /getting started checklist/i })).toBeInTheDocument();

--- a/frontend/components/swap/OnboardingChecklist.tsx
+++ b/frontend/components/swap/OnboardingChecklist.tsx
@@ -1,8 +1,10 @@
 "use client";
 
 import { useRef } from "react";
+import Link from "next/link";
 import { X, Check } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { ROUTES } from "@/lib/constants";
 import {
   ONBOARDING_STEPS,
   useOnboardingChecklist,
@@ -81,14 +83,22 @@ export function OnboardingChecklist({ completedSteps = [] }: OnboardingChecklist
         })}
       </ol>
 
-      <Button
-        variant="ghost"
-        size="sm"
-        className="mt-3 w-full text-xs text-muted-foreground"
-        onClick={dismiss}
-      >
-        Skip — I know what I&apos;m doing
-      </Button>
+      <div className="mt-3 flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+        <Link
+          href={ROUTES.GUIDE}
+          className="text-xs font-medium text-primary underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 rounded-sm"
+        >
+          First swap guide — wallet, trustline, slippage
+        </Link>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="text-xs text-muted-foreground"
+          onClick={dismiss}
+        >
+          Skip — I know what I&apos;m doing
+        </Button>
+      </div>
     </section>
   );
 }

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -1383,6 +1383,16 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
               <kbd className="font-mono">Alt+2</kbd>
             </li>
           </ul>
+          <p className="mt-4 text-sm text-muted-foreground">
+            New here?{" "}
+            <a
+              href="/guide"
+              className="font-medium text-foreground underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring rounded-sm"
+            >
+              First live swap guide
+            </a>
+            {" "}(wallet, trustline, slippage).
+          </p>
           <IconographyLegend embedded className="mt-4" />
         </DialogContent>
       </Dialog>

--- a/frontend/lib/constants.ts
+++ b/frontend/lib/constants.ts
@@ -45,4 +45,7 @@ export const STELLAR_NETWORK =
 export const ROUTES = {
   HOME: '/',
   SWAP: '/swap',
+  GUIDE: '/guide',
+  DOCS: '/docs',
+  STATUS: '/status',
 } as const;


### PR DESCRIPTION
## Summary
- Adds `docs/user-guide-first-live-swap.md` with annotated first-swap steps (wallet, trustline, slippage, confirm).
- Adds in-app `/guide` page and links from swap onboarding, keyboard help drawer (`?`), docs hub, sitemap, and empty-state spec.

## Test plan
- [x] `ls docs` includes `user-guide-first-live-swap.md`
- [x] `npm --prefix frontend run test -- components/swap/OnboardingChecklist.test.tsx`
- [x] ESLint on touched frontend files
- [ ] CI green on this PR

Closes #1021