### PR TITLE
feat: swap a11y announcements, SDK release/swap helpers, AMM ingestio…

### DIFF
--- a/crates/indexer/tests/amm_ingest.rs
+++ b/crates/indexer/tests/amm_ingest.rs
@@ -1,0 +1,231 @@
+//! Proof that the AMM loop actually ingests reserves for registered testnet pools.
+//!
+//! This is an operator/CI verification test, not a unit test: it drives the real
+//! [`AmmAggregator`] against a live Soroban **testnet** RPC and a real Postgres
+//! database, then asserts that at least one row in `amm_pool_reserves` has
+//! positive reserves with an `updated_at` newer than the moment the test started.
+//!
+//! It is `#[ignore]`d by default because it needs network + DB. Run it manually or
+//! from a nightly CI job:
+//!
+//! ```bash
+//! export DATABASE_URL=postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarroute
+//! export ROUTER_CONTRACT_ADDRESS=C...        # required
+//! export SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+//! cargo test -p stellarroute-indexer amm_ingest -- --ignored --nocapture
+//! ```
+//!
+//! Tunables (all optional):
+//!
+//! | Env var | Default | Meaning |
+//! | --- | --- | --- |
+//! | `AMM_INGEST_TIMEOUT_SECS` | `600` (10 min) | Give up after this long |
+//! | `AMM_INGEST_POLL_SECS` | `15` | Delay between aggregation cycles |
+//!
+//! Mainnet is refused outright — this test must never be pointed at production.
+
+use std::time::{Duration, Instant};
+
+use sqlx::Row;
+use stellarroute_indexer::amm::{AmmAggregator, AmmConfig};
+use stellarroute_indexer::config::{HorizonMode, IndexerConfig};
+use stellarroute_indexer::db::Database;
+use stellarroute_indexer::soroban::{SorobanRpcClient, SorobanRpcConfig, StellarNetwork};
+
+const DEFAULT_TIMEOUT_SECS: u64 = 600;
+const DEFAULT_POLL_SECS: u64 = 15;
+
+fn env_or(name: &str, default: &str) -> String {
+    std::env::var(name).unwrap_or_else(|_| default.to_string())
+}
+
+fn env_u64(name: &str, default: u64) -> u64 {
+    std::env::var(name)
+        .ok()
+        .and_then(|value| value.parse().ok())
+        .unwrap_or(default)
+}
+
+/// Reject anything that looks like mainnet. The acceptance criteria are explicit
+/// that this proof must not require — or touch — production.
+fn assert_not_mainnet(rpc_url: &str) {
+    let lowered = rpc_url.to_lowercase();
+    let looks_like_mainnet = lowered.contains("mainnet")
+        || lowered.contains("soroban-rpc.stellar.org")
+        || (lowered.contains("public") && !lowered.contains("testnet"));
+
+    assert!(
+        !looks_like_mainnet,
+        "refusing to run AMM ingestion proof against what looks like mainnet: {rpc_url}\n\
+         Point SOROBAN_RPC_URL at testnet (https://soroban-testnet.stellar.org) or a local RPC."
+    );
+}
+
+fn test_config(database_url: String, soroban_rpc_url: String, router: String) -> IndexerConfig {
+    IndexerConfig {
+        stellar_horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+        horizon_mode: HorizonMode::Poll,
+        soroban_rpc_url,
+        router_contract_address: router,
+        database_url,
+        poll_interval_secs: 5,
+        amm_poll_interval_secs: 30,
+        stale_threshold_secs: 300,
+        horizon_limit: 200,
+        max_connections: 5,
+        min_connections: 1,
+        connection_timeout_secs: 30,
+        idle_timeout_secs: 600,
+        max_lifetime_secs: 1800,
+        maintenance_interval_mins: 60,
+        snapshot_retention_days: 90,
+        snapshot_compaction_hours: 24,
+        partition_count: 4,
+        hot_pair_allowlist: String::new(),
+        hot_pair_volume_threshold: 1_000_000_000,
+        hot_pair_window_secs: 300,
+        partition_id: 0,
+    }
+}
+
+/// Every pool currently tracked in `amm_pool_reserves`, for failure diagnostics.
+async fn tracked_pools(db: &Database) -> Vec<String> {
+    sqlx::query("SELECT pool_address FROM amm_pool_reserves ORDER BY pool_address")
+        .fetch_all(db.pool())
+        .await
+        .map(|rows| {
+            rows.iter()
+                .map(|row| row.get::<String, _>("pool_address"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Returns `(pool_address, updated_at)` for the first pool with positive reserves
+/// refreshed after `started_at`.
+async fn freshly_ingested_pool(
+    db: &Database,
+    started_at: chrono::DateTime<chrono::Utc>,
+) -> Option<(String, chrono::DateTime<chrono::Utc>)> {
+    sqlx::query(
+        "SELECT pool_address, updated_at
+           FROM amm_pool_reserves
+          WHERE reserve_selling > 0
+            AND reserve_buying > 0
+            AND updated_at > $1
+          ORDER BY updated_at DESC
+          LIMIT 1",
+    )
+    .bind(started_at)
+    .fetch_optional(db.pool())
+    .await
+    .ok()
+    .flatten()
+    .map(|row| {
+        (
+            row.get::<String, _>("pool_address"),
+            row.get::<chrono::DateTime<chrono::Utc>, _>("updated_at"),
+        )
+    })
+}
+
+#[tokio::test]
+#[ignore = "requires testnet Soroban RPC, a router contract address, and a live database"]
+async fn amm_ingest_populates_reserves_for_registered_pools() {
+    let database_url = env_or(
+        "DATABASE_URL",
+        "postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarroute",
+    );
+    let soroban_rpc_url = env_or("SOROBAN_RPC_URL", "https://soroban-testnet.stellar.org");
+    let router = std::env::var("ROUTER_CONTRACT_ADDRESS").expect(
+        "ROUTER_CONTRACT_ADDRESS must be set — this test proves ingestion for a *registered* router",
+    );
+
+    assert_not_mainnet(&soroban_rpc_url);
+
+    let timeout = Duration::from_secs(env_u64("AMM_INGEST_TIMEOUT_SECS", DEFAULT_TIMEOUT_SECS));
+    let poll = Duration::from_secs(env_u64("AMM_INGEST_POLL_SECS", DEFAULT_POLL_SECS));
+
+    let config = test_config(database_url, soroban_rpc_url.clone(), router.clone());
+    let db = Database::new(&config).await.expect("database connect");
+    db.migrate().await.expect("migrations applied");
+
+    // Anchor on the database clock, not the test host's, so skew cannot produce a
+    // false pass.
+    let started_at: chrono::DateTime<chrono::Utc> = sqlx::query("SELECT now() AS now")
+        .fetch_one(db.pool())
+        .await
+        .expect("read database clock")
+        .get("now");
+
+    let soroban = SorobanRpcClient::new(SorobanRpcConfig {
+        base_url: soroban_rpc_url.clone(),
+        ..SorobanRpcConfig::for_network(StellarNetwork::Testnet)
+    })
+    .expect("soroban rpc client");
+
+    let aggregator = AmmAggregator::new(
+        AmmConfig {
+            router_contract: router.clone(),
+            ..Default::default()
+        },
+        db.clone(),
+        soroban,
+    );
+
+    println!(
+        "amm_ingest: router={router} rpc={soroban_rpc_url} timeout={}s poll={}s start={started_at}",
+        timeout.as_secs(),
+        poll.as_secs(),
+    );
+
+    let deadline = Instant::now() + timeout;
+    let mut last_rpc_error: Option<String> = None;
+    let mut cycles = 0u32;
+
+    loop {
+        cycles += 1;
+        match aggregator.aggregate_once().await {
+            Ok(()) => println!("amm_ingest: cycle {cycles} completed"),
+            Err(e) => {
+                println!("amm_ingest: cycle {cycles} failed: {e}");
+                last_rpc_error = Some(e.to_string());
+            }
+        }
+
+        if let Some((pool, updated_at)) = freshly_ingested_pool(&db, started_at).await {
+            println!(
+                "amm_ingest: PASS — pool {pool} has fresh reserves (updated_at={updated_at}) after {cycles} cycle(s)"
+            );
+            return;
+        }
+
+        if Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(poll).await;
+    }
+
+    let pools = tracked_pools(&db).await;
+    let pools_checked = if pools.is_empty() {
+        "<none — no rows in amm_pool_reserves>".to_string()
+    } else {
+        pools.join(", ")
+    };
+
+    panic!(
+        "AMM ingestion proof FAILED after {timeout_secs}s ({cycles} cycles).\n\
+         No pool in `amm_pool_reserves` has positive reserves with updated_at > {started_at}.\n\
+         \n\
+         router contract: {router}\n\
+         soroban rpc:     {soroban_rpc_url}\n\
+         pools checked:   {pools_checked}\n\
+         last RPC error:  {last_error}\n\
+         \n\
+         Likely causes: the router has no registered pools, discovery never reached the \
+         pool-registration ledger, or the RPC rejected the getEvents/simulateTransaction calls.",
+        timeout_secs = timeout.as_secs(),
+        last_error =
+            last_rpc_error.unwrap_or_else(|| "<none — all RPC calls succeeded>".to_string()),
+    );
+}

--- a/crates/sdk-rust/src/client.rs
+++ b/crates/sdk-rust/src/client.rs
@@ -28,6 +28,7 @@ use crate::{
     types::{
         BatchQuoteRequest, BatchQuoteResponse, ErrorResponse, HealthResponse, OrderbookResponse,
         PairsResponse, QuoteRequest, QuoteResponse, RoutesRequest, RoutesResponse,
+        SwapPrepareRequest, SwapPrepareResponse, SwapSubmitRequest, SwapSubmitResponse,
     },
 };
 
@@ -207,7 +208,7 @@ impl StellarRouteClient {
     /// ```no_run
     /// use stellarroute_sdk::{Client, RoutesRequest};
     ///
-    /// # async fn example() -> Result<(), stellarroute_sdk::ApiError> {
+    /// # async fn example() -> stellarroute_sdk::Result<()> {
     /// let client = Client::new("https://api.stellarroute.io")?;
     /// let response = client.routes(RoutesRequest {
     ///     base: "native",
@@ -232,7 +233,10 @@ impl StellarRouteClient {
         let quote_type = request.quote_type.map(|value| value.to_string());
 
         self.execute_with_retry(|| {
-            let mut req = self.http.get(base_url.clone()).query(&[("amount", amount.as_str())]);
+            let mut req = self
+                .http
+                .get(base_url.clone())
+                .query(&[("amount", amount.as_str())]);
             if let Some(ref slippage_bps) = slippage_bps {
                 req = req.query(&[("slippage_bps", slippage_bps.as_str())]);
             }
@@ -250,6 +254,76 @@ impl StellarRouteClient {
     /// request item is malformed or the batch is too large.
     pub async fn batch_quote(&self, request: BatchQuoteRequest) -> Result<BatchQuoteResponse> {
         let url = self.url("api/v1/batch/quote")?;
+        self.execute_with_retry(|| self.http.post(url.clone()).json(&request))
+            .await
+    }
+
+    /// `POST /api/v1/swap/prepare` — build an unsigned swap transaction.
+    ///
+    /// The server validates the route and returns a base64 XDR envelope. Sign it
+    /// with your own keys (the SDK never sees them), then hand it to
+    /// [`submit_swap`](Self::submit_swap).
+    ///
+    /// Returns [`SdkError::Api`] with [`ApiErrorCode::NoRoute`] when the path is no
+    /// longer executable, or [`ApiErrorCode::ValidationError`] for a malformed request.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use stellarroute_sdk::{Client, RoutesRequest, SwapPrepareRequest};
+    ///
+    /// # async fn example() -> stellarroute_sdk::Result<()> {
+    /// let client = Client::new("https://api.stellarroute.io")?;
+    ///
+    /// let routes = client.routes(RoutesRequest {
+    ///     base: "native",
+    ///     quote: "USDC",
+    ///     amount: 1_000_000,
+    ///     slippage_bps: Some(50),
+    ///     quote_type: None,
+    /// }).await?;
+    ///
+    /// let best = routes.routes.first().expect("at least one route");
+    /// let prepared = client
+    ///     .prepare_swap(SwapPrepareRequest::from_route(best, "100", "GABC...").slippage_bps(50))
+    ///     .await?;
+    ///
+    /// println!("sign this envelope: {}", prepared.xdr_envelope);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn prepare_swap(&self, request: SwapPrepareRequest) -> Result<SwapPrepareResponse> {
+        let url = self.url("api/v1/swap/prepare")?;
+        self.execute_with_retry(|| self.http.post(url.clone()).json(&request))
+            .await
+    }
+
+    /// `POST /api/v1/swap/submit` — broadcast a signed swap transaction.
+    ///
+    /// Takes the signed envelope produced from
+    /// [`prepare_swap`](Self::prepare_swap) and returns the transaction hash plus
+    /// submission status.
+    ///
+    /// Returns [`SdkError::Api`] with [`ApiErrorCode::ValidationError`] when the
+    /// envelope is malformed, unsigned, or has expired.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use stellarroute_sdk::{Client, SwapSubmitRequest};
+    ///
+    /// # async fn example(signed_xdr: String) -> stellarroute_sdk::Result<()> {
+    /// let client = Client::new("https://api.stellarroute.io")?;
+    ///
+    /// let receipt = client.submit_swap(SwapSubmitRequest::new(signed_xdr)).await?;
+    /// if receipt.is_success() {
+    ///     println!("swap confirmed in tx {}", receipt.tx_hash);
+    /// }
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn submit_swap(&self, request: SwapSubmitRequest) -> Result<SwapSubmitResponse> {
+        let url = self.url("api/v1/swap/submit")?;
         self.execute_with_retry(|| self.http.post(url.clone()).json(&request))
             .await
     }
@@ -301,18 +375,22 @@ impl StellarRouteClient {
 
             if !status.is_success() {
                 // SURFACE: ApiErrorCode::NoRoute — documented in OpenAPI as error_code "NO_ROUTE" on empty candidate set
-                if status == reqwest::StatusCode::NOT_FOUND
-                    || serde_json::from_str::<serde_json::Value>(&body)
-                        .ok()
-                        .and_then(|value| value.get("error_code").and_then(serde_json::Value::as_str))
-                        .map(|code| code.eq_ignore_ascii_case("NO_ROUTE"))
-                        .unwrap_or(false)
-                    || serde_json::from_str::<serde_json::Value>(&body)
-                        .ok()
-                        .and_then(|value| value.get("error").and_then(serde_json::Value::as_str))
-                        .map(|code| code.eq_ignore_ascii_case("no_route"))
-                        .unwrap_or(false)
-                {
+                let parsed_body = serde_json::from_str::<serde_json::Value>(&body).ok();
+                let body_error_code = parsed_body.as_ref().and_then(|value| {
+                    value
+                        .get("error_code")
+                        .or_else(|| value.get("error"))
+                        .and_then(serde_json::Value::as_str)
+                });
+
+                // A body that names its own error code wins; a bare 404 with no
+                // usable body is treated as "no route" for the routing endpoints.
+                let is_no_route = match body_error_code {
+                    Some(code) => code.eq_ignore_ascii_case("no_route"),
+                    None => status == reqwest::StatusCode::NOT_FOUND,
+                };
+
+                if is_no_route {
                     let message = serde_json::from_str::<ErrorResponse>(&body)
                         .map(|err| err.message)
                         .unwrap_or_else(|_| "No route found".to_string());
@@ -360,8 +438,8 @@ fn encode_path_segment(segment: &str) -> String {
     segment
         .bytes()
         .map(|byte| {
-            if (byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~')) {
-                byte as char
+            if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~') {
+                (byte as char).to_string()
             } else {
                 format!("%{:02X}", byte)
             }

--- a/crates/sdk-rust/src/lib.rs
+++ b/crates/sdk-rust/src/lib.rs
@@ -33,5 +33,5 @@ pub use error::{ApiErrorCode, RateLimitInfo, Result, SdkError};
 pub use types::{
     AssetInfo, HealthResponse, OrderbookLevel, OrderbookResponse, PairsResponse, PathStep,
     QuoteRequest, QuoteResponse, QuoteType, Route, RouteHop, RoutesRequest, RoutesResponse,
-    TradingPair,
+    SwapPrepareRequest, SwapPrepareResponse, SwapSubmitRequest, SwapSubmitResponse, TradingPair,
 };

--- a/crates/sdk-rust/src/types.rs
+++ b/crates/sdk-rust/src/types.rs
@@ -333,6 +333,107 @@ pub struct BatchQuoteRequest {
     pub quotes: Vec<QuoteRequestItem>,
 }
 
+// ── Swap execution ────────────────────────────────────────────────────────────
+
+/// Parameters for `POST /api/v1/swap/prepare`.
+///
+/// Prepare validates the route server-side and returns an unsigned Stellar XDR
+/// envelope. Signing happens on the caller's side — the SDK never handles keys.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwapPrepareRequest {
+    /// Ordered hops to execute, normally taken from [`Route::path`].
+    pub path: Vec<RouteHop>,
+    /// Input amount as a decimal string.
+    pub amount: String,
+    /// G-address of the account submitting the swap.
+    pub sender: String,
+    /// Minimum acceptable output as a decimal string.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub min_output: Option<String>,
+    /// Slippage tolerance in basis points (server default: 50).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub slippage_bps: Option<u32>,
+}
+
+impl SwapPrepareRequest {
+    /// Build a prepare request from a ranked [`Route`].
+    pub fn from_route(route: &Route, amount: impl Into<String>, sender: impl Into<String>) -> Self {
+        Self {
+            path: route.path.clone(),
+            amount: amount.into(),
+            sender: sender.into(),
+            min_output: None,
+            slippage_bps: None,
+        }
+    }
+
+    /// Set the slippage tolerance in basis points.
+    pub fn slippage_bps(mut self, bps: u32) -> Self {
+        self.slippage_bps = Some(bps);
+        self
+    }
+
+    /// Set the minimum acceptable output amount.
+    pub fn min_output(mut self, min_output: impl Into<String>) -> Self {
+        self.min_output = Some(min_output.into());
+        self
+    }
+}
+
+/// Response from `POST /api/v1/swap/prepare`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwapPrepareResponse {
+    /// Base64-encoded unsigned Stellar XDR transaction envelope.
+    pub xdr_envelope: String,
+    /// Simulated output amount for the prepared route.
+    #[serde(default)]
+    pub estimated_output: String,
+    /// Minimum output enforced by the built transaction.
+    #[serde(default)]
+    pub min_output: String,
+    /// Ledger sequence after which the envelope is no longer valid.
+    #[serde(default)]
+    pub valid_until_ledger: Option<u64>,
+}
+
+/// Parameters for `POST /api/v1/swap/submit`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwapSubmitRequest {
+    /// Base64-encoded **signed** Stellar XDR transaction envelope.
+    pub signed_xdr: String,
+}
+
+impl SwapSubmitRequest {
+    /// Wrap a signed XDR envelope for submission.
+    pub fn new(signed_xdr: impl Into<String>) -> Self {
+        Self {
+            signed_xdr: signed_xdr.into(),
+        }
+    }
+}
+
+/// Response from `POST /api/v1/swap/submit`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SwapSubmitResponse {
+    /// Stellar transaction hash.
+    pub tx_hash: String,
+    /// Submission status: `"pending"`, `"success"`, or `"failed"`.
+    pub status: String,
+    /// Realized output amount, present once the transaction is finalized.
+    #[serde(default)]
+    pub output_amount: Option<String>,
+    /// Ledger the transaction was included in, when known.
+    #[serde(default)]
+    pub ledger: Option<u64>,
+}
+
+impl SwapSubmitResponse {
+    /// Returns `true` when the network has confirmed the swap.
+    pub fn is_success(&self) -> bool {
+        self.status == "success"
+    }
+}
+
 // ── Internal error response ───────────────────────────────────────────────────
 
 /// Wire format of the API error body — used internally by the client.

--- a/crates/sdk-rust/tests/client_integration.rs
+++ b/crates/sdk-rust/tests/client_integration.rs
@@ -126,16 +126,12 @@ async fn orderbook_returns_bids_and_asks() {
             },
             "bids": [{ "price": "0.1050000", "amount": "500.0000000", "total": "52.5000000" }],
             "asks": [{ "price": "0.1060000", "amount": "300.0000000", "total": "31.8000000" }],
-<<<<<<< HEAD
             "summary": {
                 "bid": "0.1050000",
                 "ask": "0.1060000",
                 "spread_bps": 95,
                 "midpoint": "0.1055000"
             },
-=======
-            "summary": { "bid": "0.1050000", "ask": "0.1060000", "spread_bps": 9, "midpoint": "0.1055000" },
->>>>>>> origin/main
             "timestamp": 1740312000
         })))
         .mount(&server)
@@ -370,7 +366,13 @@ async fn routes_no_route_maps_to_no_route_error() {
         .await
         .unwrap_err();
 
-    assert!(matches!(err, SdkError::Api { code: ApiErrorCode::NoRoute, .. }));
+    assert!(matches!(
+        err,
+        SdkError::Api {
+            code: ApiErrorCode::NoRoute,
+            ..
+        }
+    ));
 }
 
 #[tokio::test]
@@ -415,12 +417,14 @@ async fn test_routes_no_route_returns_correct_error() {
         .await
         .expect_err("should return an error for unroutable pair");
 
-    assert_eq!(
-        err.code,
-        ApiErrorCode::NoRoute,
-        "expected NoRoute error code, got: {:?}",
-        err.code
-    );
+    match err {
+        SdkError::Api { code, .. } => assert_eq!(
+            code,
+            ApiErrorCode::NoRoute,
+            "expected NoRoute error code, got: {code:?}"
+        ),
+        other => panic!("expected API error, got: {other:?}"),
+    }
 }
 
 // ── Error handling ────────────────────────────────────────────────────────────

--- a/crates/sdk-rust/tests/swap_helpers.rs
+++ b/crates/sdk-rust/tests/swap_helpers.rs
@@ -1,0 +1,178 @@
+//! Unit tests for the swap prepare/submit helpers.
+//!
+//! HTTP is mocked with `wiremock` — no live API or network access required.
+//!
+//! Run with:
+//!   cargo test -p stellarroute-sdk swap
+
+use stellarroute_sdk::{
+    ApiErrorCode, ClientBuilder, Route, RouteHop, SdkError, SwapPrepareRequest, SwapSubmitRequest,
+};
+use wiremock::{
+    matchers::{body_partial_json, method, path},
+    Mock, MockServer, ResponseTemplate,
+};
+
+fn hop() -> RouteHop {
+    RouteHop {
+        from_asset: None,
+        to_asset: None,
+        price: "0.12".to_string(),
+        fee_bps: Some(30),
+        amount_out_of_hop: "98".to_string(),
+        source: "sdex".to_string(),
+    }
+}
+
+fn route() -> Route {
+    Route {
+        estimated_output: "98".to_string(),
+        impact_bps: 12,
+        score: 0.94,
+        policy_used: "best_output".to_string(),
+        path: vec![hop()],
+    }
+}
+
+#[tokio::test]
+async fn prepare_swap_returns_unsigned_envelope() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/swap/prepare"))
+        .and(body_partial_json(serde_json::json!({
+            "amount": "100",
+            "sender": "GABC",
+            "slippage_bps": 50,
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "xdr_envelope": "AAAAAgAAAAB...",
+            "estimated_output": "98.5",
+            "min_output": "98.0",
+            "valid_until_ledger": 1_234_567u64,
+        })))
+        .mount(&server)
+        .await;
+
+    let client = ClientBuilder::new(server.uri()).build().unwrap();
+    let prepared = client
+        .prepare_swap(SwapPrepareRequest::from_route(&route(), "100", "GABC").slippage_bps(50))
+        .await
+        .expect("prepare succeeds");
+
+    assert_eq!(prepared.xdr_envelope, "AAAAAgAAAAB...");
+    assert_eq!(prepared.estimated_output, "98.5");
+    assert_eq!(prepared.valid_until_ledger, Some(1_234_567));
+}
+
+#[tokio::test]
+async fn prepare_swap_maps_no_route_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/swap/prepare"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "error": "no_route",
+            "message": "Route is no longer executable",
+            "details": null,
+        })))
+        .mount(&server)
+        .await;
+
+    let client = ClientBuilder::new(server.uri()).build().unwrap();
+    let err = client
+        .prepare_swap(SwapPrepareRequest::from_route(&route(), "100", "GABC"))
+        .await
+        .expect_err("prepare fails");
+
+    match err {
+        SdkError::Api { code, status, .. } => {
+            assert_eq!(code, ApiErrorCode::NoRoute);
+            assert_eq!(status, 404);
+        }
+        other => panic!("expected API error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn submit_swap_returns_tx_receipt() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/swap/submit"))
+        .and(body_partial_json(serde_json::json!({
+            "signed_xdr": "c2lnbmVk",
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "tx_hash": "abc123",
+            "status": "success",
+            "output_amount": "98.4",
+            "ledger": 42u64,
+        })))
+        .mount(&server)
+        .await;
+
+    let client = ClientBuilder::new(server.uri()).build().unwrap();
+    let receipt = client
+        .submit_swap(SwapSubmitRequest::new("c2lnbmVk"))
+        .await
+        .expect("submit succeeds");
+
+    assert!(receipt.is_success());
+    assert_eq!(receipt.tx_hash, "abc123");
+    assert_eq!(receipt.output_amount.as_deref(), Some("98.4"));
+    assert_eq!(receipt.ledger, Some(42));
+}
+
+#[tokio::test]
+async fn submit_swap_maps_validation_error() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/swap/submit"))
+        .respond_with(ResponseTemplate::new(400).set_body_json(serde_json::json!({
+            "error": "validation_error",
+            "message": "Envelope is not signed",
+            "details": null,
+        })))
+        .mount(&server)
+        .await;
+
+    let client = ClientBuilder::new(server.uri()).build().unwrap();
+    let err = client
+        .submit_swap(SwapSubmitRequest::new("unsigned"))
+        .await
+        .expect_err("submit fails");
+
+    match err {
+        SdkError::Api { code, message, .. } => {
+            assert_eq!(code, ApiErrorCode::ValidationError);
+            assert_eq!(message, "Envelope is not signed");
+        }
+        other => panic!("expected API error, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn submit_swap_reports_pending_status() {
+    let server = MockServer::start().await;
+
+    Mock::given(method("POST"))
+        .and(path("/api/v1/swap/submit"))
+        .respond_with(ResponseTemplate::new(202).set_body_json(serde_json::json!({
+            "tx_hash": "pending123",
+            "status": "pending",
+        })))
+        .mount(&server)
+        .await;
+
+    let client = ClientBuilder::new(server.uri()).build().unwrap();
+    let receipt = client
+        .submit_swap(SwapSubmitRequest::new("c2lnbmVk"))
+        .await
+        .expect("submit accepted");
+
+    assert!(!receipt.is_success());
+    assert_eq!(receipt.status, "pending");
+    assert!(receipt.output_amount.is_none());
+}

--- a/docs/development/indexer-guide.md
+++ b/docs/development/indexer-guide.md
@@ -292,6 +292,50 @@ Remediation:
 3. Restart indexer if ingestion does not recover.
 4. Use reconciliation diagnostics for deeper drift analysis.
 
+## 7b. Verify AMM ingestion
+
+The queries above tell you *whether* reserves look stale. This test proves the AMM loop
+actually populates `amm_pool_reserves` end-to-end for a registered router on **testnet** —
+useful before declaring a router live, and as a nightly CI gate.
+
+It is `#[ignore]`d by default (it needs network + a live database) and refuses to run
+against anything that looks like mainnet.
+
+```bash
+export DATABASE_URL=postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarroute
+export ROUTER_CONTRACT_ADDRESS=C...                      # required — the router under test
+export SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+
+cargo test -p stellarroute-indexer amm_ingest -- --ignored --nocapture
+```
+
+Tunables:
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `AMM_INGEST_TIMEOUT_SECS` | `600` (10 min) | Give up after this long |
+| `AMM_INGEST_POLL_SECS` | `15` | Delay between aggregation cycles |
+
+**What it asserts.** It records the *database* clock at start (not the test host's, so
+clock skew cannot fake a pass), then runs `AmmAggregator::aggregate_once()` on a loop.
+It passes as soon as at least one row in `amm_pool_reserves` has `reserve_selling > 0`,
+`reserve_buying > 0`, and `updated_at` newer than that start timestamp.
+
+**On failure** it prints the router contract ID, the Soroban RPC URL, every pool address
+currently tracked in `amm_pool_reserves`, and the last error returned by the RPC — enough
+to tell "the router has no registered pools" apart from "the RPC is rejecting our calls".
+
+Typical causes of a failure:
+
+1. The router genuinely has no registered pools — check the registry fallback and
+   `PoolRegistered` events.
+2. Discovery never reached the ledger where pools were registered — inspect
+   `soroban_sync_cursors`.
+3. The RPC rejected `getEvents` / `simulateTransaction` — the printed last error will
+   carry the JSON-RPC code.
+
+Source: [`crates/indexer/tests/amm_ingest.rs`](../../crates/indexer/tests/amm_ingest.rs).
+
 ## 8. Health Verification Checklist
 
 After startup or incident recovery, verify:

--- a/docs/sdk-rust/README.md
+++ b/docs/sdk-rust/README.md
@@ -140,6 +140,60 @@ let quote = client
 println!("quote price: {}", quote.price);
 ```
 
+### Execute a swap (prepare → sign → submit)
+
+Backend integrators get the same two-step execution path as the JS SDK. The SDK never
+touches signing keys — `prepare_swap` returns an unsigned XDR envelope, you sign it with
+your own keypair, and `submit_swap` broadcasts it.
+
+```rust
+use stellarroute_sdk::{Client, RoutesRequest, SwapPrepareRequest, SwapSubmitRequest};
+
+# async fn run() -> stellarroute_sdk::Result<()> {
+let client = Client::new("https://api.stellarroute.io")?;
+
+// 1. Pick a route.
+let routes = client
+    .routes(RoutesRequest {
+        base: "native",
+        quote: "USDC",
+        amount: 1_000_000,
+        slippage_bps: Some(50),
+        quote_type: None,
+    })
+    .await?;
+let best = routes.routes.first().expect("at least one route");
+
+// 2. Prepare — server validates the path and returns an unsigned envelope.
+let prepared = client
+    .prepare_swap(
+        SwapPrepareRequest::from_route(best, "100", "GABC...")
+            .slippage_bps(50)
+            .min_output("98"),
+    )
+    .await?;
+
+// 3. Sign `prepared.xdr_envelope` with your own keypair, then submit.
+let signed_xdr = my_signer(&prepared.xdr_envelope);
+let receipt = client.submit_swap(SwapSubmitRequest::new(signed_xdr)).await?;
+
+if receipt.is_success() {
+    println!("swap confirmed: {}", receipt.tx_hash);
+}
+# Ok(())
+# }
+# fn my_signer(xdr: &str) -> String { xdr.to_string() }
+```
+
+Notes:
+
+- `SwapPrepareResponse::valid_until_ledger` bounds how long the envelope stays valid —
+  re-prepare rather than submitting a stale envelope.
+- `submit_swap` may return `status == "pending"`; poll or watch the tx hash on Horizon
+  before treating the swap as final.
+- `prepare_swap` surfaces `ApiErrorCode::NoRoute` when the path went stale between
+  `routes` and `prepare`, and `ApiErrorCode::ValidationError` for a malformed request.
+
 ## Error handling patterns
 
 The SDK returns `stellarroute_sdk::Result<T>` and `stellarroute_sdk::SdkError`.

--- a/frontend/components/swap/SwapStatusLiveRegion.test.tsx
+++ b/frontend/components/swap/SwapStatusLiveRegion.test.tsx
@@ -1,0 +1,62 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { SwapStatusLiveRegion } from './SwapStatusLiveRegion';
+
+describe('SwapStatusLiveRegion', () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it('announces pending politely', () => {
+    render(<SwapStatusLiveRegion status="pending" />);
+
+    const polite = screen.getByRole('status', { hidden: true });
+    expect(polite).toHaveAttribute('aria-live', 'polite');
+    expect(polite).toHaveTextContent('Swap submitted. Waiting for confirmation.');
+  });
+
+  it('announces finalized politely with detail', () => {
+    render(<SwapStatusLiveRegion status="finalized" detail="Transaction abc123." />);
+
+    expect(screen.getByRole('status', { hidden: true })).toHaveTextContent(
+      'Swap confirmed. Transaction abc123.',
+    );
+  });
+
+  it('announces errors assertively', () => {
+    render(<SwapStatusLiveRegion status="error" detail="Slippage exceeded." />);
+
+    const alert = screen.getByRole('alert', { hidden: true });
+    expect(alert).toHaveAttribute('aria-live', 'assertive');
+    expect(alert).toHaveTextContent('Swap failed. Slippage exceeded.');
+  });
+
+  it('exposes a keyboard path to update the quote and confirm', async () => {
+    const user = userEvent.setup();
+    const onConfirm = vi.fn();
+    const onUpdateQuote = vi.fn();
+
+    render(
+      <SwapStatusLiveRegion status="error" onConfirm={onConfirm} onUpdateQuote={onUpdateQuote} />,
+    );
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: /update quote/i })).toHaveFocus();
+    await user.keyboard('{Enter}');
+    expect(onUpdateQuote).toHaveBeenCalledTimes(1);
+
+    await user.tab();
+    expect(screen.getByRole('button', { name: /confirm swap/i })).toHaveFocus();
+    await user.keyboard('{Enter}');
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('disables actions while a swap is pending', () => {
+    render(<SwapStatusLiveRegion status="pending" onConfirm={vi.fn()} onUpdateQuote={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /confirm swap/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: /update quote/i })).toBeDisabled();
+  });
+});

--- a/frontend/components/swap/SwapStatusLiveRegion.tsx
+++ b/frontend/components/swap/SwapStatusLiveRegion.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+export type SwapStatus = 'idle' | 'pending' | 'finalized' | 'error';
+
+export interface SwapStatusLiveRegionProps {
+  /** Current lifecycle state of the swap submission. */
+  status: SwapStatus;
+  /** Optional detail appended to the announcement (tx hash, error copy, rate). */
+  detail?: string | null;
+  /** Keyboard-reachable confirm action. Omitted when the swap is not confirmable. */
+  onConfirm?: () => void;
+  /** Keyboard-reachable quote refresh action. */
+  onUpdateQuote?: () => void;
+}
+
+/**
+ * Announces swap submission state to screen readers.
+ *
+ * `pending` and `finalized` are polite (`role="status"`) so they never interrupt
+ * the user mid-word; `error` is assertive (`role="alert"`) because it blocks the
+ * flow. Announcements never move focus — the confirm / update-quote controls stay
+ * in the natural tab order so a keyboard-only user can act on what they just heard.
+ */
+export function SwapStatusLiveRegion({
+  status,
+  detail,
+  onConfirm,
+  onUpdateQuote,
+}: SwapStatusLiveRegionProps) {
+  const suffix = detail ? ` ${detail}` : '';
+
+  const politeMessage =
+    status === 'pending'
+      ? `Swap submitted. Waiting for confirmation.${suffix}`
+      : status === 'finalized'
+        ? `Swap confirmed.${suffix}`
+        : '';
+
+  const assertiveMessage =
+    status === 'error' ? `Swap failed.${suffix} Update the quote and try again.` : '';
+
+  return (
+    <>
+      <div role="status" aria-live="polite" aria-atomic="true" className="sr-only">
+        {politeMessage}
+      </div>
+      <div role="alert" aria-live="assertive" aria-atomic="true" className="sr-only">
+        {assertiveMessage}
+      </div>
+
+      {(onUpdateQuote || onConfirm) && (
+        <div className="flex gap-2" aria-label="Swap actions" role="group">
+          {onUpdateQuote && (
+            <button
+              type="button"
+              onClick={onUpdateQuote}
+              aria-describedby="swap-status-hint"
+              disabled={status === 'pending'}
+            >
+              Update quote
+            </button>
+          )}
+          {onConfirm && (
+            <button
+              type="button"
+              onClick={onConfirm}
+              aria-describedby="swap-status-hint"
+              disabled={status === 'pending'}
+            >
+              Confirm swap
+            </button>
+          )}
+          <span id="swap-status-hint" className="sr-only">
+            Swap status: {status}
+          </span>
+        </div>
+      )}
+    </>
+  );
+}

--- a/frontend/components/swap/index.ts
+++ b/frontend/components/swap/index.ts
@@ -7,6 +7,9 @@ export type { TokenPairSelectorProps } from "./TokenPairSelector";
 export { SwapPresetTemplates } from "./SwapPresetTemplates";
 export type { SwapPresetTemplatesProps } from "./SwapPresetTemplates";
 
+export { SwapStatusLiveRegion } from "./SwapStatusLiveRegion";
+export type { SwapStatusLiveRegionProps, SwapStatus } from "./SwapStatusLiveRegion";
+
 export { QuoteStreamStatusIndicator } from "./QuoteStreamStatusIndicator";
 export type { QuoteStreamStatusIndicatorProps } from "./QuoteStreamStatusIndicator";
 

--- a/frontend/docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md
+++ b/frontend/docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md
@@ -60,11 +60,34 @@ Focus must remain on the control the user is editing (amount field, refresh butt
 2. Attempt to refresh the quote.
 3. **Pass**: Assertive failure mentioning offline/reconnect guidance.
 
+## Swap status announcements (issue #1007)
+
+`SwapStatusLiveRegion` covers the submission lifecycle after a quote is accepted.
+
+| Status | Region | Priority | Expected announcement |
+| --- | --- | --- | --- |
+| `pending` | `role="status"` | polite | “Swap submitted. Waiting for confirmation.” |
+| `finalized` | `role="status"` | polite | “Swap confirmed. {tx detail}” |
+| `error` | `role="alert"` | assertive | “Swap failed. {message} Update the quote and try again.” |
+
+### Test steps
+
+1. Open `/swap`, connect a wallet, and enter a valid amount.
+2. **Keyboard path**: without touching the mouse, `Tab` to **Update quote**, press `Enter`
+   (a fresh quote is fetched), then `Tab` to **Confirm swap** and press `Enter`.
+   **Pass**: both controls are reachable and activate on `Enter`/`Space`.
+3. While the transaction is in flight, **Pass**: a polite “Swap submitted…” is announced and
+   both action buttons report as *dimmed/unavailable*.
+4. On success, **Pass**: a polite “Swap confirmed…” is announced; focus has not moved.
+5. Force a failure (reject in wallet, or point the API at an unreachable host).
+   **Pass**: an assertive “Swap failed…” interrupts, and the **Update quote** control is
+   immediately reachable with a single `Tab` from where focus already sits.
+
 ## Automated coverage
 
 ```bash
 cd frontend
-npm test -- lib/quote-refresh-announcements.test.ts hooks/useQuoteRefreshAnnouncements.test.ts components/swap/QuoteRefreshLiveRegion.test.tsx
+npm test -- lib/quote-refresh-announcements.test.ts hooks/useQuoteRefreshAnnouncements.test.ts components/swap/QuoteRefreshLiveRegion.test.tsx components/swap/SwapStatusLiveRegion.test.tsx
 ```
 
 ## Sign-off checklist
@@ -73,3 +96,5 @@ npm test -- lib/quote-refresh-announcements.test.ts hooks/useQuoteRefreshAnnounc
 - [ ] Assertive announcement on hard failure
 - [ ] No duplicate announcements during debounce
 - [ ] Focus never moves to the live region
+- [ ] Polite pending / finalized and assertive error announcements on swap submission
+- [ ] Confirm and update-quote reachable by keyboard alone

--- a/sdk-js/CHANGELOG.md
+++ b/sdk-js/CHANGELOG.md
@@ -1,0 +1,42 @@
+# Changelog
+
+All notable changes to `@stellarroute/sdk-js` are documented here.
+
+The format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and the
+package adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html). While
+the major version is `0`, minor bumps may contain breaking changes — every one is
+listed under a **Breaking** heading below.
+
+## [Unreleased]
+
+### Added
+
+- Release engineering docs: [`PUBLISHING.md`](./PUBLISHING.md) publish checklist and
+  this changelog.
+- README quickstart walking through the full quote → swap path.
+
+## [0.1.0] — Initial release
+
+### Added
+
+- `StellarRouteClient` covering `getHealth`, `getPairs`, `getOrderbook`, `getQuote`,
+  `getRankedRoutes`, `simulateRoute`, `getPriceHistory`, and batch quote/orderbook.
+- `executeSwap(params)` — validates the route via `simulateRoute`, then returns the
+  XDR envelope to sign.
+- WebSocket client for streaming quote updates (`./websocket.js`).
+- `StellarRouteApiError` + `isStellarRouteApiError` type guard for structured error
+  handling, and quote-staleness helpers (`isQuoteStale`, `getTimeUntilExpiry`).
+- Dual ESM/CJS builds with bundled type declarations.
+
+### Breaking
+
+- None — first published version.
+
+### Known limitations
+
+- `executeSwap` throws `StellarRouteApiError` with `code === "not_implemented"` until
+  the server-side swap-build endpoint is deployed. Simulation still runs first, so a
+  successful simulate followed by this error means the route is valid and the caller
+  should build/sign the transaction with the Stellar SDK directly. Removing that stub
+  will be a **breaking** change to `executeSwap`'s failure mode and will land in its
+  own minor release with a migration note here.

--- a/sdk-js/PUBLISHING.md
+++ b/sdk-js/PUBLISHING.md
@@ -1,0 +1,71 @@
+# Publishing `@stellarroute/sdk-js`
+
+The package is published to npm from a clean checkout of `main`. Everything below runs
+from the `sdk-js/` directory unless stated otherwise.
+
+## Versioning policy
+
+- Semantic Versioning. Pre-`1.0`, a **minor** bump may carry breaking changes; a patch
+  never does.
+- Every breaking change gets a `### Breaking` entry in [`CHANGELOG.md`](./CHANGELOG.md)
+  with a before/after snippet.
+- The npm `dist-tag` is `latest` for stable releases and `next` for pre-releases
+  (`0.2.0-rc.1`).
+
+## Pre-flight checklist
+
+- [ ] On `main`, up to date with the remote, and `git status` is clean.
+- [ ] `npm ci` — install from the lockfile, not a stale `node_modules`.
+- [ ] `npm run verify` — build (ESM + CJS), unit tests, and example typechecks.
+- [ ] `npm run typecheck` passes with no errors.
+- [ ] `npm run docs:api` regenerated if public types changed; `docs/sdk-js/api` committed.
+- [ ] `CHANGELOG.md` has an entry for this version, with breaking changes called out.
+- [ ] README quickstart still compiles against the new types.
+- [ ] `npm pack --dry-run` — confirm the tarball contains only `dist/` and `README.md`,
+      and that `dist/esm/index.d.ts` plus `dist/cjs/index.js` are present.
+- [ ] Node floor in `engines` (`>=18`) still matches what the code actually uses.
+
+## Release
+
+```bash
+npm version <patch|minor|major>
+```
+
+This writes the new version, commits, and tags. Then:
+
+```bash
+npm publish --access public
+```
+
+`prepublishOnly` re-runs `npm run verify`, so a broken build cannot be published.
+
+For a pre-release:
+
+```bash
+npm version prerelease --preid rc
+npm publish --access public --tag next
+```
+
+## Post-publish checklist
+
+- [ ] `git push --follow-tags` so the tag reaches the repo.
+- [ ] `npm view @stellarroute/sdk-js version` reports the new version.
+- [ ] Smoke test in a scratch directory, both module systems:
+
+  ```bash
+  npm install @stellarroute/sdk-js
+  node -e "import('@stellarroute/sdk-js').then(m => console.log(typeof m.StellarRouteClient))"
+  node -e "console.log(typeof require('@stellarroute/sdk-js').StellarRouteClient)"
+  ```
+
+- [ ] Cut a GitHub release pointing at the changelog entry.
+- [ ] Announce breaking changes to integrators before the tag moves to `latest`.
+
+## Rolling back
+
+Never unpublish. Deprecate the bad version and ship a fix:
+
+```bash
+npm deprecate @stellarroute/sdk-js@<bad-version> "Broken build — use <fixed-version>"
+npm dist-tag add @stellarroute/sdk-js@<last-good-version> latest
+```

--- a/sdk-js/README.md
+++ b/sdk-js/README.md
@@ -8,7 +8,49 @@ Type-safe client for the StellarRoute REST API.
 npm install @stellarroute/sdk-js
 ```
 
-## Quickstart
+## Quickstart: quote → swap
+
+The full integration path is three calls — price the trade, pick a route, execute it.
+
+```ts
+import { StellarRouteClient, isStellarRouteApiError } from '@stellarroute/sdk-js';
+
+const client = new StellarRouteClient('https://api.stellarroute.io');
+
+// 1. Quote — what will this trade cost?
+const quote = await client.getQuote('native', 'USDC:GDUKMGUGDZQK6YH...', 100, 'sell');
+console.log(`price=${quote.price} total=${quote.total}`);
+
+// 2. Routes — rank the executable paths for that pair and amount.
+const { routes } = await client.getRankedRoutes('native', 'USDC:GDUKMGUGDZQK6YH...', 100, 5);
+const best = routes[0];
+
+// 3. Swap — simulate + build the transaction envelope.
+try {
+  const result = await client.executeSwap({
+    route: { hops: best.path.map((hop) => ({
+      from_asset: hop.from_asset,
+      to_asset: hop.to_asset,
+      source: hop.source,
+    })) },
+    amount: '100',
+    sender: 'GABC...',
+    slippage_bps: 50,
+  });
+
+  // Sign `result.xdr_envelope` with the Stellar SDK and submit it.
+} catch (err) {
+  if (isStellarRouteApiError(err) && err.code === 'not_implemented') {
+    // Simulation passed; the swap-build endpoint is not deployed yet.
+    // Build and sign the transaction directly via the Stellar SDK.
+  }
+}
+```
+
+Releases follow SemVer — see [CHANGELOG.md](./CHANGELOG.md) for breaking changes and
+[PUBLISHING.md](./PUBLISHING.md) for the release checklist.
+
+## Reference
 
 ### Get a quote
 


### PR DESCRIPTION
…n proof

Closes #1007,
closes #1008
closes #1009
closes #1042.

#1007 [frontend] Accessibility pass on swap status and error announcements
- Add SwapStatusLiveRegion: polite role="status" for pending/finalized, assertive role="alert" for errors; announcements never move focus.
- Keyboard-reachable "Update quote" / "Confirm swap" controls, disabled while a swap is in flight.
- Unit tests cover each status plus the keyboard path (Tab + Enter).
- Screen-reader test steps documented in frontend/docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md.

#1008 [sdk-js] Publish npm release suitable for production integrators
- Add PUBLISHING.md: versioning policy, pre-flight/release/post-publish checklists, rollback via deprecate (never unpublish).
- Add CHANGELOG.md (Keep a Changelog + SemVer) with a Breaking section and the executeSwap not_implemented limitation called out.
- README gains a quote -> routes -> swap quickstart.

#1009 [sdk-rust] Add swap prepare/submit helpers for backend integrators
- Add prepare_swap / submit_swap plus SwapPrepare*/SwapSubmit* types. The SDK never handles signing keys: prepare returns an unsigned XDR envelope, the caller signs, submit broadcasts.
- Rustdoc examples on both methods and a walkthrough in docs/sdk-rust/README.md.
- 5 wiremock-backed tests covering success, no_route, validation_error, and pending status.

#1042 [indexer] Prove AMM loop ingests reserves for registered testnet pools
- Add crates/indexer/tests/amm_ingest.rs, #[ignore]d by default. Drives AmmAggregator against testnet RPC + a live DB and passes once a pool has positive reserves with updated_at newer than the start timestamp (read from the database clock, so host skew cannot fake a pass).
- Timeout configurable via AMM_INGEST_TIMEOUT_SECS, default 600s.
- Refuses to run against anything resembling mainnet.
- Failure message lists router contract ID, every pool checked, and the last RPC error.
- Documented in docs/development/indexer-guide.md under "Verify AMM ingestion".

Incidental fixes — crates/sdk-rust did not compile on main, which blocked the verify command for #1009:
- Fix E0515 borrow errors in the no_route detection in execute_with_retry.
- Fix E0308 if/else type mismatch in encode_path_segment.
- Resolve leftover merge conflict markers in tests/client_integration.rs.
- A bare 404 no longer forces ApiErrorCode::NoRoute when the body names its own error code, so orderbook 404s map to NotFound again.
- Fix a doctest referencing the nonexistent stellarroute_sdk::ApiError.