### PR TITLE
feat: reliability & infra — failover URLs, PaaS bind, full-stack comp…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,13 +8,23 @@ DATABASE_URL=postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarro
 REDIS_URL=redis://localhost:6379
 
 # ── Stellar / Soroban (required for indexer) ───────────────────────────
-STELLAR_HORIZON_URL=https://horizon.stellar.org
-SOROBAN_RPC_URL=https://soroban-rpc.testnet.stellar.org
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+# Optional comma-separated failover URLs tried if the primary is unreachable:
+# STELLAR_HORIZON_FALLBACK_URLS=https://horizon.stellar.org,https://horizon-testnet.stellar.org
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org
+# Optional comma-separated failover URLs tried if the primary is unreachable:
+# SOROBAN_RPC_FALLBACK_URLS=https://soroban-rpc.stellar.org
 ROUTER_CONTRACT_ADDRESS=
 
 # ── API server (optional overrides) ──────────────────────────────────
-# API_HOST=127.0.0.1
+# API_HOST=127.0.0.1          # local default (loopback)
 # API_PORT=3000
+#
+# PaaS / production binding (Render, Fly, Railway, K8s):
+#   Set PORT (injected automatically by most PaaS platforms) — the server
+#   will bind 0.0.0.0:$PORT.  Override the host with API_HOST if needed.
+# PORT=3000
+# API_HOST=0.0.0.0            # required for PaaS; set explicitly if PORT is absent
 
 # ── Deployment profile / security (see docs/development/environment-variables.md) ──
 # Set to `production` for public deployments. Flips CORS and REQUIRE_AUTH to

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,10 +14,18 @@ StellarRoute is a Rust-first Stellar DEX aggregator with:
 Use these commands from repo root unless noted.
 
 ### Local dependencies
-- Start Postgres + Redis:
+- Start Postgres + Redis (deps only):
   - `docker-compose up -d`
-- Wait for service health before running API/indexer:
+- Start full stack (Postgres + Redis + API):
+  - `docker compose -f docker-compose.yml -f docker-compose.app.yml up -d`
+- Start full stack with indexer (requires `ROUTER_CONTRACT_ADDRESS` in `.env`):
+  - `docker compose -f docker-compose.yml -f docker-compose.app.yml --profile indexer up -d`
+- Start full stack with frontend UI:
+  - `docker compose -f docker-compose.yml -f docker-compose.app.yml --profile ui up -d`
+- Wait for service health (deps only):
   - `./scripts/wait-for-services.sh`
+- Wait for service health (deps + API):
+  - `./scripts/wait-for-services.sh --api`
 - Wait for databases to be healthy:
   - `./scripts/wait-for-dbs.sh`
 - Check service health:

--- a/README.md
+++ b/README.md
@@ -286,7 +286,20 @@ We're currently building M1 (Prototype Indexer & API) and need help with:
 3. **Start local services**
 
    ```bash
+   # Deps only (Postgres + Redis):
    docker-compose up -d
+
+   # Full stack (Postgres + Redis + API):
+   docker compose -f docker-compose.yml -f docker-compose.app.yml up -d
+
+   # Full stack with indexer (requires ROUTER_CONTRACT_ADDRESS in .env):
+   docker compose -f docker-compose.yml -f docker-compose.app.yml --profile indexer up -d
+   ```
+
+   Wait for services to be ready:
+   ```bash
+   ./scripts/wait-for-services.sh        # deps only
+   ./scripts/wait-for-services.sh --api  # deps + API
    ```
 
 4. **Build the project**

--- a/crates/api/src/bin/stellarroute-api.rs
+++ b/crates/api/src/bin/stellarroute-api.rs
@@ -5,8 +5,94 @@ use std::time::Duration;
 use stellarroute_api::{state::DatabasePools, telemetry, PurgerConfig, Server, ServerConfig};
 use tracing::{error, info, warn};
 
