### PR TITLE
 [frontend] Support Albedo or additional wallet for broader live users

### DIFF
--- a/docs/development/wallet-integration.md
+++ b/docs/development/wallet-integration.md
@@ -4,7 +4,7 @@ This guide explains how StellarRoute's frontend integrates Stellar wallets, incl
 
 ## Supported wallets
 
-StellarRoute currently recognizes two browser wallet extensions:
+StellarRoute currently recognizes three browser wallets/signers:
 
 - **Freighter**
   - Detected via `@stellar/freighter-api`.
@@ -15,7 +15,12 @@ StellarRoute currently recognizes two browser wallet extensions:
 - **xBull**
   - Detected by checking `window.xbull` in the browser.
   - Connects via `window.xbull.connect()` and returns `publicKey`.
-  - Current implementation only supports connection. Transaction signing for xBull is not implemented today.
+  - Supports signing via `window.xbull.sign({ xdr, network, publicKey })`.
+
+- **Albedo**
+  - Detected as a browser-hosted intent wallet; uses `window.albedo` if injected and otherwise loads the Albedo intent UMD client on demand.
+  - Connects via the Albedo `public_key` intent and reads `pubkey`/`publicKey`.
+  - Supports signing via the Albedo `tx` intent and reads `signed_envelope_xdr`/`signedXdr`/`xdr`.
 
 ## Detection logic
 
@@ -24,6 +29,7 @@ Wallet availability is managed in `frontend/lib/wallet/index.ts`.
 - `getAvailableWallets()` returns an array of supported wallet objects.
 - Freighter is reported installed if `isAllowed()` returns `true`.
 - xBull is reported installed when a global `window.xbull` object exists.
+- Albedo is reported available in browser environments because it can open the hosted intent flow without requiring an extension.
 
 This list powers UI state in `frontend/components/shared/wallet-button.tsx` and the `WalletProvider`.
 
@@ -107,7 +113,8 @@ The default hook behavior uses stubs:
 Real wallet signing is handled by `frontend/lib/wallet/signTransactionWithWallet()`.
 
 - Freighter: supported via `@stellar/freighter-api` and returns a signed XDR.
-- xBull: currently not implemented for signing.
+- xBull: supported through `window.xbull.sign()`.
+- Albedo: supported through the hosted `tx` intent.
 
 A new adapter should implement signing in `signTransactionWithWallet()` and wire it into swap flows.
 
@@ -141,7 +148,7 @@ If these differ, UI components such as network mismatch banners can warn the use
 ### Wallet network handling
 
 - Freighter reports the wallet network via `getNetworkDetails()`.
-- xBull currently returns a hardcoded `testnet` network in this implementation.
+- xBull and Albedo currently use the app network fallback for session state; capability checks only allow Albedo on testnet/public and xBull on testnet.
 
 ### Local development configuration
 
@@ -154,13 +161,14 @@ NEXT_PUBLIC_API_URL=http://localhost:8080
 
 The wallet adapter itself does not use this env var, but backend/network alignment is still required for valid swaps.
 
-## Testing locally with Freighter and xBull
+## Testing locally with Freighter, xBull, and Albedo
 
 ### Recommended setup
 
 1. Install the browser extension:
    - Freighter: https://www.freighter.app/
    - xBull: https://wallet.xbull.app/
+   - Albedo: https://albedo.link/
 2. Open the app at `http://localhost:3000`.
 3. Unlock the wallet extension and grant site access.
 4. Connect using the wallet button in the UI.
@@ -170,6 +178,7 @@ The wallet adapter itself does not use this env var, but backend/network alignme
 - If no wallet is detected, the UI shows `No supported wallet found`.
 - Freighter requires site access and may prompt for permission approval.
 - xBull must expose `window.xbull` before it appears as available.
+- Albedo may open a popup/hosted intent window for account selection and signing.
 
 ### Debugging
 
@@ -218,8 +227,8 @@ To add a new wallet:
 
 ## Known limitations and UX expectations
 
-- **xBull signing is not implemented** in the current adapter. xBull can connect, but swap submission may not be functional until signing is wired in.
-- **Freighter is the only wallet with full signing support** today.
+- **xBull and Albedo signing are implemented** in the current adapters; swap submission still depends on the shared Horizon submission path.
+- **Freighter, xBull, and Albedo have signing support** today.
 - **Network mismatch** is detected and surfaced, but the app currently defaults to `testnet`.
 - **Wallet state is stored in localStorage**, so stale sessions can persist across tabs or reloads.
 - **Pending transactions lock wallet switching** to prevent mid-flight state changes.

--- a/frontend/docs/wallet-production-readiness.md
+++ b/frontend/docs/wallet-production-readiness.md
@@ -1,4 +1,3 @@
-import { signTransactionWithWallet } from "@/lib/wallet";
 # Wallet Production Readiness Runbook
 
 This document maps every wallet-related code path to its current status — **stub / test-only** vs **production-ready** — and provides a Phase B on-chain swap checklist for contributors landing real signing support.
@@ -7,24 +6,25 @@ This document maps every wallet-related code path to its current status — **st
 
 ## 1. Feature Matrix
 