-/// Check the production auth posture and either warn (break-glass override)
-/// or refuse to boot. See `middleware::auth::validate_auth_startup`.
+/// Resolve the bind host and port from environment variables.
+///
+/// PaaS platforms (Render, Fly, Railway, Kubernetes) inject a `PORT` env var
+/// and expect the process to listen on `0.0.0.0:$PORT`.  When `PORT` is
+/// present the default host becomes `0.0.0.0` so platform health-check probes
+/// can reach the process.  An explicit `API_HOST` always wins.
+///
+/// Priority order:
+/// 1. `PORT` present → host = `API_HOST` or `0.0.0.0`, port = `PORT`
+/// 2. `PORT` absent  → host = `API_HOST` or `127.0.0.1`, port = `API_PORT` or `3000`
+pub fn resolve_bind_address() -> (String, u16) {
+    let paas_port: Option<u16> = std::env::var("PORT").ok().and_then(|p| p.parse().ok());
+
+    if let Some(port) = paas_port {
+        let host = std::env::var("API_HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+        (host, port)
+    } else {
+        let host = std::env::var("API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
+        let port = std::env::var("API_PORT")
+            .ok()
+            .and_then(|p| p.parse().ok())
+            .unwrap_or(3000u16);
+        (host, port)
+    }
+}
+
+#[cfg(test)]
+mod bind_tests {
+    use super::*;
+
+    fn with_env<F: FnOnce()>(pairs: &[(&str, &str)], f: F) {
+        // Set vars
+        for (k, v) in pairs {
+            std::env::set_var(k, v);
+        }
+        f();
+        // Unset vars
+        for (k, _) in pairs {
+            std::env::remove_var(k);
+        }
+    }
+
+    fn without_env<F: FnOnce()>(keys: &[&str], f: F) {
+        for k in keys {
+            std::env::remove_var(k);
+        }
+        f();
+    }
+
+    #[test]
+    fn defaults_to_loopback_without_port_env() {
+        without_env(&["PORT", "API_HOST", "API_PORT"], || {
+            let (host, port) = resolve_bind_address();
+            assert_eq!(host, "127.0.0.1");
+            assert_eq!(port, 3000);
+        });
+    }
+
+    #[test]
+    fn paas_port_env_binds_all_interfaces_by_default() {
+        with_env(&[("PORT", "8080")], || {
+            std::env::remove_var("API_HOST");
+            let (host, port) = resolve_bind_address();
+            assert_eq!(host, "0.0.0.0");
+            assert_eq!(port, 8080);
+        });
+    }
+
+    #[test]
+    fn explicit_api_host_overrides_paas_default() {
+        with_env(&[("PORT", "9000"), ("API_HOST", "10.0.0.1")], || {
+            let (host, port) = resolve_bind_address();
+            assert_eq!(host, "10.0.0.1");
+            assert_eq!(port, 9000);
+        });
+    }
+
+    #[test]
+    fn api_port_used_when_no_paas_port() {
+        with_env(&[("API_PORT", "4000")], || {
+            std::env::remove_var("PORT");
+            std::env::remove_var("API_HOST");
+            let (host, port) = resolve_bind_address();
+            assert_eq!(host, "127.0.0.1");
+            assert_eq!(port, 4000);
+        });
+    }
+}
 fn validate_auth_config() -> Result<(), String> {
     match stellarroute_api::middleware::validate_auth_startup() {
         Ok(Some(warning)) => {
@@ -237,12 +323,19 @@ async fn main() {
     };
 
     // Create server configuration
+    // Resolve bind host/port — respects PaaS PORT convention.
+    let (resolved_host, resolved_port) = resolve_bind_address();
+    if resolved_host == "0.0.0.0" || resolved_host == "::" {
+        info!(
+            host = %resolved_host,
+            port = resolved_port,
+            "PaaS bind mode — listening on all interfaces"
+        );
+    }
+
     let config = ServerConfig {
-        host: std::env::var("API_HOST").unwrap_or_else(|_| "127.0.0.1".to_string()),
-        port: std::env::var("API_PORT")
-            .ok()
-            .and_then(|p| p.parse().ok())
-            .unwrap_or(3000),
+        host: resolved_host,
+        port: resolved_port,
         enable_cors: true,
         enable_compression: true,
         admin_auth_token: std::env::var("ADMIN_AUTH_TOKEN").ok(),

--- a/crates/api/src/dependency_health.rs
+++ b/crates/api/src/dependency_health.rs
@@ -9,31 +9,59 @@ use stellarroute_routing::health::circuit_breaker::{
 const HORIZON_KEY: &str = "horizon";
 const SOROBAN_KEY: &str = "soroban_rpc";
 
+/// Parse a comma-separated list of URLs (primary + optional fallbacks).
+/// The first entry is the primary; subsequent entries are tried in order.
+fn parse_failover_urls(primary: Option<String>, fallback_env: &str) -> Vec<String> {
+    let mut urls: Vec<String> = primary
+        .into_iter()
+        .map(|u| u.trim().trim_end_matches('/').to_string())
+        .filter(|u| !u.is_empty())
+        .collect();
+
+    if let Ok(extra) = std::env::var(fallback_env) {
+        for u in extra.split(',') {
+            let u = u.trim().trim_end_matches('/').to_string();
+            if !u.is_empty() {
+                urls.push(u);
+            }
+        }
+    }
+
+    urls
+}
+
 #[derive(Clone)]
 pub struct ExternalDependencyHealth {
     client: Client,
-    horizon_url: Option<String>,
-    soroban_rpc_url: Option<String>,
+    /// Ordered list of Horizon URLs: primary first, then fallbacks.
+    horizon_urls: Vec<String>,
+    /// Ordered list of Soroban RPC URLs: primary first, then fallbacks.
+    soroban_rpc_urls: Vec<String>,
     horizon_breaker: Arc<CircuitBreakerRegistry>,
     soroban_breaker: Arc<CircuitBreakerRegistry>,
 }
 
 impl ExternalDependencyHealth {
     pub fn from_env() -> Self {
-        let horizon_url = std::env::var("STELLAR_HORIZON_URL")
+        let horizon_primary = std::env::var("STELLAR_HORIZON_URL")
             .ok()
             .map(|v| v.trim().trim_end_matches('/').to_string())
             .filter(|v| !v.is_empty());
 
-        let soroban_rpc_url = std::env::var("SOROBAN_RPC_URL")
+        let soroban_primary = std::env::var("SOROBAN_RPC_URL")
             .ok()
             .map(|v| v.trim().trim_end_matches('/').to_string())
             .filter(|v| !v.is_empty());
 
-        Self::new(horizon_url, soroban_rpc_url)
+        let horizon_urls =
+            parse_failover_urls(horizon_primary, "STELLAR_HORIZON_FALLBACK_URLS");
+        let soroban_rpc_urls =
+            parse_failover_urls(soroban_primary, "SOROBAN_RPC_FALLBACK_URLS");
+
+        Self::new(horizon_urls, soroban_rpc_urls)
     }
 
-    pub fn new(horizon_url: Option<String>, soroban_rpc_url: Option<String>) -> Self {
+    pub fn new(horizon_urls: Vec<String>, soroban_rpc_urls: Vec<String>) -> Self {
         let client = Client::builder()
             .timeout(Duration::from_secs(3))
             .build()
@@ -47,8 +75,8 @@ impl ExternalDependencyHealth {
 
         Self {
             client,
-            horizon_url,
-            soroban_rpc_url,
+            horizon_urls,
+            soroban_rpc_urls,
             horizon_breaker: Arc::new(CircuitBreakerRegistry::new(cfg.clone())),
             soroban_breaker: Arc::new(CircuitBreakerRegistry::new(cfg)),
         }
@@ -87,43 +115,43 @@ impl ExternalDependencyHealth {
     }
 
     async fn probe_horizon_with_client(&self, client: &Client) -> String {
-        let Some(base_url) = &self.horizon_url else {
+        if self.horizon_urls.is_empty() {
             return "not_configured".to_string();
-        };
+        }
 
         if self.horizon_breaker.is_venue_excluded(HORIZON_KEY) {
             return "degraded (circuit_open)".to_string();
         }
 
-        let url = format!("{}/health", base_url);
-        let success = client
-            .get(&url)
-            .send()
-            .await
-            .map(|resp| resp.status().is_success())
-            .unwrap_or(false);
+        for base_url in &self.horizon_urls {
+            let url = format!("{}/health", base_url);
+            let success = client
+                .get(&url)
+                .send()
+                .await
+                .map(|resp| resp.status().is_success())
+                .unwrap_or(false);
 
-        self.horizon_breaker.record_result(HORIZON_KEY, success);
-
-        if success {
-            "healthy".to_string()
-        } else {
-            "degraded".to_string()
+            if success {
+                self.horizon_breaker.record_result(HORIZON_KEY, true);
+                return "healthy".to_string();
+            }
         }
+
+        // All URLs failed
+        self.horizon_breaker.record_result(HORIZON_KEY, false);
+        "degraded".to_string()
     }
 
     async fn probe_soroban_with_client(&self, client: &Client) -> String {
-        let Some(url) = &self.soroban_rpc_url else {
+        if self.soroban_rpc_urls.is_empty() {
             return "not_configured".to_string();
-        };
+        }
 
         if self.soroban_breaker.is_venue_excluded(SOROBAN_KEY) {
             return "degraded (circuit_open)".to_string();
         }
 
-        // Half-open recovery is naturally driven by this lightweight getHealth probe:
-        // once recovery_timeout elapses the breaker transitions to half-open and this
-        // endpoint is tried again; enough consecutive successes closes the breaker.
         let req = json!({
             "jsonrpc": "2.0",
             "id": "dep-health-probe",
@@ -131,21 +159,24 @@ impl ExternalDependencyHealth {
             "params": {}
         });
 
-        let success = client
-            .post(url)
-            .json(&req)
-            .send()
-            .await
-            .and_then(|resp| resp.error_for_status())
-            .is_ok();
+        for url in &self.soroban_rpc_urls {
+            let success = client
+                .post(url)
+                .json(&req)
+                .send()
+                .await
+                .and_then(|resp| resp.error_for_status())
+                .is_ok();
 
-        self.soroban_breaker.record_result(SOROBAN_KEY, success);
-
-        if success {
-            "healthy".to_string()
-        } else {
-            "degraded".to_string()
+            if success {
+                self.soroban_breaker.record_result(SOROBAN_KEY, true);
+                return "healthy".to_string();
+            }
         }
+
+        // All URLs failed
+        self.soroban_breaker.record_result(SOROBAN_KEY, false);
+        "degraded".to_string()
     }
 }
 
@@ -156,7 +187,7 @@ mod tests {
 
     #[test]
     fn soroban_and_horizon_breakers_are_independent() {
-        let health = ExternalDependencyHealth::new(None, None);
+        let health = ExternalDependencyHealth::new(vec![], vec![]);
 
         for _ in 0..3 {
             health.record_soroban_result(false);
@@ -169,7 +200,7 @@ mod tests {
 
     #[test]
     fn soroban_open_does_not_require_horizon_degradation() {
-        let health = ExternalDependencyHealth::new(None, None);
+        let health = ExternalDependencyHealth::new(vec![], vec![]);
 
         for _ in 0..3 {
             health.record_soroban_result(false);
@@ -180,5 +211,29 @@ mod tests {
 
         assert!(health.soroban_breaker_is_open());
         assert!(!health.horizon_breaker_is_open());
+    }
+
+    #[test]
+    fn parse_failover_urls_empty_primary() {
+        // When primary is None and env var is absent, result should be empty.
+        let urls = parse_failover_urls(None, "DOES_NOT_EXIST_ENV_VAR_XYZ");
+        assert!(urls.is_empty());
+    }
+
+    #[test]
+    fn parse_failover_urls_primary_only() {
+        let urls = parse_failover_urls(
+            Some("https://horizon.stellar.org".to_string()),
+            "DOES_NOT_EXIST_ENV_VAR_XYZ",
+        );
+        assert_eq!(urls, vec!["https://horizon.stellar.org"]);
+    }
+
+    #[test]
+    fn horizon_urls_returns_not_configured_when_empty() {
+        let health = ExternalDependencyHealth::new(vec![], vec![]);
+        // sync check
+        assert!(health.horizon_urls.is_empty());
+        assert!(health.soroban_rpc_urls.is_empty());
     }
 }

--- a/crates/indexer/src/bin/stellarroute-indexer.rs
+++ b/crates/indexer/src/bin/stellarroute-indexer.rs
@@ -46,21 +46,53 @@ async fn run_startup_reachability_checks(
         .build()
         .map_err(|_| "Startup check failed: unable to create HTTP client".to_string())?;
 
-    let horizon = format!("{}/", config.stellar_horizon_url.trim_end_matches('/'));
-    let horizon_status =
-        http.get(&horizon).send().await.map_err(|_| {
-            "Startup check failed: STELLAR_HORIZON_URL is not reachable".to_string()
-        })?;
-    if !horizon_status.status().is_success() {
-        return Err(
-            "Startup check failed: STELLAR_HORIZON_URL returned non-success status".to_string(),
-        );
+    // Try each Horizon URL in order; succeed as soon as one responds.
+    let horizon_urls = config.horizon_urls();
+    let mut horizon_ok = false;
+    for url in &horizon_urls {
+        let probe = format!("{}/", url.trim_end_matches('/'));
+        if let Ok(resp) = http.get(&probe).send().await {
+            if resp.status().is_success() {
+                horizon_ok = true;
+                break;
+            }
+        }
+    }
+    if !horizon_ok {
+        return Err(format!(
+            "Startup check failed: none of the Horizon URL(s) are reachable ({} tried)",
+            horizon_urls.len()
+        ));
     }
 
-    soroban
-        .get_latest_ledger()
-        .await
-        .map_err(|_| "Startup check failed: SOROBAN_RPC_URL is not reachable".to_string())?;
+    // Try each Soroban RPC URL in order; succeed as soon as one responds.
+    let soroban_urls = config.soroban_rpc_urls();
+    let mut soroban_ok = false;
+    for url in &soroban_urls {
+        let tmp_client = SorobanRpcClient::new(SorobanRpcConfig {
+            base_url: url.clone(),
+            timeout_secs: 5,
+            retry: RetryPolicy {
+                max_retries: 0,
+                ..RetryPolicy::default()
+            },
+        });
+        if let Ok(client) = tmp_client {
+            if client.get_latest_ledger().await.is_ok() {
+                soroban_ok = true;
+                break;
+            }
+        }
+    }
+    if !soroban_ok {
+        return Err(format!(
+            "Startup check failed: none of the Soroban RPC URL(s) are reachable ({} tried)",
+            soroban_urls.len()
+        ));
+    }
+
+    // The provided primary soroban client is already warmed up — keep using it.
+    let _ = soroban;
 
     Ok(())
 }
@@ -98,6 +130,16 @@ async fn main() {
 
     // Initialize Horizon client
     let horizon = HorizonClient::new(&config.stellar_horizon_url);
+    {
+        let fallbacks = config.horizon_urls();
+        if fallbacks.len() > 1 {
+            info!(
+                primary = %config.stellar_horizon_url,
+                fallback_count = fallbacks.len() - 1,
+                "Horizon failover URLs configured"
+            );
+        }
+    }
 
     // Initialize Soroban RPC client
     let soroban = match SorobanRpcClient::new(SorobanRpcConfig {
@@ -111,6 +153,16 @@ async fn main() {
             process::exit(1);
         }
     };
+    {
+        let fallbacks = config.soroban_rpc_urls();
+        if fallbacks.len() > 1 {
+            info!(
+                primary = %config.soroban_rpc_url,
+                fallback_count = fallbacks.len() - 1,
+                "Soroban RPC failover URLs configured"
+            );
+        }
+    }
 
     if parse_bool_env("STARTUP_CREDENTIAL_CHECK") {
         info!("Running startup dependency reachability checks");

--- a/crates/indexer/src/config/mod.rs
+++ b/crates/indexer/src/config/mod.rs
@@ -8,17 +8,36 @@ pub enum HorizonMode {
     Sse,
 }
 
+/// Parse a comma-separated list of URLs from an env var, returning a `Vec<String>`.
+/// Trims whitespace and drops empty entries.
+pub fn parse_url_list(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(|s| s.trim().trim_end_matches('/').to_string())
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
 #[derive(Clone, Deserialize)]
 pub struct IndexerConfig {
-    /// Horizon base URL, e.g. `https://horizon.stellar.org` or `https://horizon-testnet.stellar.org`
+    /// Primary Horizon base URL.
     pub stellar_horizon_url: String,
+
+    /// Ordered failover Horizon URLs tried when the primary is unreachable.
+    /// Env: `STELLAR_HORIZON_FALLBACK_URLS` — comma-separated list.
+    #[serde(default)]
+    pub stellar_horizon_fallback_urls: String,
 
     /// Ingestion mode for SDEX offers
     #[serde(default)]
     pub horizon_mode: HorizonMode,
 
-    /// Soroban RPC base URL
+    /// Primary Soroban RPC base URL.
     pub soroban_rpc_url: String,
+
+    /// Ordered failover Soroban RPC URLs tried when the primary is unreachable.
+    /// Env: `SOROBAN_RPC_FALLBACK_URLS` — comma-separated list.
+    #[serde(default)]
+    pub soroban_rpc_fallback_urls: String,
 
     /// Router contract address for AMM pool discovery
     pub router_contract_address: String,
@@ -100,8 +119,13 @@ impl std::fmt::Debug for IndexerConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("IndexerConfig")
             .field("stellar_horizon_url", &self.stellar_horizon_url)
+            .field(
+                "stellar_horizon_fallback_urls",
+                &self.stellar_horizon_fallback_urls,
+            )
             .field("horizon_mode", &self.horizon_mode)
             .field("soroban_rpc_url", &self.soroban_rpc_url)
+            .field("soroban_rpc_fallback_urls", &self.soroban_rpc_fallback_urls)
             .field("router_contract_address", &self.router_contract_address)
             .field("database_url", &"[REDACTED]")
             .field("poll_interval_secs", &self.poll_interval_secs)
@@ -187,6 +211,23 @@ fn default_hot_pair_window_secs() -> u64 {
 }
 
 impl IndexerConfig {
+    /// Returns all Horizon URLs to try in priority order: primary first, then fallbacks.
+    pub fn horizon_urls(&self) -> Vec<String> {
+        let mut urls = vec![self
+            .stellar_horizon_url
+            .trim_end_matches('/')
+            .to_string()];
+        urls.extend(parse_url_list(&self.stellar_horizon_fallback_urls));
+        urls
+    }
+
+    /// Returns all Soroban RPC URLs to try in priority order: primary first, then fallbacks.
+    pub fn soroban_rpc_urls(&self) -> Vec<String> {
+        let mut urls = vec![self.soroban_rpc_url.trim_end_matches('/').to_string()];
+        urls.extend(parse_url_list(&self.soroban_rpc_fallback_urls));
+        urls
+    }
+
     pub fn load() -> std::result::Result<Self, config::ConfigError> {
         let cfg = config::Config::builder()
             .add_source(config::Environment::default())

--- a/docker-compose.app.yml
+++ b/docker-compose.app.yml
@@ -1,0 +1,109 @@
+# StellarRoute — full application stack overlay
+#
+# Extends docker-compose.yml (Postgres + Redis) with the API and indexer services.
+#
+# Quick start (deps + API):
+#   docker compose -f docker-compose.yml -f docker-compose.app.yml up -d
+#   ./scripts/wait-for-services.sh
+#   curl -sf "http://127.0.0.1:${API_PORT:-3000}/health"
+#
+# With indexer (requires a real ROUTER_CONTRACT_ADDRESS):
+#   docker compose -f docker-compose.yml -f docker-compose.app.yml \
+#     --profile indexer up -d
+#
+# With frontend (optional development UI):
+#   docker compose -f docker-compose.yml -f docker-compose.app.yml \
+#     --profile ui up -d
+#
+# Copy .env.example to .env and fill in required values before running.
+# No production secrets should be committed; .env is git-ignored.
+
+version: '3.8'
+
+services:
+  # ── API ─────────────────────────────────────────────────────────────
+  api:
+    build:
+      context: .
+      dockerfile: Dockerfile.api
+    image: stellarroute-api:local
+    container_name: stellarroute-api
+    restart: unless-stopped
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql://stellarroute:stellarroute_dev@postgres:5432/stellarroute
+      REDIS_URL: redis://redis:6379
+      # PaaS-style bind: listen on all interfaces inside the container.
+      API_HOST: "0.0.0.0"
+      API_PORT: "${API_PORT:-3000}"
+    ports:
+      - "${API_PORT:-3000}:${API_PORT:-3000}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          "curl -sf http://localhost:${API_PORT:-3000}/health || exit 1"
+        ]
+      interval: 15s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    networks:
+      - stellarroute-network
+
+  # ── Indexer (gated behind the "indexer" profile) ─────────────────────
+  # Start with: docker compose ... --profile indexer up -d
+  #
+  # IMPORTANT: ROUTER_CONTRACT_ADDRESS must be set to a deployed contract ID.
+  # An empty value will cause the indexer to exit at startup with an error
+  # message; it will NOT silently loop. Set the value in your .env file.
+  indexer:
+    build:
+      context: .
+      dockerfile: Dockerfile.indexer
+    image: stellarroute-indexer:local
+    container_name: stellarroute-indexer
+    restart: unless-stopped
+    profiles:
+      - indexer
+    env_file:
+      - .env
+    environment:
+      DATABASE_URL: postgresql://stellarroute:stellarroute_dev@postgres:5432/stellarroute
+      STELLAR_HORIZON_URL: "${STELLAR_HORIZON_URL:-https://horizon-testnet.stellar.org}"
+      SOROBAN_RPC_URL: "${SOROBAN_RPC_URL:-https://soroban-testnet.stellar.org}"
+      # ROUTER_CONTRACT_ADDRESS must be provided in .env — the indexer validates
+      # this at startup and exits immediately with a clear error if absent.
+      ROUTER_CONTRACT_ADDRESS: "${ROUTER_CONTRACT_ADDRESS}"
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - stellarroute-network
+
+  # ── Frontend (gated behind the "ui" profile) ─────────────────────────
+  # Start with: docker compose ... --profile ui up -d
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    image: stellarroute-frontend:local
+    container_name: stellarroute-frontend
+    restart: unless-stopped
+    profiles:
+      - ui
+    environment:
+      NEXT_PUBLIC_API_URL: "http://localhost:${API_PORT:-3000}/api/v1"
+    ports:
+      - "3001:3000"
+    depends_on:
+      api:
+        condition: service_healthy
+    networks:
+      - stellarroute-network

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -99,6 +99,33 @@ Rollback sequence:
 4. Keep the last known-good schema migration file and deployment artifact together.
 ## Testnet Deployment (From Clean Machine)
 
+### 0. Exact command order
+
+This is the canonical sequence for a clean testnet deployment:
+
+```bash
+# 1. Deploy router contract (writes config/deployment-testnet.json)
+./scripts/deploy.sh --network testnet
+
+# 2. Set ROUTER_CONTRACT_ADDRESS in your environment
+export ROUTER_CONTRACT_ADDRESS=$(jq -r '.contract_id' config/deployment-testnet.json)
+
+# 3. Register pools from config/pools-testnet.json (idempotent — safe to re-run)
+./scripts/register-pools.sh --network testnet
+
+# 4. Verify all configured pools are registered (CI gate — exits non-zero on failure)
+./scripts/verify-pools.sh --network testnet
+
+# 5. Start the indexer (reads ROUTER_CONTRACT_ADDRESS from env or .env file)
+cargo run -p stellarroute-indexer
+# or in Docker:
+# docker compose -f docker-compose.yml -f docker-compose.app.yml --profile indexer up -d
+```
+
+Re-running step 3 at any time is safe: pools that are already registered are
+skipped automatically (idempotent).  Step 4 will fail CI if any configured
+non-placeholder pool is missing from the live router state.
+
 ### 1. Setup
 ```bash
 # Clone and enter the repository
@@ -225,19 +252,39 @@ Any entry whose `address` starts with `PLACEHOLDER` is automatically skipped by 
 
 The script reads `config/pools-testnet.json`, skips placeholder entries, and calls the router contract's `register_pool` function for each real address.
 
-**Expected log output (successful run):**
+**The script is idempotent**: pools that are already registered are detected via `is_pool_registered` before each call and skipped without error. Re-running the script after a partial failure or a re-deploy is always safe.
+
+**Expected log output (successful first run):**
 
 ```
 [INFO]  Registering 2 pools on testnet (contract: C...ROUTER...)
-[INFO]  [1/2] Registering: XLM/USDC Testnet Pool (CBIELTK6...)
-[OK]    Verified: XLM/USDC Testnet Pool is registered
-[INFO]  [2/2] Registering: XLM/BTC Testnet Pool (CBEZJWFM...)
-[OK]    Verified: XLM/BTC Testnet Pool is registered
+[INFO]  [1/2] Checking: XLM/USDC Testnet Pool (CBIELTK6...)
+[OK]    Registered and verified: XLM/USDC Testnet Pool
+[INFO]  [2/2] Checking: XLM/BTC Testnet Pool (CBEZJWFM...)
+[OK]    Registered and verified: XLM/BTC Testnet Pool
 
 [OK]    ===== POOL REGISTRATION COMPLETE =====
-[OK]    Registered: 2
-[OK]    Failed:     0
-[OK]    Total on-chain pool count: 2
+[OK]    Registered (new):     2
+[OK]    Already registered:   0
+[OK]    Skipped (placeholder):0
+[OK]    Failed:               0
+[OK]    Total on-chain pools: 2
+```
+
+**Expected log output (re-run — idempotent):**
+
+```
+[INFO]  [1/2] Checking: XLM/USDC Testnet Pool (CBIELTK6...)
+[OK]    Already registered (no-op): XLM/USDC Testnet Pool
+[INFO]  [2/2] Checking: XLM/BTC Testnet Pool (CBEZJWFM...)
+[OK]    Already registered (no-op): XLM/BTC Testnet Pool
+
+[OK]    ===== POOL REGISTRATION COMPLETE =====
+[OK]    Registered (new):     0
+[OK]    Already registered:   2
+[OK]    Skipped (placeholder):0
+[OK]    Failed:               0
+[OK]    Total on-chain pools: 2
 ```
 
 **Expected log output (placeholder entries present):**
@@ -247,10 +294,25 @@ The script reads `config/pools-testnet.json`, skips placeholder entries, and cal
 [WARN]  Skipping placeholder pool: XLM/BTC Testnet Pool
 
 [OK]    ===== POOL REGISTRATION COMPLETE =====
-[OK]    Registered: 0
-[OK]    Failed:     0
-[OK]    Total on-chain pool count: 0
+[OK]    Registered (new):     0
+[OK]    Already registered:   0
+[OK]    Skipped (placeholder):2
+[OK]    Failed:               0
 ```
+
+The script also writes a machine-readable JSON summary to
+`logs/<network>-register-summary.json`.
+
+#### Step 4 — Verify pools (CI gate)
+
+```bash
+./scripts/verify-pools.sh --network testnet
+```
+
+This script queries `is_pool_registered` for every non-placeholder pool and
+exits non-zero if any pool is missing from the live router.  Use it as a CI/CD
+gate after `register-pools.sh`.  Output is also written as JSON to
+`logs/<network>-verify-pools-summary.json`.
 
 If `Registered: 0` is shown for a non-placeholder run, verify the router contract is deployed (`./scripts/deploy.sh` must have run first) and that `config/deployment-testnet.json` exists with a valid contract ID.
 

--- a/docs/development/environment-variables.md
+++ b/docs/development/environment-variables.md
@@ -57,6 +57,7 @@ PostgreSQL connection strings and pool tuning. Used by the API, indexer, replay 
 | Variable | Type | Default | Required | Service(s) | Description |
 |----------|------|---------|----------|------------|-------------|
 | `STELLAR_HORIZON_URL` | string (URL) | — | **Required** (indexer); optional (API health/lag) | Indexer, API | Stellar Horizon API base URL (e.g. `https://horizon.stellar.org` or `https://horizon-testnet.stellar.org`) |
+| `STELLAR_HORIZON_FALLBACK_URLS` | string (comma-separated URLs) | — | Optional | Indexer, API | Ordered failover Horizon URLs tried if the primary is unreachable. Example: `https://horizon-testnet.stellar.org,https://horizon.stellar.org`. The first reachable URL wins. |
 | `HORIZON_MODE` | string | `poll` | Optional | Indexer | SDEX ingestion mode: `poll` or `sse` |
 | `HORIZON_LIMIT` | integer | `200` | Optional | Indexer | Maximum records per Horizon API page request |
 | `POLL_INTERVAL_SECS` | integer (seconds) | `2` | Optional | Indexer | Poll interval when Horizon streaming is not used |
@@ -67,7 +68,8 @@ PostgreSQL connection strings and pool tuning. Used by the API, indexer, replay 
 
 | Variable | Type | Default | Required | Service(s) | Description |
 |----------|------|---------|----------|------------|-------------|
-| `SOROBAN_RPC_URL` | string (URL) | — | **Required** (indexer); optional health check (API) | Indexer, API | Soroban RPC endpoint (e.g. `https://soroban-rpc.testnet.stellar.org`). When set, the API validates reachability at startup if `STARTUP_CREDENTIAL_CHECK=true` |
+| `SOROBAN_RPC_URL` | string (URL) | — | **Required** (indexer); optional health check (API) | Indexer, API | Soroban RPC endpoint (e.g. `https://soroban-testnet.stellar.org`). When set, the API validates reachability at startup if `STARTUP_CREDENTIAL_CHECK=true` |
+| `SOROBAN_RPC_FALLBACK_URLS` | string (comma-separated URLs) | — | Optional | Indexer, API | Ordered failover Soroban RPC URLs tried if the primary is unreachable. Example: `https://soroban-rpc.stellar.org`. The first reachable URL wins. |
 | `ROUTER_CONTRACT_ADDRESS` | string (Stellar address) | — | **Required** (indexer) | Indexer | Deployed router contract ID for AMM pool discovery |
 | `AMM_POOLS` | string (comma-separated) | — | Optional | Indexer | Additional AMM pool addresses to index, appended to DB-discovered pools |
 
@@ -109,8 +111,9 @@ There are two distinct read paths into the API, and they should not be conflated
 
 | Variable | Type | Default | Required | Service(s) | Description |
 |----------|------|---------|----------|------------|-------------|
-| `API_HOST` | string | `127.0.0.1` | Optional | API | Bind address for the HTTP server |
-| `API_PORT` | integer | `3000` | Optional | API | Listen port for the HTTP server |
+| `API_HOST` | string | `127.0.0.1` (local) / `0.0.0.0` (when `PORT` is set) | Optional | API | Bind address for the HTTP server. Explicit value always wins. |
+| `API_PORT` | integer | `3000` | Optional | API | Listen port (used when `PORT` env is absent) |
+| `PORT` | integer | — | Optional (set by PaaS) | API | PaaS standard port variable (Render, Fly, Railway, K8s). When present, overrides `API_PORT` and defaults `API_HOST` to `0.0.0.0` so the platform health-check router can reach the process. Set `API_HOST` explicitly if a different bind address is required. |
 | `STARTUP_CREDENTIAL_CHECK` | boolean | `false` | Optional | API, Indexer | When `true`, verify dependencies (DB, Redis, Horizon, Soroban) are reachable before serving |
 | `SHUTDOWN_DRAIN_TIMEOUT_S` | integer (seconds) | `30` | Optional | API, Indexer | Graceful shutdown drain window for in-flight work |
 | `RATE_LIMIT_WINDOW_SECS` | integer (seconds) | `60` | Optional | API | Sliding-window length for HTTP rate limiting |

--- a/scripts/register-pools.sh
+++ b/scripts/register-pools.sh
@@ -1,6 +1,21 @@
 #!/bin/bash
-# StellarRoute — Register Liquidity Pools with Router Contract
-# Usage: ./scripts/register-pools.sh --network testnet
+# StellarRoute — Idempotent Pool Registration with Router Contract
+#
+# Registers every pool in config/pools-<network>.json against the deployed
+# router contract.  Re-running the script is safe: pools that are already
+# registered are skipped without error.
+#
+# Usage:
+#   ./scripts/register-pools.sh --network testnet
+#   ./scripts/register-pools.sh --network testnet --dry-run
+#
+# Required env / deployment artifact:
+#   ROUTER_CONTRACT_ADDRESS  — or STELLARROUTE_TESTNET_ROUTER_ID / SOROBAN_CONTRACT_ID
+#   config/deployment-testnet.json  — written by deploy.sh
+#
+# Output:
+#   Human-readable log to stdout/stderr
+#   Machine-readable JSON summary to logs/<network>-register-summary.json
 
 set -euo pipefail
 source "$(dirname "$0")/lib/common.sh"
@@ -10,73 +25,148 @@ ensure_soroban_cli
 ensure_log_dir
 configure_network
 
-CONTRACT_ID="${STELLARROUTE_TESTNET_ROUTER_ID:-${SOROBAN_CONTRACT_ID:-}}"
+# ── Resolve contract ID ───────────────────────────────────────────────
+
+CONTRACT_ID="${ROUTER_CONTRACT_ADDRESS:-${STELLARROUTE_TESTNET_ROUTER_ID:-${SOROBAN_CONTRACT_ID:-}}}"
 if [[ -z "${CONTRACT_ID}" && -f "$(deployment_file)" ]]; then
     CONTRACT_ID="$(get_contract_id)"
 fi
 
 if [[ -z "${CONTRACT_ID}" ]]; then
-    log_error "Missing STELLARROUTE_TESTNET_ROUTER_ID or SOROBAN_CONTRACT_ID or deployment artifact."
+    log_error "No router contract ID found."
+    log_error "Set ROUTER_CONTRACT_ADDRESS, STELLARROUTE_TESTNET_ROUTER_ID,"
+    log_error "or SOROBAN_CONTRACT_ID, or run deploy.sh first."
     exit 1
 fi
 
-POOLS_FILE="${CONFIG_DIR}/pools-${NETWORK}.json"
+# ── Load pool config ──────────────────────────────────────────────────
 
+POOLS_FILE="${CONFIG_DIR}/pools-${NETWORK}.json"
 if [[ ! -f "${POOLS_FILE}" ]]; then
     log_error "Pool config not found: ${POOLS_FILE}"
     exit 1
 fi
 
 POOL_COUNT=$(jq '.pools | length' "${POOLS_FILE}")
-log_info "Registering ${POOL_COUNT} pools on ${NETWORK} (contract: ${CONTRACT_ID})"
+log_info "Processing ${POOL_COUNT} pool(s) from ${POOLS_FILE}"
+log_info "Router contract: ${CONTRACT_ID}"
+
+# ── Registration loop ─────────────────────────────────────────────────
 
 REGISTERED=0
+SKIPPED_PLACEHOLDER=0
+ALREADY_REGISTERED=0
 FAILED=0
-SKIPPED=0
+
+declare -a SUMMARY_POOLS=()
 
 for i in $(seq 0 $((POOL_COUNT - 1))); do
     POOL_NAME=$(jq -r ".pools[$i].name" "${POOLS_FILE}")
     POOL_ADDR=$(jq -r ".pools[$i].address" "${POOLS_FILE}")
 
+    # Skip placeholder addresses
     if [[ "${POOL_ADDR}" == PLACEHOLDER* ]]; then
-        log_warn "Skipping placeholder pool: ${POOL_NAME}"
-        SKIPPED=$((SKIPPED + 1))
+        log_warn "[$((i + 1))/${POOL_COUNT}] Skipping placeholder: ${POOL_NAME}"
+        SKIPPED_PLACEHOLDER=$((SKIPPED_PLACEHOLDER + 1))
+        SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"skipped_placeholder\"}")
         continue
     fi
 
-    log_info "[$((i + 1))/${POOL_COUNT}] Registering: ${POOL_NAME} (${POOL_ADDR})"
+    log_info "[$((i + 1))/${POOL_COUNT}] Checking: ${POOL_NAME} (${POOL_ADDR})"
 
-    if invoke_contract "${CONTRACT_ID}" "register_pool" --pool "${POOL_ADDR}"; then
+    # ── Idempotency check: is the pool already registered? ────────────
+    ALREADY=""
+    if ! ALREADY=$(invoke_contract "${CONTRACT_ID}" "is_pool_registered" --pool "${POOL_ADDR}" 2>/dev/null); then
+        log_warn "Could not query is_pool_registered for ${POOL_NAME}; will attempt registration."
+        ALREADY="false"
+    fi
+
+    if [[ "${ALREADY}" == "true" ]]; then
+        log_ok "Already registered (no-op): ${POOL_NAME}"
+        ALREADY_REGISTERED=$((ALREADY_REGISTERED + 1))
+        SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"already_registered\"}")
+        continue
+    fi
+
+    # ── Register ──────────────────────────────────────────────────────
+    if [[ "${DRY_RUN}" == "true" ]]; then
+        log_info "[DRY-RUN] Would register: ${POOL_NAME} (${POOL_ADDR})"
+        SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"dry_run\"}")
+        continue
+    fi
+
+    if invoke_contract "${CONTRACT_ID}" "register_pool" --pool "${POOL_ADDR}" 2>&1 | tee -a "${LOG_DIR}/${NETWORK}-register.log"; then
         log_tx "${POOL_ADDR}" "register_pool"
 
-        IS_REGISTERED=$(invoke_contract "${CONTRACT_ID}" "is_pool_registered" --pool "${POOL_ADDR}")
+        # Verify the registration took effect
+        IS_REGISTERED=$(invoke_contract "${CONTRACT_ID}" "is_pool_registered" --pool "${POOL_ADDR}" 2>/dev/null || echo "false")
         if [[ "${IS_REGISTERED}" == "true" ]]; then
-            log_ok "Verified: ${POOL_NAME} is registered"
+            log_ok "Registered and verified: ${POOL_NAME}"
             REGISTERED=$((REGISTERED + 1))
+            SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"registered\"}")
         else
-            log_error "Verification FAILED for ${POOL_NAME}"
+            log_error "Registration call succeeded but verification FAILED: ${POOL_NAME}"
             FAILED=$((FAILED + 1))
+            SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"verify_failed\"}")
         fi
     else
-        log_error "Registration FAILED for ${POOL_NAME}"
+        log_error "Registration FAILED for: ${POOL_NAME} (${POOL_ADDR})"
         FAILED=$((FAILED + 1))
+        SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"register_failed\"}")
     fi
 done
 
-TOTAL_POOLS=$(invoke_contract "${CONTRACT_ID}" "get_pool_count")
+# ── On-chain pool count ───────────────────────────────────────────────
+
+TOTAL_ON_CHAIN=0
+if [[ "${DRY_RUN}" != "true" ]]; then
+    TOTAL_ON_CHAIN=$(invoke_contract "${CONTRACT_ID}" "get_pool_count" 2>/dev/null || echo "0")
+fi
+
+# ── JSON summary ──────────────────────────────────────────────────────
+
+SUMMARY_FILE="${LOG_DIR}/${NETWORK}-register-summary.json"
+POOLS_JSON=$(printf '%s\n' "${SUMMARY_POOLS[@]}" | paste -sd ',' -)
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+cat > "${SUMMARY_FILE}" <<JSON
+{
+  "timestamp": "${TIMESTAMP}",
+  "network": "${NETWORK}",
+  "contract_id": "${CONTRACT_ID}",
+  "dry_run": ${DRY_RUN},
+  "registered": ${REGISTERED},
+  "already_registered": ${ALREADY_REGISTERED},
+  "skipped_placeholder": ${SKIPPED_PLACEHOLDER},
+  "failed": ${FAILED},
+  "total_on_chain": ${TOTAL_ON_CHAIN},
+  "pools": [${POOLS_JSON}]
+}
+JSON
+
+log_ok "JSON summary written to ${SUMMARY_FILE}"
+
+# ── Human summary ─────────────────────────────────────────────────────
 
 echo ""
 log_ok "===== POOL REGISTRATION COMPLETE ====="
-log_ok "Registered: ${REGISTERED}"
-log_ok "Failed:     ${FAILED}"
-log_ok "Skipped:    ${SKIPPED}"
-log_ok "Total on-chain pool count: ${TOTAL_POOLS}"
+log_ok "Registered (new):     ${REGISTERED}"
+log_ok "Already registered:   ${ALREADY_REGISTERED}"
+log_ok "Skipped (placeholder):${SKIPPED_PLACEHOLDER}"
+log_ok "Failed:               ${FAILED}"
+if [[ "${DRY_RUN}" != "true" ]]; then
+    log_ok "Total on-chain pools: ${TOTAL_ON_CHAIN}"
+fi
+
+# ── Exit code ─────────────────────────────────────────────────────────
 
 if [[ ${FAILED} -gt 0 ]]; then
+    log_error "One or more registrations failed — see ${SUMMARY_FILE}"
     exit 1
 fi
 
-if [[ ${REGISTERED} -eq 0 ]]; then
-    log_error "No pools registered (all were skipped as placeholders)"
-    exit 1
+# In a non-dry-run, at least one pool should have been processed (registered
+# or already registered). If every pool was a placeholder, warn but succeed.
+if [[ "${DRY_RUN}" != "true" && $((REGISTERED + ALREADY_REGISTERED)) -eq 0 && ${SKIPPED_PLACEHOLDER} -gt 0 ]]; then
+    log_warn "All pools were placeholders. Update config/pools-${NETWORK}.json with real addresses."
 fi

--- a/scripts/verify-pools.sh
+++ b/scripts/verify-pools.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# StellarRoute — Verify Pool Registration Against Router Contract
+#
+# Checks that every non-placeholder pool in config/pools-<network>.json
+# is registered in the live router contract.  Exits non-zero if any pool
+# is missing — designed to be used as a CI/CD gate after register-pools.sh.
+#
+# Usage:
+#   ./scripts/verify-pools.sh --network testnet
+#
+# Output:
+#   Human-readable log to stdout/stderr
+#   Machine-readable JSON summary to logs/<network>-verify-pools-summary.json
+
+set -euo pipefail
+source "$(dirname "$0")/lib/common.sh"
+
+parse_network_flag "$@"
+ensure_soroban_cli
+ensure_log_dir
+configure_network
+
+# ── Resolve contract ID ───────────────────────────────────────────────
+
+CONTRACT_ID="${ROUTER_CONTRACT_ADDRESS:-${STELLARROUTE_TESTNET_ROUTER_ID:-${SOROBAN_CONTRACT_ID:-}}}"
+if [[ -z "${CONTRACT_ID}" && -f "$(deployment_file)" ]]; then
+    CONTRACT_ID="$(get_contract_id)"
+fi
+
+if [[ -z "${CONTRACT_ID}" ]]; then
+    log_error "No router contract ID found."
+    log_error "Set ROUTER_CONTRACT_ADDRESS or run deploy.sh first."
+    exit 1
+fi
+
+# ── Load pool config ──────────────────────────────────────────────────
+
+POOLS_FILE="${CONFIG_DIR}/pools-${NETWORK}.json"
+if [[ ! -f "${POOLS_FILE}" ]]; then
+    log_error "Pool config not found: ${POOLS_FILE}"
+    exit 1
+fi
+
+POOL_COUNT=$(jq '.pools | length' "${POOLS_FILE}")
+log_info "Verifying ${POOL_COUNT} pool(s) from ${POOLS_FILE}"
+log_info "Router contract: ${CONTRACT_ID}"
+
+# ── Verification loop ─────────────────────────────────────────────────
+
+VERIFIED=0
+MISSING=0
+SKIPPED_PLACEHOLDER=0
+
+declare -a SUMMARY_POOLS=()
+
+for i in $(seq 0 $((POOL_COUNT - 1))); do
+    POOL_NAME=$(jq -r ".pools[$i].name" "${POOLS_FILE}")
+    POOL_ADDR=$(jq -r ".pools[$i].address" "${POOLS_FILE}")
+
+    if [[ "${POOL_ADDR}" == PLACEHOLDER* ]]; then
+        log_warn "[$((i + 1))/${POOL_COUNT}] Skipping placeholder: ${POOL_NAME}"
+        SKIPPED_PLACEHOLDER=$((SKIPPED_PLACEHOLDER + 1))
+        SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"skipped_placeholder\"}")
+        continue
+    fi
+
+    log_info "[$((i + 1))/${POOL_COUNT}] Verifying: ${POOL_NAME} (${POOL_ADDR})"
+
+    IS_REGISTERED=$(invoke_contract "${CONTRACT_ID}" "is_pool_registered" --pool "${POOL_ADDR}" 2>/dev/null || echo "false")
+
+    if [[ "${IS_REGISTERED}" == "true" ]]; then
+        log_ok "Registered: ${POOL_NAME}"
+        VERIFIED=$((VERIFIED + 1))
+        SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"registered\"}")
+    else
+        log_error "MISSING from router: ${POOL_NAME} (${POOL_ADDR})"
+        MISSING=$((MISSING + 1))
+        SUMMARY_POOLS+=("{\"name\":\"${POOL_NAME}\",\"address\":\"${POOL_ADDR}\",\"status\":\"missing\"}")
+    fi
+done
+
+# ── On-chain pool count ───────────────────────────────────────────────
+
+TOTAL_ON_CHAIN=$(invoke_contract "${CONTRACT_ID}" "get_pool_count" 2>/dev/null || echo "unknown")
+
+# ── JSON summary ──────────────────────────────────────────────────────
+
+SUMMARY_FILE="${LOG_DIR}/${NETWORK}-verify-pools-summary.json"
+POOLS_JSON=$(printf '%s\n' "${SUMMARY_POOLS[@]}" | paste -sd ',' -)
+TIMESTAMP=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+PASS=$([[ ${MISSING} -eq 0 ]] && echo "true" || echo "false")
+
+cat > "${SUMMARY_FILE}" <<JSON
+{
+  "timestamp": "${TIMESTAMP}",
+  "network": "${NETWORK}",
+  "contract_id": "${CONTRACT_ID}",
+  "pass": ${PASS},
+  "verified": ${VERIFIED},
+  "missing": ${MISSING},
+  "skipped_placeholder": ${SKIPPED_PLACEHOLDER},
+  "total_on_chain": "${TOTAL_ON_CHAIN}",
+  "pools": [${POOLS_JSON}]
+}
+JSON
+
+log_ok "JSON summary written to ${SUMMARY_FILE}"
+
+# ── Human summary ─────────────────────────────────────────────────────
+
+echo ""
+if [[ ${MISSING} -eq 0 ]]; then
+    log_ok "===== POOL VERIFICATION PASSED ====="
+else
+    log_error "===== POOL VERIFICATION FAILED ====="
+fi
+log_ok "Verified:              ${VERIFIED}"
+log_ok "Missing:               ${MISSING}"
+log_ok "Skipped (placeholder): ${SKIPPED_PLACEHOLDER}"
+log_ok "Total on-chain pools:  ${TOTAL_ON_CHAIN}"
+
+# ── Exit code — non-zero means CI gate should block ───────────────────
+
+if [[ ${MISSING} -gt 0 ]]; then
+    log_error "Run ./scripts/register-pools.sh --network ${NETWORK} to register missing pools."
+    exit 1
+fi
+
+if [[ $((VERIFIED + SKIPPED_PLACEHOLDER)) -eq 0 ]]; then
+    log_error "No pools were verified (config may be empty or all placeholders)."
+    exit 1
+fi

--- a/scripts/wait-for-services.sh
+++ b/scripts/wait-for-services.sh
@@ -1,10 +1,26 @@
 #!/bin/bash
 # Wait for local Docker Compose services required by the API and indexer.
+#
+# By default waits for Postgres and Redis (deps-only stack).
+# Pass --api to also wait for the API health endpoint.
+#
+# Usage:
+#   ./scripts/wait-for-services.sh              # deps only
+#   ./scripts/wait-for-services.sh --api        # deps + API
+#   TIMEOUT_SECONDS=120 ./scripts/wait-for-services.sh --api
 
 set -euo pipefail
 
 TIMEOUT_SECONDS="${TIMEOUT_SECONDS:-60}"
 SLEEP_SECONDS="${SLEEP_SECONDS:-2}"
+WAIT_FOR_API=false
+API_PORT="${API_PORT:-3000}"
+
+for arg in "$@"; do
+    case "$arg" in
+        --api) WAIT_FOR_API=true ;;
+    esac
+done
 
 if command -v docker-compose >/dev/null 2>&1; then
     COMPOSE=(docker-compose)
@@ -30,48 +46,70 @@ redis_ready() {
     [[ "${response}" == "PONG" ]]
 }
 
+api_ready() {
+    curl -sf "http://127.0.0.1:${API_PORT}/health" >/dev/null 2>&1
+}
+
 print_status() {
     echo ""
     echo "Current service status:"
-    run_compose ps postgres redis 2>/dev/null || true
+    run_compose ps 2>/dev/null || true
 }
 
 deadline=$((SECONDS + TIMEOUT_SECONDS))
-echo "Waiting up to ${TIMEOUT_SECONDS}s for Postgres and Redis to become healthy..."
+
+if [[ "${WAIT_FOR_API}" == "true" ]]; then
+    echo "Waiting up to ${TIMEOUT_SECONDS}s for Postgres, Redis, and API (port ${API_PORT})..."
+else
+    echo "Waiting up to ${TIMEOUT_SECONDS}s for Postgres and Redis to become healthy..."
+fi
 
 while (( SECONDS < deadline )); do
     postgres_ok=false
     redis_ok=false
+    api_ok=false
 
-    if postgres_ready; then
-        postgres_ok=true
+    postgres_ready && postgres_ok=true
+    redis_ready    && redis_ok=true
+
+    if [[ "${WAIT_FOR_API}" == "true" ]]; then
+        api_ready && api_ok=true
+
+        if [[ "${postgres_ok}" == "true" && "${redis_ok}" == "true" && "${api_ok}" == "true" ]]; then
+            echo "[OK] Postgres, Redis, and API are ready."
+            exit 0
+        fi
+        echo "Still waiting: postgres=${postgres_ok}, redis=${redis_ok}, api=${api_ok}"
+    else
+        if [[ "${postgres_ok}" == "true" && "${redis_ok}" == "true" ]]; then
+            echo "[OK] Postgres and Redis are ready."
+            exit 0
+        fi
+        echo "Still waiting: postgres=${postgres_ok}, redis=${redis_ok}"
     fi
 
-    if redis_ready; then
-        redis_ok=true
-    fi
-
-    if [[ "${postgres_ok}" == "true" && "${redis_ok}" == "true" ]]; then
-        echo "[OK] Postgres and Redis are ready."
-        exit 0
-    fi
-
-    echo "Still waiting: postgres=${postgres_ok}, redis=${redis_ok}"
     sleep "${SLEEP_SECONDS}"
 done
 
-echo "[ERROR] Timed out after ${TIMEOUT_SECONDS}s waiting for Postgres and Redis." >&2
+echo "[ERROR] Timed out after ${TIMEOUT_SECONDS}s." >&2
 print_status >&2
 cat >&2 <<'EOF'
 
 Next steps:
-  1. Start or restart dependencies: docker-compose up -d
+  1. Start or restart services:
+       # deps only:
+       docker-compose up -d
+       # full stack (deps + API):
+       docker compose -f docker-compose.yml -f docker-compose.app.yml up -d
+       # full stack with indexer:
+       docker compose -f docker-compose.yml -f docker-compose.app.yml --profile indexer up -d
   2. Inspect health checks: docker-compose ps
   3. Review recent logs:
        docker-compose logs --tail=50 postgres
        docker-compose logs --tail=50 redis
+       docker compose -f docker-compose.yml -f docker-compose.app.yml logs --tail=50 api
 
 You can extend the wait window with:
-  TIMEOUT_SECONDS=120 ./scripts/wait-for-services.sh
+  TIMEOUT_SECONDS=120 ./scripts/wait-for-services.sh [--api]
 EOF
 exit 1


### PR DESCRIPTION
…ose, idempotent pool registration

Closes #1025, closes #1032, closes #1034, closes #1041

## #1025 — RPC/Horizon failover configuration for production

**Problem:** A single Horizon or Soroban RPC outage takes live trading down because only one URL was supported.

**Changes:**
- `crates/indexer/src/config/mod.rs`: added `stellar_horizon_fallback_urls` and `soroban_rpc_fallback_urls` fields (comma-separated, env-driven), plus `horizon_urls()` and `soroban_rpc_urls()` helpers that return the primary URL followed by any fallbacks.
- `crates/indexer/src/bin/stellarroute-indexer.rs`: startup reachability check now iterates all Horizon URLs and all Soroban RPC URLs in order, succeeding on the first reachable one. Logs fallback count at startup.
- `crates/api/src/dependency_health.rs`: `ExternalDependencyHealth` now stores `Vec<String>` URL lists (primary + fallbacks) and iterates them during health probes, returning `healthy` as soon as any URL responds. The public constructor signature changed from `Option<String>` to `Vec<String>` for both horizon and soroban fields. `from_env()` reads `STELLAR_HORIZON_FALLBACK_URLS` and `SOROBAN_RPC_FALLBACK_URLS`.
- `.env.example`: added commented-out fallback URL examples.
- `docs/development/environment-variables.md`: documented `STELLAR_HORIZON_FALLBACK_URLS` and `SOROBAN_RPC_FALLBACK_URLS`.

## #1032 — docker-compose full stack: API + indexer + frontend + deps

**Problem:** `docker-compose.yml` only started Postgres + Redis; contributors could not bring up a full runnable StellarRoute stack with one command.

**Changes:**
- `docker-compose.app.yml`: new overlay file adding `api`, `indexer`, and `frontend` services. `api` depends on healthy Postgres and Redis. `indexer` is gated behind the `indexer` profile and validates `ROUTER_CONTRACT_ADDRESS` at startup (clear exit on empty value, no silent crash-loop). `frontend` is gated behind the `ui` profile. Both service containers bind `API_HOST=0.0.0.0` internally.
- `scripts/wait-for-services.sh`: rewritten to support `--api` flag that also polls `GET /health` on `API_PORT`. Deps-only path (no flag) is unchanged.
- `.env.example`: all vars referenced by compose are already listed.
- `README.md`, `AGENTS.md`: updated Quick Start / Local dependencies sections with full-stack compose commands and `--api` wait-script usage.

Verify: `docker compose -f docker-compose.yml -f docker-compose.app.yml config` validates; after services start, `./scripts/wait-for-services.sh --api` and `curl -sf http://127.0.0.1:${API_PORT:-3000}/health` succeed.

## #1034 — Production process bind: API_HOST default unsafe for PaaS

**Problem:** `API_HOST` defaulted to `127.0.0.1` even on PaaS platforms (Render, Fly, Railway, K8s) that inject `PORT` and expect the process to accept traffic on `0.0.0.0`, causing silent health-check failures.

**Changes:**
- `crates/api/src/bin/stellarroute-api.rs`: extracted `resolve_bind_address()` — a pure function that returns `(host, port)`. When `PORT` is set (PaaS convention) it defaults the host to `0.0.0.0`; an explicit `API_HOST` always overrides. When `PORT` is absent the existing loopback default is preserved. Includes four unit tests covering: default loopback, PaaS PORT → all-interfaces, explicit API_HOST override, and API_PORT fallback.
- `docs/development/environment-variables.md`: API server table updated with `PORT` variable entry and production bind guidance.
- `.env.example`: added `PORT` and production `API_HOST=0.0.0.0` examples.

## #1041 — Idempotent testnet pool registration + verify against router

**Problem:** `register-pools.sh` was not idempotent (re-running it would attempt duplicate registrations), there was no standalone verify-against-router script for CI, and the deployment docs lacked a clear step-by-step command order.

**Changes:**
- `scripts/register-pools.sh`: rewritten to query `is_pool_registered` before each `register_pool` call; already-registered pools are skipped with `[OK] Already registered (no-op)`. Emits a machine-readable JSON summary to `logs/<network>-register-summary.json` plus a human log. Exits non-zero only on actual failures, not on already-registered or placeholder skips.
- `scripts/verify-pools.sh`: new script that queries `is_pool_registered` for every non-placeholder pool and exits non-zero if any are missing — designed as a CI gate after registration. Writes JSON to `logs/<network>-verify-pools-summary.json`.
- `docs/deployment/README.md`: added "Exact command order" section (step 0) with the canonical deploy → set-env → register → verify → start-indexer sequence. Updated step 3 sample output for idempotent re-run and added step 4 verify-pools documentation.