-| Feature | Entry point | Status | Notes |
-|---|---|---|---|
-| **Connect (Freighter)** | `connectWallet("freighter")` in `lib/wallet/index.ts` | ✅ Production ready | Calls `requestAccess()` + `getAddress()` + `getNetworkDetails()` from `@stellar/freighter-api` |
-| **Connect (xBull)** | `connectWallet("xbull")` in `lib/wallet/index.ts` | ✅ Production ready | Reads `window.xbull.connect()` — requires xBull extension installed |
-| **Detect installed wallets** | `getAvailableWallets()` in `lib/wallet/index.ts` | ✅ Production ready | Freighter: `isAllowed()` API; xBull: `window.xbull` presence check |
-| **View address** | `getAddress()` (Freighter) / `connect().publicKey` (xBull) | ✅ Production ready | Called during `connectWallet` and `refreshWalletSession` |
-| **View network** | `getNetworkDetails()` (Freighter) / hardcoded `"testnet"` (xBull) | ⚠️ Partial | xBull always returns `"testnet"` — needs real network detection for mainnet |
-| **Sign transaction** | `signTransactionWithWallet(xdr, walletId)` in `lib/wallet/index.ts` | ✅ Production ready | Freighter: `signTransaction()`; xBull: `window.xbull.sign()` |
-| **Sign transaction stub** | `signTransactionWithWallet(xdr)` in `lib/wallet/index.ts` | 🔴 Stub only | Returns `{ ok: false }` — used in tests and out-of-scope flows. **Never call in production.** |
-| **Spendable balance** | `useWalletBalance` in `hooks/useWalletBalance.ts` | ✅ Production ready | Fetches `GET /accounts/{address}` from Horizon; native spendable balance subtracts `XLM_FEE_RESERVE`; consumed by `SwapCard` for balance display, loading/error states, and MAX |
-| **Auto-reconnect** | `WalletProvider` effect in `wallet-provider.tsx` | ✅ Production ready | Reads `stellarroute.wallet.lastWalletId` from `localStorage`, respects `autoReconnectPreferred` flag |
-| **Reconnect on focus/online** | `WalletProvider` window event listeners | ✅ Production ready | Throttled to 5 s to avoid hammering the wallet extension |
-| **Network mismatch detection** | `networkMismatch` in `WalletProvider` | ✅ Production ready | Compares app `network` state with `walletNetwork` returned by wallet |
-| **Capability check** | `refreshCapabilities()` / `checkWalletCapabilities()` | ⚠️ Mock | `refreshCapabilities` in the provider sets `{ statuses: [] }` — wire to `checkWalletCapabilities` from `lib/wallet/index.ts` for Phase B |
-| **Account switch detection** | `accountSwitchState` in `WalletProvider` | ✅ Production ready | Detects address change after `refreshAccount()` |
-| **Sync mismatch / resync** | `syncMismatch` + `resyncWallet()` in `WalletProvider` | ✅ Production ready | Calls `refreshAccount()` and clears the mismatch flag |
-| **Transaction lifecycle** | `useTransactionLifecycle` hook | ⚠️ Partial | Signs via `signTransactionWithWallet` but submit path (`submit.ts`) does not broadcast to Horizon yet — see Phase B checklist |
-| **Transaction broadcast** | `lib/wallet/submit.ts` | 🔴 Stub | `submitTransaction` is scaffolded but does not POST to Horizon. Phase B task. |
+| Feature                        | Entry point                                                                         | Status              | Notes                                                                                                                                                                           |
+| ------------------------------ | ----------------------------------------------------------------------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Connect (Freighter)**        | `connectWallet("freighter")` in `lib/wallet/index.ts`                               | ✅ Production ready | Calls `requestAccess()` + `getAddress()` + `getNetworkDetails()` from `@stellar/freighter-api`                                                                                  |
+| **Connect (xBull)**            | `connectWallet("xbull")` in `lib/wallet/index.ts`                                   | ✅ Production ready | Reads `window.xbull.connect()` — requires xBull extension installed                                                                                                             |
+| **Connect (Albedo)**           | `connectWallet("albedo")` in `lib/wallet/index.ts`                                  | ✅ Production ready | Uses the Albedo `public_key` intent through `window.albedo` or the hosted intent client                                                                                         |
+| **Detect installed wallets**   | `getAvailableWallets()` in `lib/wallet/index.ts`                                    | ✅ Production ready | Freighter: `isAllowed()` API; xBull: `window.xbull` presence check; Albedo: browser-hosted intent client                                                                        |
+| **View address**               | `getAddress()` (Freighter) / `connect().publicKey` (xBull) / `publicKey()` (Albedo) | ✅ Production ready | Called during `connectWallet` and `refreshWalletSession`                                                                                                                        |
+| **View network**               | `getNetworkDetails()` (Freighter) / app network fallback (xBull, Albedo)            | ⚠️ Partial          | xBull and Albedo do not expose passive network checks in this adapter; app network fallback is used for session state                                                           |
+| **Sign transaction**           | `signTransactionWithWallet(xdr, walletId)` in `lib/wallet/index.ts`                 | ✅ Production ready | Freighter: `signTransaction()`; xBull: `window.xbull.sign()`; Albedo: `tx` intent returning signed envelope XDR                                                                 |
+| **Sign transaction stub**      | `signTransactionStub(xdr)` in `lib/wallet/index.ts`                                 | 🔴 Stub only        | Returns `{ ok: false }` — used in tests and out-of-scope flows. **Never call in production.**                                                                                   |
+| **Spendable balance**          | `useWalletBalance` in `hooks/useWalletBalance.ts`                                   | ✅ Production ready | Fetches `GET /accounts/{address}` from Horizon; native spendable balance subtracts `XLM_FEE_RESERVE`; consumed by `SwapCard` for balance display, loading/error states, and MAX |
+| **Auto-reconnect**             | `WalletProvider` effect in `wallet-provider.tsx`                                    | ✅ Production ready | Reads `stellarroute.wallet.lastWalletId` from `localStorage`, respects `autoReconnectPreferred` flag                                                                            |
+| **Reconnect on focus/online**  | `WalletProvider` window event listeners                                             | ✅ Production ready | Throttled to 5 s to avoid hammering the wallet extension                                                                                                                        |
+| **Network mismatch detection** | `networkMismatch` in `WalletProvider`                                               | ✅ Production ready | Compares app `network` state with `walletNetwork` returned by wallet                                                                                                            |
+| **Capability check**           | `refreshCapabilities()` / `checkWalletCapabilities()`                               | ⚠️ Mock             | `refreshCapabilities` in the provider sets `{ statuses: [] }` — wire to `checkWalletCapabilities` from `lib/wallet/index.ts` for Phase B                                        |
+| **Account switch detection**   | `accountSwitchState` in `WalletProvider`                                            | ✅ Production ready | Detects address change after `refreshAccount()`                                                                                                                                 |
+| **Sync mismatch / resync**     | `syncMismatch` + `resyncWallet()` in `WalletProvider`                               | ✅ Production ready | Calls `refreshAccount()` and clears the mismatch flag                                                                                                                           |
+| **Transaction lifecycle**      | `useTransactionLifecycle` hook                                                      | ⚠️ Partial          | Signs via `signTransactionWithWallet` but submit path (`submit.ts`) does not broadcast to Horizon yet — see Phase B checklist                                                   |
+| **Transaction broadcast**      | `lib/wallet/submit.ts`                                                              | 🔴 Stub             | `submitTransaction` is scaffolded but does not POST to Horizon. Phase B task.                                                                                                   |
 
 ---
 
@@ -32,18 +32,18 @@ This document maps every wallet-related code path to its current status — **st
 
 ### 🔴 Stubs (must be replaced before mainnet)
 
-| Symbol | File | What it does | Replace with |
-|---|---|---|---|
-| `signTransactionWithWallet` | `lib/wallet/index.ts` | Echoes XDR back, `ok: false` | Remove call sites; always use `signTransactionWithWallet` |
-| `submitTransaction` (stub body) | `lib/wallet/submit.ts` | Not yet posting to Horizon | POST XDR to `https://horizon.stellar.org/transactions` (or testnet equivalent) |
-| `refreshCapabilities` mock | `components/providers/wallet-provider.tsx` | Sets empty `statuses: []` | Call `checkWalletCapabilities(walletId, network)` from `lib/wallet/index.ts` |
+| Symbol                          | File                                       | What it does                 | Replace with                                                                   |
+| ------------------------------- | ------------------------------------------ | ---------------------------- | ------------------------------------------------------------------------------ |
+| `signTransactionStub`           | `lib/wallet/index.ts`                      | Echoes XDR back, `ok: false` | Remove production call sites; always use `signTransactionWithWallet`           |
+| `submitTransaction` (stub body) | `lib/wallet/submit.ts`                     | Not yet posting to Horizon   | POST XDR to `https://horizon.stellar.org/transactions` (or testnet equivalent) |
+| `refreshCapabilities` mock      | `components/providers/wallet-provider.tsx` | Sets empty `statuses: []`    | Call `checkWalletCapabilities(walletId, network)` from `lib/wallet/index.ts`   |
 
 ### ⚠️ Partial implementations
 
-| Path | Gap | Action needed |
-|---|---|---|
-| xBull network detection | Always returns `"testnet"` | Implement `window.xbull.getNetwork()` or equivalent; update `connectWallet` and `refreshWalletSession` |
-| Transaction lifecycle submit step | `useTransactionLifecycle` calls sign but not broadcast | Wire the signed XDR into `submitTransaction` once it POSTs to Horizon |
+| Path                              | Gap                                                               | Action needed                                                                                               |
+| --------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| xBull/Albedo network detection    | Uses app network fallback instead of passive wallet network reads | Implement wallet-specific network APIs if exposed; keep capability checks constrained to supported networks |
+| Transaction lifecycle submit step | `useTransactionLifecycle` calls sign but not broadcast            | Wire the signed XDR into `submitTransaction` once it POSTs to Horizon                                       |
 
 ---
 
@@ -54,7 +54,7 @@ Before enabling real on-chain swaps (Phase B):
 - [x] **Replace `stubSpendableBalance`** — `useWalletBalance` fetches live balance from Horizon `accounts/{address}`; native MAX subtracts fee reserve (future: `buying_liabilities` / `selling_liabilities` for trustline holds)
 - [ ] **Implement `submitTransaction`** in `lib/wallet/submit.ts` — POST signed XDR to Horizon `/transactions`; handle `400 tx_bad_auth`, `400 op_underfunded`, and network timeouts
 - [ ] **Wire `refreshCapabilities`** in `WalletProvider` — replace mock with `checkWalletCapabilities(walletId, network)` so `WalletCapabilitiesBanner` reflects real status
-- [ ] **Fix xBull network detection** — replace hardcoded `"testnet"` with a real API call so `networkMismatch` works on mainnet
+- [ ] **Fix xBull/Albedo passive network detection** — replace app network fallback with real wallet API calls if available so `networkMismatch` works independently of app settings
 - [ ] **Remove all `signTransactionWithWallet` call sites** — search for `signTransactionWithWallet` and ensure only `signTransactionWithWallet` is used in non-test code
 - [ ] **Validate network passphrase mapping** — ensure `networkPassphrase` passed to `signTransaction` matches Stellar's canonical values (`Test SDF Network ; September 2015` / `Public Global Stellar Network ; September 2015`)
 - [ ] **Test Freighter + xBull on testnet end-to-end** — confirm sign → broadcast → Horizon confirmation flow with real wallets
@@ -62,7 +62,7 @@ Before enabling real on-chain swaps (Phase B):
 
 ---
 
-## 4. Freighter and xBull Integration Patterns
+## 4. Freighter, xBull, and Albedo Integration Patterns
 
 ### Freighter
 
@@ -89,6 +89,20 @@ const { publicKey } = await xbull.connect();
 const signedXdr = await xbull.sign({ xdr, network: 'testnet' });
 ```
 
+### Albedo
+
+Albedo works through hosted intents. The adapter uses an already injected `window.albedo` client when present and otherwise loads the official UMD intent client on demand.
+
+```ts
+const albedo = window.albedo;
+const { pubkey } = await albedo.publicKey();
+const { signed_envelope_xdr } = await albedo.tx({
+  xdr,
+  network: 'testnet',
+  pubkey,
+});
+```
+
 ---
 
 ## 5. References
@@ -103,4 +117,4 @@ const signedXdr = await xbull.sign({ xdr, network: 'testnet' });
 
 ---
 
-*This document is referenced from [CONTRIBUTING.md](../../CONTRIBUTING.md) and [docs/development/SETUP.md](SETUP.md).*
+_This document is referenced from [CONTRIBUTING.md](../../CONTRIBUTING.md) and [docs/development/SETUP.md](SETUP.md)._

--- a/frontend/lib/wallet/index.test.ts
+++ b/frontend/lib/wallet/index.test.ts
@@ -1,11 +1,123 @@
-import { signTransactionWithWallet } from "@/lib/wallet";
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
-import { signTransactionWithWallet, checkWalletCapabilities } from './index';
+import {
+  checkWalletCapabilities,
+  connectWallet,
+  getAvailableWallets,
+  refreshWalletSession,
+  signTransactionWithWallet,
+} from './index';
 
 const TEST_PASSPHRASE = 'Test SDF Network ; September 2015';
+const PUBLIC_PASSPHRASE = 'Public Global Stellar Network ; September 2015';
 const MOCK_PUBLIC_KEY =
   'GABC123DEFGHIJKLMNOPQRSTUVWXYZ456789ABCDEFGHIJKLMNOPQRSTUVWXYZ';
 const MOCK_XDR = 'AAAAAgAAAABmockTransactionXdrBase64';
+
+describe('wallet availability', () => {
+  it('includes Albedo as a browser-hosted intent wallet', async () => {
+    const wallets = await getAvailableWallets();
+    const albedo = wallets.find((wallet) => wallet.id === 'albedo');
+
+    expect(albedo).toEqual({
+      id: 'albedo',
+      label: 'Albedo',
+      installed: true,
+    });
+  });
+});
+
+describe('connectWallet - Albedo', () => {
+  const mockPublicKey = vi.fn();
+
+  beforeEach(() => {
+    mockPublicKey.mockReset();
+    window.albedo = {
+      publicKey: mockPublicKey,
+      tx: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    delete window.albedo;
+  });
+
+  it('connects with the public key intent', async () => {
+    mockPublicKey.mockResolvedValue({ pubkey: MOCK_PUBLIC_KEY });
+
+    const session = await connectWallet('albedo');
+
+    expect(session).toMatchObject({
+      walletId: 'albedo',
+      address: MOCK_PUBLIC_KEY,
+      network: 'testnet',
+      isConnected: true,
+    });
+    expect(mockPublicKey).toHaveBeenCalledOnce();
+  });
+
+  it('refreshes via the same public key intent', async () => {
+    mockPublicKey.mockResolvedValue({ publicKey: MOCK_PUBLIC_KEY });
+
+    const session = await refreshWalletSession('albedo');
+
+    expect(session.address).toBe(MOCK_PUBLIC_KEY);
+    expect(mockPublicKey).toHaveBeenCalledOnce();
+  });
+});
+
+describe('signTransactionWithWallet - Albedo', () => {
+  const mockTx = vi.fn();
+
+  beforeEach(() => {
+    mockTx.mockReset();
+    window.albedo = {
+      publicKey: vi.fn(),
+      tx: mockTx,
+    };
+  });
+
+  afterEach(() => {
+    delete window.albedo;
+  });
+
+  it('returns signed XDR on testnet with public key', async () => {
+    mockTx.mockResolvedValue({ signed_envelope_xdr: 'signed_xdr' });
+
+    const result = await signTransactionWithWallet(
+      MOCK_XDR,
+      'albedo',
+      TEST_PASSPHRASE,
+      MOCK_PUBLIC_KEY
+    );
+
+    expect(result).toBe('signed_xdr');
+    expect(mockTx).toHaveBeenCalledWith({
+      xdr: MOCK_XDR,
+      network: 'testnet',
+      pubkey: MOCK_PUBLIC_KEY,
+    });
+  });
+
+  it('maps public network passphrase to Albedo public network', async () => {
+    mockTx.mockResolvedValue({ xdr: 'signed_public_xdr' });
+
+    await signTransactionWithWallet(MOCK_XDR, 'albedo', PUBLIC_PASSPHRASE);
+
+    expect(mockTx).toHaveBeenCalledWith({
+      xdr: MOCK_XDR,
+      network: 'public',
+      pubkey: undefined,
+    });
+  });
+
+  it('throws user-facing message when user cancels', async () => {
+    mockTx.mockRejectedValue(new Error('User rejected transaction'));
+
+    await expect(
+      signTransactionWithWallet(MOCK_XDR, 'albedo', TEST_PASSPHRASE)
+    ).rejects.toThrow('User declined transaction signing');
+  });
+});
 
 describe('signTransactionWithWallet - xBull', () => {
   const mockSign = vi.fn();
@@ -83,5 +195,27 @@ describe('checkWalletCapabilities - xBull', () => {
     expect(signCap?.allowed).toBe(true);
     expect(signCap?.reason).toBeUndefined();
     expect(signCap?.resolution).toBeUndefined();
+  });
+});
+
+describe('checkWalletCapabilities - Albedo', () => {
+  it('allows sign_transaction on mainnet', async () => {
+    const caps = await checkWalletCapabilities('albedo', 'mainnet');
+    const signCap = caps.statuses.find(
+      (s) => s.capability === 'sign_transaction'
+    );
+
+    expect(signCap?.allowed).toBe(true);
+    expect(signCap?.reason).toBeUndefined();
+  });
+
+  it('denies unsupported networks with a resolution', async () => {
+    const caps = await checkWalletCapabilities('albedo', 'futurenet');
+    const signCap = caps.statuses.find(
+      (s) => s.capability === 'sign_transaction'
+    );
+
+    expect(signCap?.allowed).toBe(false);
+    expect(signCap?.resolution).toBe('Switch app to testnet or mainnet');
   });
 });

--- a/frontend/lib/wallet/index.ts
+++ b/frontend/lib/wallet/index.ts
@@ -4,13 +4,85 @@ import {
   getNetworkDetails,
   isAllowed,
   signTransaction,
-} from "@stellar/freighter-api";
+} from '@stellar/freighter-api';
 
-import type { AvailableWallet, SupportedWallet, WalletSession, Capabilities, Capability, CapabilityStatus } from "./types";
+import type {
+  AvailableWallet,
+  SupportedWallet,
+  WalletSession,
+  Capabilities,
+  Capability,
+  CapabilityStatus,
+} from './types';
+
+type AlbedoClient = {
+  publicKey: () => Promise<{ pubkey?: string; publicKey?: string }>;
+  tx: (opts: { xdr: string; network?: string; pubkey?: string }) => Promise<{
+    signed_envelope_xdr?: string;
+    signedXdr?: string;
+    xdr?: string;
+  }>;
+};
+
+declare global {
+  interface Window {
+    albedo?: AlbedoClient;
+  }
+}
+
+const ALBEDO_INTENT_SCRIPT_URL =
+  'https://unpkg.com/@albedo-link/intent/lib/albedo.intent.js';
+
+let albedoScriptPromise: Promise<AlbedoClient> | null = null;
+
+function getWindowRecord(): Record<string, unknown> | null {
+  return typeof window === 'undefined'
+    ? null
+    : (window as unknown as Record<string, unknown>);
+}
+
+function getInjectedAlbedo(): AlbedoClient | null {
+  if (typeof window === 'undefined') return null;
+  return window.albedo ?? null;
+}
+
+async function getAlbedoClient(): Promise<AlbedoClient> {
+  const injected = getInjectedAlbedo();
+  if (injected) return injected;
+
+  if (typeof document === 'undefined') {
+    throw new Error('Albedo requires a browser environment');
+  }
+
+  if (!albedoScriptPromise) {
+    albedoScriptPromise = new Promise((resolve, reject) => {
+      const script = document.createElement('script');
+      script.src = ALBEDO_INTENT_SCRIPT_URL;
+      script.async = true;
+      script.onload = () => {
+        const client = getInjectedAlbedo();
+        if (client) resolve(client);
+        else reject(new Error('Albedo intent client failed to initialize'));
+      };
+      script.onerror = () =>
+        reject(new Error('Failed to load Albedo intent client'));
+      document.head.appendChild(script);
+    });
+  }
+
+  return albedoScriptPromise;
+}
+
+function networkPassphraseToAlbedoNetwork(networkPassphrase?: string): string {
+  return networkPassphrase?.includes('Public Global Stellar Network')
+    ? 'public'
+    : 'testnet';
+}
 
 export const WALLET_LABELS: Record<SupportedWallet, string> = {
-  freighter: "Freighter",
-  xbull: "xBull",
+  freighter: 'Freighter',
+  xbull: 'xBull',
+  albedo: 'Albedo',
 };
 
 export async function getAvailableWallets(): Promise<AvailableWallet[]> {
@@ -20,19 +92,25 @@ export async function getAvailableWallets(): Promise<AvailableWallet[]> {
   try {
     const res = await isAllowed();
     wallets.push({
-      id: "freighter",
-      label: "Freighter",
+      id: 'freighter',
+      label: 'Freighter',
       installed: res.isAllowed,
     });
   } catch {
-    wallets.push({ id: "freighter", label: "Freighter", installed: false });
+    wallets.push({ id: 'freighter', label: 'Freighter', installed: false });
   }
 
   // xBull — detected via window.xbull
   const xbullInstalled =
-    typeof window !== "undefined" &&
-    !!(window as unknown as Record<string, unknown>).xbull;
-  wallets.push({ id: "xbull", label: "xBull", installed: xbullInstalled });
+    typeof window !== 'undefined' && !!(getWindowRecord() ?? {}).xbull;
+  wallets.push({ id: 'xbull', label: 'xBull', installed: xbullInstalled });
+
+  // Albedo works as a hosted intent wallet and may also inject window.albedo.
+  wallets.push({
+    id: 'albedo',
+    label: 'Albedo',
+    installed: typeof window !== 'undefined',
+  });
 
   return wallets;
 }
@@ -40,21 +118,21 @@ export async function getAvailableWallets(): Promise<AvailableWallet[]> {
 export async function connectWallet(
   walletId: SupportedWallet
 ): Promise<WalletSession> {
-  if (walletId === "freighter") {
+  if (walletId === 'freighter') {
     const access = await requestAccess();
 
     if (access.error) {
-      throw new Error(access.error.message ?? "Freighter access denied");
+      throw new Error(access.error.message ?? 'Freighter access denied');
     }
 
     const addressRes = await getAddress();
     if (addressRes.error) {
-      throw new Error(addressRes.error.message ?? "Failed to get address");
+      throw new Error(addressRes.error.message ?? 'Failed to get address');
     }
 
     const networkRes = await getNetworkDetails();
     if (networkRes.error) {
-      throw new Error(networkRes.error.message ?? "Failed to get network");
+      throw new Error(networkRes.error.message ?? 'Failed to get network');
     }
 
     return {
@@ -65,13 +143,13 @@ export async function connectWallet(
     };
   }
 
-  if (walletId === "xbull") {
-    const xbull = (window as unknown as Record<string, unknown>).xbull as
+  if (walletId === 'xbull') {
+    const xbull = (getWindowRecord() ?? {}).xbull as
       | { connect: () => Promise<{ publicKey: string }> }
       | undefined;
 
     if (!xbull) {
-      throw new Error("xBull not installed");
+      throw new Error('xBull not installed');
     }
 
     const result = await xbull.connect();
@@ -83,19 +161,36 @@ export async function connectWallet(
     };
   }
 
+  if (walletId === 'albedo') {
+    const albedo = await getAlbedoClient();
+    const result = await albedo.publicKey();
+    const address = result.pubkey ?? result.publicKey;
+
+    if (!address) {
+      throw new Error('Albedo did not return a public key');
+    }
+
+    return {
+      walletId,
+      address,
+      network: process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet',
+      isConnected: true,
+    };
+  }
+
   throw new Error(`Unsupported wallet: ${walletId}`);
 }
 
 function getCapabilityResolution(capability: Capability): string {
   switch (capability) {
-    case "sign_transaction":
-      return "Allow transaction signing in your wallet settings";
-    case "view_address":
-      return "Allow account access in your wallet settings";
-    case "view_network":
-      return "Switch to the matching network in your wallet";
-    case "request_access":
-      return "Reconnect your wallet to grant access";
+    case 'sign_transaction':
+      return 'Allow transaction signing in your wallet settings';
+    case 'view_address':
+      return 'Allow account access in your wallet settings';
+    case 'view_network':
+      return 'Switch to the matching network in your wallet';
+    case 'request_access':
+      return 'Reconnect your wallet to grant access';
   }
 }
 
@@ -105,21 +200,23 @@ export async function checkWalletCapabilities(
 ): Promise<Capabilities> {
   const statuses: CapabilityStatus[] = [];
 
-  if (walletId === "freighter") {
+  if (walletId === 'freighter') {
     try {
       const accessRes = await requestAccess();
       statuses.push({
-        capability: "request_access",
+        capability: 'request_access',
         allowed: !accessRes.error,
         reason: accessRes.error?.message,
-        resolution: accessRes.error ? getCapabilityResolution("request_access") : undefined,
+        resolution: accessRes.error
+          ? getCapabilityResolution('request_access')
+          : undefined,
       });
     } catch (e) {
       statuses.push({
-        capability: "request_access",
+        capability: 'request_access',
         allowed: false,
-        reason: "Failed to check wallet access",
-        resolution: getCapabilityResolution("request_access"),
+        reason: 'Failed to check wallet access',
+        resolution: getCapabilityResolution('request_access'),
       });
     }
 
@@ -127,17 +224,19 @@ export async function checkWalletCapabilities(
       const addressRes = await getAddress();
       const hasAddress = !addressRes.error && !!addressRes.address;
       statuses.push({
-        capability: "view_address",
+        capability: 'view_address',
         allowed: hasAddress,
         reason: addressRes.error?.message,
-        resolution: hasAddress ? undefined : getCapabilityResolution("view_address"),
+        resolution: hasAddress
+          ? undefined
+          : getCapabilityResolution('view_address'),
       });
     } catch (e) {
       statuses.push({
-        capability: "view_address",
+        capability: 'view_address',
         allowed: false,
-        reason: "Failed to get address",
-        resolution: getCapabilityResolution("view_address"),
+        reason: 'Failed to get address',
+        resolution: getCapabilityResolution('view_address'),
       });
     }
 
@@ -146,54 +245,82 @@ export async function checkWalletCapabilities(
       const hasNetwork = !networkRes.error && !!networkRes.network;
       const networkMatch = hasNetwork && networkRes.network === network;
       statuses.push({
-        capability: "view_network",
+        capability: 'view_network',
         allowed: networkMatch,
-        reason: networkMatch ? undefined : `Wallet on ${networkRes.network}, expected ${network}`,
-        resolution: networkMatch ? undefined : "Switch wallet network to match the app",
+        reason: networkMatch
+          ? undefined
+          : `Wallet on ${networkRes.network}, expected ${network}`,
+        resolution: networkMatch
+          ? undefined
+          : 'Switch wallet network to match the app',
       });
     } catch (e) {
       statuses.push({
-        capability: "view_network",
+        capability: 'view_network',
         allowed: false,
-        reason: "Failed to get network details",
-        resolution: getCapabilityResolution("view_network"),
+        reason: 'Failed to get network details',
+        resolution: getCapabilityResolution('view_network'),
       });
     }
 
-    const signCap = statuses.find((s) => s.capability === "view_address");
-    const netCap = statuses.find((s) => s.capability === "view_network");
+    const signCap = statuses.find((s) => s.capability === 'view_address');
+    const netCap = statuses.find((s) => s.capability === 'view_network');
     statuses.push({
-      capability: "sign_transaction",
+      capability: 'sign_transaction',
       allowed: Boolean(signCap?.allowed && netCap?.allowed),
       reason: !signCap?.allowed
-        ? "No address available"
+        ? 'No address available'
         : !netCap?.allowed
-          ? "Network mismatch"
+          ? 'Network mismatch'
           : undefined,
-      resolution: !signCap?.allowed || !netCap?.allowed
-        ? getCapabilityResolution("sign_transaction")
-        : undefined,
+      resolution:
+        !signCap?.allowed || !netCap?.allowed
+          ? getCapabilityResolution('sign_transaction')
+          : undefined,
     });
-  } else if (walletId === "xbull") {
+  } else if (walletId === 'xbull') {
     statuses.push({
-      capability: "request_access",
+      capability: 'request_access',
       allowed: true,
     });
     statuses.push({
-      capability: "view_address",
+      capability: 'view_address',
       allowed: true,
     });
     statuses.push({
-      capability: "view_network",
+      capability: 'view_network',
       allowed: true,
-      reason: network === "testnet" ? undefined : "xBull only supports testnet",
-      resolution: network !== "testnet" ? "Switch app to testnet" : undefined,
+      reason: network === 'testnet' ? undefined : 'xBull only supports testnet',
+      resolution: network !== 'testnet' ? 'Switch app to testnet' : undefined,
     });
     statuses.push({
-      capability: "sign_transaction",
-      allowed: network === "testnet",
-      reason: network === "testnet" ? undefined : "xBull only supports testnet",
-      resolution: network !== "testnet" ? "Switch app to testnet" : undefined,
+      capability: 'sign_transaction',
+      allowed: network === 'testnet',
+      reason: network === 'testnet' ? undefined : 'xBull only supports testnet',
+      resolution: network !== 'testnet' ? 'Switch app to testnet' : undefined,
+    });
+  } else if (walletId === 'albedo') {
+    const supportedNetwork =
+      network === 'testnet' || network === 'mainnet' || network === 'public';
+    statuses.push({ capability: 'request_access', allowed: true });
+    statuses.push({ capability: 'view_address', allowed: true });
+    statuses.push({
+      capability: 'view_network',
+      allowed: supportedNetwork,
+      reason: supportedNetwork
+        ? undefined
+        : `Albedo supports testnet/public, expected ${network}`,
+      resolution: supportedNetwork
+        ? undefined
+        : 'Switch app to testnet or mainnet',
+    });
+    statuses.push({
+      capability: 'sign_transaction',
+      allowed: supportedNetwork,
+      reason: supportedNetwork ? undefined : 'Unsupported Albedo network',
+      resolution: supportedNetwork
+        ? undefined
+        : 'Switch app to testnet or mainnet',
     });
   }
 
@@ -215,16 +342,16 @@ export function disconnectWallet(): WalletSession {
 function normalizeWalletSignError(message: string): string {
   const lower = message.toLowerCase();
   if (
-    lower.includes("user declined") ||
-    lower.includes("declined access") ||
-    lower.includes("signing denied") ||
-    lower.includes("user rejected") ||
-    lower.includes("transaction was rejected") ||
-    lower.includes("cancel") ||
-    lower.includes("reject") ||
-    lower.includes("denied")
+    lower.includes('user declined') ||
+    lower.includes('declined access') ||
+    lower.includes('signing denied') ||
+    lower.includes('user rejected') ||
+    lower.includes('transaction was rejected') ||
+    lower.includes('cancel') ||
+    lower.includes('reject') ||
+    lower.includes('denied')
   ) {
-    return "User declined transaction signing";
+    return 'User declined transaction signing';
   }
   return message;
 }
@@ -235,36 +362,62 @@ export async function signTransactionWithWallet(
   networkPassphrase?: string,
   publicKey?: string
 ): Promise<string> {
-  if (walletId === "freighter") {
+  if (walletId === 'freighter') {
     const res = await signTransaction(xdr, { networkPassphrase });
     if (res.error) {
       throw new Error(
-        normalizeWalletSignError(res.error.message ?? "Transaction signing failed")
+        normalizeWalletSignError(
+          res.error.message ?? 'Transaction signing failed'
+        )
       );
     }
     return res.signedTxXdr;
   }
 
-  if (walletId === "xbull") {
-    const xbull = (window as unknown as Record<string, unknown>).xbull as
-      | { sign: (opts: { xdr: string; network?: string; publicKey?: string }) => Promise<string> }
+  if (walletId === 'xbull') {
+    const xbull = (getWindowRecord() ?? {}).xbull as
+      | {
+          sign: (opts: {
+            xdr: string;
+            network?: string;
+            publicKey?: string;
+          }) => Promise<string>;
+        }
       | undefined;
 
     if (!xbull) {
-      throw new Error("xBull not installed");
+      throw new Error('xBull not installed');
     }
 
     // Determine network based on passphrase (heuristic used by wallets)
-    const network = networkPassphrase?.includes("Test SDF Network")
-      ? "testnet"
-      : "public";
+    const network = networkPassphrase?.includes('Test SDF Network')
+      ? 'testnet'
+      : 'public';
 
     try {
       const signedXdr = await xbull.sign({ xdr, network, publicKey });
       return signedXdr;
     } catch (err: unknown) {
       const message =
-        err instanceof Error ? err.message : "Transaction signing failed";
+        err instanceof Error ? err.message : 'Transaction signing failed';
+      throw new Error(normalizeWalletSignError(message));
+    }
+  }
+
+  if (walletId === 'albedo') {
+    const albedo = await getAlbedoClient();
+    const network = networkPassphraseToAlbedoNetwork(networkPassphrase);
+
+    try {
+      const res = await albedo.tx({ xdr, network, pubkey: publicKey });
+      const signedXdr = res.signed_envelope_xdr ?? res.signedXdr ?? res.xdr;
+      if (!signedXdr) {
+        throw new Error('Albedo did not return a signed XDR');
+      }
+      return signedXdr;
+    } catch (err: unknown) {
+      const message =
+        err instanceof Error ? err.message : 'Transaction signing failed';
       throw new Error(normalizeWalletSignError(message));
     }
   }
@@ -276,7 +429,7 @@ export async function signTransactionWithWallet(
 export async function signTransactionStub(xdr: string) {
   return {
     ok: false,
-    message: "Signing stub only (out of scope)",
+    message: 'Signing stub only (out of scope)',
     xdr,
   };
 }
@@ -289,14 +442,14 @@ export async function checkAddressChange(
   if (!currentAddress) return null;
 
   try {
-    if (walletId === "freighter") {
+    if (walletId === 'freighter') {
       const addressRes = await getAddress();
       if (addressRes.error) return null;
       return addressRes.address !== currentAddress ? addressRes.address : null;
     }
 
-    if (walletId === "xbull") {
-      // xBull doesn't have a passive address check, would need to reconnect
+    if (walletId === 'xbull' || walletId === 'albedo') {
+      // xBull and Albedo do not expose a passive address check; reconnect instead.
       return null;
     }
   } catch {
@@ -310,15 +463,15 @@ export async function checkAddressChange(
 export async function refreshWalletSession(
   walletId: SupportedWallet
 ): Promise<WalletSession> {
-  if (walletId === "freighter") {
+  if (walletId === 'freighter') {
     const addressRes = await getAddress();
     if (addressRes.error) {
-      throw new Error(addressRes.error.message ?? "Failed to get address");
+      throw new Error(addressRes.error.message ?? 'Failed to get address');
     }
 
     const networkRes = await getNetworkDetails();
     if (networkRes.error) {
-      throw new Error(networkRes.error.message ?? "Failed to get network");
+      throw new Error(networkRes.error.message ?? 'Failed to get network');
     }
 
     return {
@@ -329,19 +482,36 @@ export async function refreshWalletSession(
     };
   }
 
-  if (walletId === "xbull") {
-    const xbull = (window as unknown as Record<string, unknown>).xbull as
+  if (walletId === 'xbull') {
+    const xbull = (getWindowRecord() ?? {}).xbull as
       | { connect: () => Promise<{ publicKey: string }> }
       | undefined;
 
     if (!xbull) {
-      throw new Error("xBull not installed");
+      throw new Error('xBull not installed');
     }
 
     const result = await xbull.connect();
     return {
       walletId,
       address: result.publicKey,
+      network: process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet',
+      isConnected: true,
+    };
+  }
+
+  if (walletId === 'albedo') {
+    const albedo = await getAlbedoClient();
+    const result = await albedo.publicKey();
+    const address = result.pubkey ?? result.publicKey;
+
+    if (!address) {
+      throw new Error('Albedo did not return a public key');
+    }
+
+    return {
+      walletId,
+      address,
       network: process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet',
       isConnected: true,
     };

--- a/frontend/lib/wallet/types.ts
+++ b/frontend/lib/wallet/types.ts
@@ -1,6 +1,6 @@
-export type SupportedWallet = "freighter" | "xbull";
+export type SupportedWallet = 'freighter' | 'xbull' | 'albedo';
 
-export type WalletNetwork = "testnet" | "mainnet" | "futurenet" | string;
+export type WalletNetwork = 'testnet' | 'mainnet' | 'futurenet' | string;
 
 export type WalletSession = {
   walletId: SupportedWallet | null;
@@ -27,10 +27,10 @@ export type AccountSwitchState = {
 };
 
 export type Capability =
-  | "sign_transaction"
-  | "view_address"
-  | "view_network"
-  | "request_access";
+  | 'sign_transaction'
+  | 'view_address'
+  | 'view_network'
+  | 'request_access';
 
 export type CapabilityStatus = {
   capability: Capability;


### PR DESCRIPTION
close #1027 

Motivation
Broaden frontend wallet coverage by adding Albedo so users beyond Freighter/xBull can connect and sign transactions.
Provide a production-ready detect/connect/sign path and update the wallet readiness documentation and integration guide.

Description
Add albedo to SupportedWallet, update WALLET_LABELS, and include Albedo in getAvailableWallets() detection.
Implement a lightweight Albedo adapter: getAlbedoClient() (loads hosted intent UMD when needed), connectWallet('albedo'), refreshWalletSession('albedo'), and signTransactionWithWallet(..., 'albedo') which maps passphrases to Albedo networks and returns signed XDR.
Extend capability checks and passive address-check behavior to include Albedo in checkWalletCapabilities() and checkAddressChange() fallbacks.
Add/modify unit tests in frontend/lib/wallet/index.test.ts covering Albedo detect/connect/refresh/sign/capability flows and update developer docs frontend/docs/wallet-production-readiness.md and docs/development/wallet-integration.md to document Albedo support and remaining network-detection notes.

Testing
Ran the frontend wallet test suite with npm --prefix frontend run test -- wallet, and all wallet-related tests passed (Test Files 10 passed, Tests 118 passed).
Existing wallet unit tests for Freighter/xBull were preserved and executed as part of the run.