### PR TITLE
fix(m3,m5): live-router config guardrails + dependency circuit breaker

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -8,9 +8,26 @@ DATABASE_URL=postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarro
 REDIS_URL=redis://localhost:6379
 
 # ── Stellar / Soroban (required for indexer) ───────────────────────────
-STELLAR_HORIZON_URL=https://horizon.stellar.org
-SOROBAN_RPC_URL=https://soroban-rpc.testnet.stellar.org
+# Pick exactly ONE network block below. Horizon and Soroban RPC MUST point at
+# the same network: a mixed pair (e.g. mainnet Horizon + testnet Soroban) makes
+# SDEX and AMM liquidity describe two different ledgers and is unsupported.
+# Canonical URLs per network live in `config/networks.json`.
+
+# ── Testnet (default) ──
+STELLAR_HORIZON_URL=https://horizon-testnet.stellar.org
+SOROBAN_RPC_URL=https://soroban-testnet.stellar.org:443
+NEXT_PUBLIC_STELLAR_NETWORK=testnet
+# Network passphrase (reference): "Test SDF Network ; September 2015"
+# Copy the router ID from the committed deploy artifact:
+#   jq -r .router_contract_id config/deployments/testnet.json
 ROUTER_CONTRACT_ADDRESS=
+
+# ── Mainnet (comment out the testnet block above before enabling) ──
+# STELLAR_HORIZON_URL=https://horizon.stellar.org
+# SOROBAN_RPC_URL=https://soroban-rpc.mainnet.stellar.org:443
+# NEXT_PUBLIC_STELLAR_NETWORK=mainnet
+# Network passphrase (reference): "Public Global Stellar Network ; September 2015"
+# ROUTER_CONTRACT_ADDRESS=
 
 # ── API server (optional overrides) ──────────────────────────────────
 # API_HOST=127.0.0.1

--- a/.github/workflows/deploy-testnet.yml
+++ b/.github/workflows/deploy-testnet.yml
@@ -3,6 +3,11 @@ name: Deploy to Testnet
 on:
   workflow_dispatch:
     inputs:
+      deploy_router:
+        description: "Deploy a fresh router to testnet and emit config/deployments/testnet.json."
+        required: false
+        default: false
+        type: boolean
       contract_id:
         description: "Optional router contract id. Defaults to repository variable SOROBAN_CONTRACT_ID."
         required: false
@@ -13,8 +18,76 @@ env:
   STELLAR_NETWORK: testnet
 
 jobs:
+  # Deploys the router and emits the committed-shape, non-secret artifact
+  # (config/deployments/testnet.json). Opt-in per run; mainnet is never
+  # deployed from here and config/pools-mainnet.json is never touched.
+  deploy-router:
+    name: Deploy Router to Testnet
+    if: ${{ inputs.deploy_router }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+
+      - name: Install Soroban CLI
+        run: cargo install --locked soroban-cli || true
+
+      # `soroban keys add` reads the secret from stdin so it never appears in
+      # argv or the run log. GitHub also masks registered secrets in output.
+      - name: Set up deployer identity
+        env:
+          SOROBAN_DEPLOYER_SECRET: ${{ secrets.SOROBAN_DEPLOYER_SECRET }}
+        run: |
+          if [ -z "${SOROBAN_DEPLOYER_SECRET}" ]; then
+            echo "::error::SOROBAN_DEPLOYER_SECRET is not configured"
+            exit 1
+          fi
+          soroban network add testnet \
+            --rpc-url "https://soroban-testnet.stellar.org:443" \
+            --network-passphrase "Test SDF Network ; September 2015" || true
+          printf '%s' "${SOROBAN_DEPLOYER_SECRET}" \
+            | soroban keys add deployer --secret-key stdin --global
+
+      - name: Deploy router and write artifact
+        run: ./scripts/deploy.sh --network testnet
+
+      # Hard gate: the emitted ID must answer on-chain, or the run fails and
+      # the artifact is not published.
+      - name: Smoke check deployed router
+        run: |
+          set -euo pipefail
+          ROUTER_ID="$(jq -r .router_contract_id config/deployments/testnet.json)"
+          if [ -z "${ROUTER_ID}" ] || [ "${ROUTER_ID}" = "null" ]; then
+            echo "::error::Artifact contains no router_contract_id"
+            exit 1
+          fi
+          echo "Smoke-checking ${ROUTER_ID}"
+          soroban contract invoke \
+            --id "${ROUTER_ID}" \
+            --source deployer \
+            --network testnet \
+            -- get_admin
+
+      - name: Show artifact
+        run: |
+          cat config/deployments/testnet.json
+          echo "Copy this into ROUTER_CONTRACT_ADDRESS:"
+          jq -r .router_contract_id config/deployments/testnet.json
+
+      - name: Upload deployment artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: deployment-testnet
+          path: config/deployments/testnet.json
+
   smoke-test:
     name: Testnet Contract Smoke Tests
+    needs: [deploy-router]
+    if: ${{ always() && !cancelled() && needs.deploy-router.result != 'failure' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -56,7 +56,9 @@ sdk-js/node_modules/
 tarpaulin-report.html
 coverage/
 
-# Deployment artifacts (generated at runtime)
+# Deployment artifacts (generated at runtime, may contain local build paths).
+# The reviewable, non-secret artifacts in config/deployments/ are tracked on
+# purpose — see config/deployments/README.md.
 config/deployment-*.json
 logs/
 

--- a/config/deployments/README.md
+++ b/config/deployments/README.md
@@ -1,0 +1,38 @@
+# Deployment artifacts (committed, non-secret)
+
+This directory holds the **reviewable** record of what is deployed on each network.
+Unlike `config/deployment-*.json` (gitignored, written locally by `scripts/deploy.sh`
+and containing local build paths), everything here is public and safe to commit.
+
+## Schema
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `network` | string | `testnet` or `mainnet` |
+| `router_contract_id` | string | Deployed router contract ID (56 chars, starts with `C`). Empty means not yet deployed |
+| `constant_product_adapter_contract_id` | string | Deployed adapter contract ID |
+| `deployed_at` | string (RFC 3339, UTC) | When the deploy completed |
+| `git_sha` | string | Commit that produced the deployed WASM |
+| `rpc_url` | string | Public Soroban RPC endpoint for `network` |
+
+## Producing it
+
+`scripts/deploy.sh --network testnet` writes this file via `save_public_deployment`,
+after which the deploy is smoke-checked against the live contract. The
+`Deploy to Testnet` GitHub Actions workflow runs the same path and uploads the
+result as a build artifact for review before it is committed.
+
+## Consuming it
+
+```bash
+export ROUTER_CONTRACT_ADDRESS="$(jq -r .router_contract_id config/deployments/testnet.json)"
+```
+
+The indexer validates this value at startup and refuses to run on an empty or
+malformed ID — see [`docs/development/indexer-guide.md`](../../docs/development/indexer-guide.md).
+
+## Rules
+
+- **Never** add secret keys, seed phrases, deployer identities, or local paths here.
+- `mainnet.json` is intentionally absent: mainnet deploys stay manually gated, and
+  `config/pools-mainnet.json` is never auto-populated by a workflow.

--- a/config/deployments/testnet.json
+++ b/config/deployments/testnet.json
@@ -1,0 +1,8 @@
+{
+  "network": "testnet",
+  "router_contract_id": "",
+  "constant_product_adapter_contract_id": "",
+  "deployed_at": "",
+  "git_sha": "",
+  "rpc_url": "https://soroban-testnet.stellar.org:443"
+}

--- a/crates/api/src/dependency_health.rs
+++ b/crates/api/src/dependency_health.rs
@@ -8,6 +8,13 @@ use stellarroute_routing::health::circuit_breaker::{
 
 const HORIZON_KEY: &str = "horizon";
 const SOROBAN_KEY: &str = "soroban_rpc";
+const DATABASE_KEY: &str = "database";
+
+/// Dependencies whose failure makes a quote/swap answer wrong rather than slow.
+///
+/// Redis is deliberately excluded: it is a performance cache and the API already
+/// degrades gracefully without it, so an open Redis breaker must not reject traffic.
+const LIVE_PATH_DEPENDENCIES: [&str; 3] = [DATABASE_KEY, SOROBAN_KEY, HORIZON_KEY];
 
 #[derive(Clone)]
 pub struct ExternalDependencyHealth {
@@ -16,6 +23,7 @@ pub struct ExternalDependencyHealth {
     soroban_rpc_url: Option<String>,
     horizon_breaker: Arc<CircuitBreakerRegistry>,
     soroban_breaker: Arc<CircuitBreakerRegistry>,
+    database_breaker: Arc<CircuitBreakerRegistry>,
 }
 
 impl ExternalDependencyHealth {
@@ -50,8 +58,69 @@ impl ExternalDependencyHealth {
             horizon_url,
             soroban_rpc_url,
             horizon_breaker: Arc::new(CircuitBreakerRegistry::new(cfg.clone())),
-            soroban_breaker: Arc::new(CircuitBreakerRegistry::new(cfg)),
+            soroban_breaker: Arc::new(CircuitBreakerRegistry::new(cfg.clone())),
+            database_breaker: Arc::new(CircuitBreakerRegistry::new(cfg)),
         }
+    }
+
+    fn breaker_for(&self, key: &str) -> &CircuitBreakerRegistry {
+        match key {
+            DATABASE_KEY => &self.database_breaker,
+            SOROBAN_KEY => &self.soroban_breaker,
+            _ => &self.horizon_breaker,
+        }
+    }
+
+    /// Dependencies whose breaker is open right now, refreshing the exported gauge.
+    pub fn open_dependencies(&self) -> Vec<&'static str> {
+        LIVE_PATH_DEPENDENCIES
+            .into_iter()
+            .filter(|key| {
+                let open = self.breaker_for(key).is_venue_excluded(key);
+                crate::metrics::DEPENDENCY_BREAKER_OPEN
+                    .with_label_values(&[key])
+                    .set(open as i64);
+                open
+            })
+            .collect()
+    }
+
+    /// Fail-fast guard for the quote/swap path.
+    ///
+    /// When a dependency breaker is open, reject immediately with 503 instead of
+    /// letting every request pay the full timeout against a known-dead dependency.
+    pub fn guard_live_path(&self) -> crate::error::Result<()> {
+        let open = self.open_dependencies();
+        if open.is_empty() {
+            return Ok(());
+        }
+
+        for dep in &open {
+            crate::metrics::DEPENDENCY_FAIL_FAST
+                .with_label_values(&[dep])
+                .inc();
+        }
+
+        Err(crate::error::ApiError::DependencyUnavailable(format!(
+            "Upstream dependency unavailable: {}. Circuit breaker is open; retry shortly.",
+            open.join(", ")
+        )))
+    }
+
+    pub fn database_breaker_is_open(&self) -> bool {
+        self.database_breaker.is_venue_excluded(DATABASE_KEY)
+    }
+
+    pub fn record_database_result(&self, success: bool) {
+        self.database_breaker.record_result(DATABASE_KEY, success);
+        self.refresh_gauge(DATABASE_KEY);
+    }
+
+    fn refresh_gauge(&self, key: &str) {
+        let open = self.breaker_for(key).is_venue_excluded(key);
+        crate::metrics::DEPENDENCY_BREAKER_OPEN
+            .with_label_values(&[key])
+            .set(open as i64);
     }
 
     pub async fn probe_horizon(&self) -> String {
@@ -80,10 +149,12 @@ impl ExternalDependencyHealth {
 
     pub fn record_soroban_result(&self, success: bool) {
         self.soroban_breaker.record_result(SOROBAN_KEY, success);
+        self.refresh_gauge(SOROBAN_KEY);
     }
 
     pub fn record_horizon_result(&self, success: bool) {
         self.horizon_breaker.record_result(HORIZON_KEY, success);
+        self.refresh_gauge(HORIZON_KEY);
     }
 
     async fn probe_horizon_with_client(&self, client: &Client) -> String {
@@ -103,7 +174,7 @@ impl ExternalDependencyHealth {
             .map(|resp| resp.status().is_success())
             .unwrap_or(false);
 
-        self.horizon_breaker.record_result(HORIZON_KEY, success);
+        self.record_horizon_result(success);
 
         if success {
             "healthy".to_string()
@@ -139,7 +210,7 @@ impl ExternalDependencyHealth {
             .and_then(|resp| resp.error_for_status())
             .is_ok();
 
-        self.soroban_breaker.record_result(SOROBAN_KEY, success);
+        self.record_soroban_result(success);
 
         if success {
             "healthy".to_string()
@@ -152,6 +223,7 @@ impl ExternalDependencyHealth {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use axum::response::IntoResponse;
     use stellarroute_routing::health::circuit_breaker::BreakerState;
 
     #[test]
@@ -165,6 +237,72 @@ mod tests {
         assert_eq!(health.soroban_breaker_state(), Some(BreakerState::Open));
         assert!(!health.horizon_breaker_is_open());
         assert_ne!(health.horizon_breaker_state(), Some(BreakerState::Open));
+    }
+
+    /// Simulated Soroban RPC outage: the live path must reject fast with 503
+    /// rather than let each request wait on a dependency known to be down.
+    #[test]
+    fn live_path_fails_fast_when_soroban_dependency_fails() {
+        let health = ExternalDependencyHealth::new(None, None);
+        assert!(health.guard_live_path().is_ok());
+
+        for _ in 0..3 {
+            health.record_soroban_result(false);
+        }
+
+        let err = health.guard_live_path().unwrap_err();
+        assert!(matches!(err, crate::error::ApiError::DependencyUnavailable(_)));
+        assert_eq!(
+            err.into_response().status(),
+            axum::http::StatusCode::SERVICE_UNAVAILABLE
+        );
+    }
+
+    /// Simulated Postgres outage, fed by the `/health/deps` probe.
+    #[test]
+    fn live_path_fails_fast_when_database_dependency_fails() {
+        let health = ExternalDependencyHealth::new(None, None);
+
+        for _ in 0..3 {
+            health.record_database_result(false);
+        }
+
+        assert!(health.database_breaker_is_open());
+        assert_eq!(health.open_dependencies(), vec!["database"]);
+        assert!(health.guard_live_path().is_err());
+    }
+
+    /// A recovered dependency must stop rejecting traffic.
+    #[test]
+    fn live_path_recovers_once_breaker_closes() {
+        let health = ExternalDependencyHealth::new(None, None);
+
+        for _ in 0..3 {
+            health.record_horizon_result(false);
+        }
+        assert!(health.guard_live_path().is_err());
+
+        // Breakers only leave Open via the recovery timeout, so drive the
+        // transition explicitly through a fresh instance's success path.
+        let recovered = ExternalDependencyHealth::new(None, None);
+        recovered.record_horizon_result(true);
+        assert!(recovered.guard_live_path().is_ok());
+        assert!(recovered.open_dependencies().is_empty());
+    }
+
+    #[test]
+    fn open_dependencies_reports_every_failing_dependency() {
+        let health = ExternalDependencyHealth::new(None, None);
+
+        for _ in 0..3 {
+            health.record_soroban_result(false);
+            health.record_database_result(false);
+        }
+
+        let open = health.open_dependencies();
+        assert!(open.contains(&"soroban_rpc"));
+        assert!(open.contains(&"database"));
+        assert!(!open.contains(&"horizon"));
     }
 
     #[test]

--- a/crates/api/src/error.rs
+++ b/crates/api/src/error.rs
@@ -34,6 +34,10 @@ pub enum ApiError {
     #[error("System overloaded: {0}")]
     Overloaded(String),
 
+    /// A dependency circuit breaker is open — reject fast instead of cascading latency.
+    #[error("Dependency unavailable: {0}")]
+    DependencyUnavailable(String),
+
     #[error("Unauthorized: {0}")]
     Unauthorized(String),
 
@@ -92,6 +96,11 @@ impl IntoResponse for ApiError {
             ApiError::Overloaded(msg) => (
                 StatusCode::SERVICE_UNAVAILABLE,
                 ApiErrorCode::Overloaded,
+                msg,
+            ),
+            ApiError::DependencyUnavailable(msg) => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                ApiErrorCode::DependencyUnavailable,
                 msg,
             ),
             ApiError::Unauthorized(msg) => {

--- a/crates/api/src/metrics.rs
+++ b/crates/api/src/metrics.rs
@@ -138,6 +138,26 @@ lazy_static! {
     )
     .expect("Can't create QUEUE_VIRTUAL_CLOCK gauge");
 
+    // ── Dependency circuit breaker metrics ────────────────────────────────
+
+    /// Whether a dependency's circuit breaker is currently open (1) or not (0).
+    /// Labels: dependency (horizon / soroban_rpc / database)
+    pub static ref DEPENDENCY_BREAKER_OPEN: IntGaugeVec = register_int_gauge_vec!(
+        "stellarroute_dependency_breaker_open",
+        "Dependency circuit breaker state: 1 = open (failing fast), 0 = closed/half-open",
+        &["dependency"]
+    )
+    .expect("Can't create DEPENDENCY_BREAKER_OPEN gauge");
+
+    /// Requests rejected on the live path because a dependency breaker was open.
+    /// Labels: dependency (horizon / soroban_rpc / database)
+    pub static ref DEPENDENCY_FAIL_FAST: IntCounterVec = register_int_counter_vec!(
+        "stellarroute_dependency_fail_fast_total",
+        "Requests rejected fast because a dependency circuit breaker was open",
+        &["dependency"]
+    )
+    .expect("Can't create DEPENDENCY_FAIL_FAST counter");
+
     // ── Indexer lag metrics ───────────────────────────────────────────────
 
     /// Indexer lag in ledger counts relative to Horizon.
@@ -369,13 +389,13 @@ pub fn update_indexer_lag(
 /// Record health score recomputation job duration.
 pub fn record_health_score_duration(duration: Duration) {
     HEALTH_SCORE_JOB_DURATION
-        .with_label_values(&[])
+        .with_label_values::<&str>(&[])
         .observe(duration.as_secs_f64());
 }
 
 /// Increment the health score recomputation failure counter.
 pub fn record_health_score_failure() {
-    HEALTH_SCORE_JOB_FAILURES.with_label_values(&[]).inc();
+    HEALTH_SCORE_JOB_FAILURES.with_label_values::<&str>(&[]).inc();
 }
 
 // ── Webhook metrics ───────────────────────────────────────────────────────────
@@ -448,12 +468,12 @@ pub fn record_webhook_delivery_attempt(integrator_id: &str, attempt: u32) {
 }
 
 pub fn update_webhook_pending_quotes(count: i64) {
-    WEBHOOK_PENDING_QUOTES.with_label_values(&[]).set(count);
+    WEBHOOK_PENDING_QUOTES.with_label_values::<&str>(&[]).set(count);
 }
 
 pub fn record_webhook_poll_cycle_duration(duration: Duration) {
     WEBHOOK_POLL_CYCLE_DURATION
-        .with_label_values(&[])
+        .with_label_values::<&str>(&[])
         .observe(duration.as_secs_f64());
 }
 

--- a/crates/api/src/models/response.rs
+++ b/crates/api/src/models/response.rs
@@ -638,6 +638,8 @@ pub enum ApiErrorCode {
     RateLimitExceeded,
     /// Server is temporarily overloaded
     Overloaded,
+    /// An upstream dependency's circuit breaker is open
+    DependencyUnavailable,
     /// Request lacks valid credentials
     Unauthorized,
     /// Invalid Stellar asset identifier
@@ -665,6 +667,7 @@ impl ApiErrorCode {
             Self::ValidationError => "validation_error",
             Self::RateLimitExceeded => "rate_limit_exceeded",
             Self::Overloaded => "overloaded",
+            Self::DependencyUnavailable => "dependency_unavailable",
             Self::Unauthorized => "unauthorized",
             Self::InvalidAsset => "invalid_asset",
             Self::InvalidAmount => "invalid_amount",

--- a/crates/api/src/routes/health.rs
+++ b/crates/api/src/routes/health.rs
@@ -140,10 +140,18 @@ pub async fn dependency_health(
     let mut all_ok = true;
 
     // --- PostgreSQL ---
+    // Feeds the database circuit breaker so the live path can fail fast rather
+    // than queue behind an unreachable Postgres.
     let db_status = match sqlx::query("SELECT 1").execute(state.db.read_pool()).await {
-        Ok(_) => "healthy".to_string(),
+        Ok(_) => {
+            state.external_dependency_health.record_database_result(true);
+            "healthy".to_string()
+        }
         Err(e) => {
             warn!("Dependency DB health check failed: {}", e);
+            state
+                .external_dependency_health
+                .record_database_result(false);
             all_ok = false;
             "degraded".to_string()
         }

--- a/crates/api/src/routes/mod.rs
+++ b/crates/api/src/routes/mod.rs
@@ -70,6 +70,23 @@ async fn production_admin_guard(
     }
 }
 
+/// Fail-fast guard for quote/swap traffic.
+///
+/// When a dependency circuit breaker (Postgres, Soroban RPC, Horizon) is open,
+/// reject with `503` immediately instead of letting every request queue behind a
+/// dependency that is already known to be down. Health endpoints stay reachable so
+/// operators can still see why, and so probes can close the breaker again.
+async fn dependency_breaker_guard(
+    State(state): State<Arc<AppState>>,
+    request: Request,
+    next: Next,
+) -> Response {
+    match state.external_dependency_health.guard_live_path() {
+        Ok(()) => next.run(request).await,
+        Err(err) => err.into_response(),
+    }
+}
+
 /// Create the main API router
 pub fn create_router(state: Arc<AppState>) -> Router {
     // Operator-only surfaces: publicly reachable in dev/test for local
@@ -89,11 +106,38 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             production_admin_guard,
         ));
 
+    // Quote/swap surfaces. These are the paths that price real trades against
+    // live dependencies, so they fail fast when a dependency breaker is open.
+    let live_path_routes = Router::new()
+        .route("/api/v1/quote/:base/:quote", get(quote::get_quote))
+        .route("/api/v1/quote", post(idempotent_quote::post_quote))
+        .route(
+            "/api/v1/route/:base/:quote",
+            get(quote::get_route).route_layer(axum::middleware::from_fn(legacy_route_deprecation)),
+        )
+        .route(
+            "/api/v1/batch/quote",
+            axum::routing::post(quote::get_batch_quotes),
+        )
+        .route(
+            "/api/v1/routes/:base/:quote",
+            get(routes_endpoint::get_routes),
+        )
+        .route(
+            "/api/v1/simulate/route",
+            post(simulation_route::simulate_route_dry_run),
+        )
+        .route_layer(axum::middleware::from_fn_with_state(
+            state.clone(),
+            dependency_breaker_guard,
+        ));
+
     Router::new()
         // Health check
         .route("/health", get(health::health_check))
         .route("/health/deps", get(health::dependency_health))
         .merge(operator_routes)
+        .merge(live_path_routes)
         // API v1 routes
         .route("/api/v1/assets", get(assets::list_assets_metadata))
         .route("/api/v1/assets/:code", get(assets::get_asset_metadata))
@@ -108,16 +152,6 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             "/api/v1/orderbook/:base/:quote",
             get(orderbook::get_orderbook),
         )
-        .route("/api/v1/quote/:base/:quote", get(quote::get_quote))
-        .route("/api/v1/quote", post(idempotent_quote::post_quote))
-        .route(
-            "/api/v1/route/:base/:quote",
-            get(quote::get_route).route_layer(axum::middleware::from_fn(legacy_route_deprecation)),
-        )
-        .route(
-            "/api/v1/batch/quote",
-            axum::routing::post(quote::get_batch_quotes),
-        )
         .route(
             "/api/v1/batch/orderbook",
             axum::routing::post(orderbook::get_batch_orderbooks),
@@ -127,10 +161,6 @@ pub fn create_router(state: Arc<AppState>) -> Router {
             post(integrator_webhooks::upsert_quote_expiration_webhook),
         )
         // Replay routes are registered above via `operator_routes`.
-        .route(
-            "/api/v1/routes/:base/:quote",
-            get(routes_endpoint::get_routes),
-        )
         // Admin routes
         .route(
             "/api/v1/admin/cache/flush/:base/:quote",
@@ -148,10 +178,7 @@ pub fn create_router(state: Arc<AppState>) -> Router {
         // Canary routes
         .route("/api/v1/system/canary/report", get(canary::get_report))
         .route("/api/v1/system/canary/config", post(canary::update_config))
-        .route(
-            "/api/v1/simulate/route",
-            post(simulation_route::simulate_route_dry_run),
-        )
+        // `/api/v1/simulate/route` is registered above via `live_path_routes`.
         // Contract registry routes
         .route(
             "/api/v1/contracts/registry",

--- a/crates/indexer/src/bin/stellarroute-indexer.rs
+++ b/crates/indexer/src/bin/stellarroute-indexer.rs
@@ -3,7 +3,7 @@
 //! Main entry point for the SDEX orderbook indexer service.
 
 use std::process;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use std::time::Duration;
 use stellarroute_indexer::amm::{AmmAggregator, AmmConfig};
@@ -139,7 +139,10 @@ async fn main() {
     let partition_manager = stellarroute_indexer::partition::PartitionManager::from_config(&config);
     let sdex_indexer = SdexIndexer::with_mode(horizon, db.clone(), sdex_mode, partition_manager);
 
-    // Create AMM aggregator
+    // Create AMM aggregator. An empty router here means `ALLOW_EMPTY_ROUTER` was
+    // honored (dev only — `from_env` rejects it otherwise), so run SDEX-only
+    // rather than starting an aggregation loop against no contract.
+    let amm_enabled = !config.router_contract_address.trim().is_empty();
     let amm_config = AmmConfig {
         router_contract: config.router_contract_address.clone(),
         poll_interval_secs: config.amm_poll_interval_secs,
@@ -162,6 +165,13 @@ async fn main() {
 
     let amm_shutdown = shutdown.clone();
     let amm_handle = tokio::spawn(async move {
+        if !amm_enabled {
+            warn!(
+                "ALLOW_EMPTY_ROUTER is set and ROUTER_CONTRACT_ADDRESS is empty — \
+                 running SDEX-only, AMM pool discovery is disabled"
+            );
+            return;
+        }
         info!("Starting AMM aggregation loop");
         if let Err(e) = amm_aggregator.start_aggregation().await {
             if !amm_shutdown.is_stopping() {

--- a/crates/indexer/src/config/mod.rs
+++ b/crates/indexer/src/config/mod.rs
@@ -20,7 +20,12 @@ pub struct IndexerConfig {
     /// Soroban RPC base URL
     pub soroban_rpc_url: String,
 
-    /// Router contract address for AMM pool discovery
+    /// Router contract address for AMM pool discovery.
+    ///
+    /// Enforced by [`check_router_contract_address`] in [`IndexerConfig::from_env`]
+    /// rather than by serde, so that the dev-only `ALLOW_EMPTY_ROUTER` escape hatch
+    /// can leave it blank without deserialization failing.
+    #[serde(default)]
     pub router_contract_address: String,
 
     /// Postgres connection string
@@ -186,6 +191,71 @@ fn default_hot_pair_window_secs() -> u64 {
     300
 }
 
+/// Length of a Soroban contract ID in its StrKey (base32) text form.
+const CONTRACT_ID_LEN: usize = 56;
+
+/// Format-only check for a Soroban contract ID (`C` + 55 base32 chars).
+///
+/// Deliberately does not verify the StrKey checksum or hit the network — this is
+/// a startup footgun guard, not an on-chain existence proof.
+fn is_contract_id_shaped(value: &str) -> bool {
+    value.len() == CONTRACT_ID_LEN
+        && value.starts_with('C')
+        && value
+            .bytes()
+            .all(|b| b.is_ascii_uppercase() || (b'2'..=b'7').contains(&b))
+}
+
+/// Validate `ROUTER_CONTRACT_ADDRESS` before any indexing loop is started.
+///
+/// `raw` is the raw env value (`None` when the variable is unset). `allow_empty`
+/// reflects `ALLOW_EMPTY_ROUTER`, and `is_production` reflects
+/// `STELLARROUTE_ENV=production` — the escape hatch is refused in production.
+///
+/// Returns the validated contract ID, or `None` when the dev-only escape hatch
+/// legitimately permits an empty AMM side.
+pub fn check_router_contract_address(
+    raw: Option<&str>,
+    allow_empty: bool,
+    is_production: bool,
+) -> std::result::Result<Option<String>, String> {
+    let value = raw.unwrap_or("").trim();
+
+    if value.is_empty() {
+        if allow_empty && is_production {
+            return Err(
+                "ROUTER_CONTRACT_ADDRESS is missing or empty. ALLOW_EMPTY_ROUTER is a \
+                 development-only escape hatch and is refused when STELLARROUTE_ENV=production. \
+                 Set ROUTER_CONTRACT_ADDRESS to the deployed router contract ID (see \
+                 `jq -r .router_contract_id config/deployments/testnet.json`)."
+                    .to_string(),
+            );
+        }
+        if allow_empty {
+            return Ok(None);
+        }
+        return Err(
+            "ROUTER_CONTRACT_ADDRESS is missing or empty. Set it to the deployed router \
+             contract ID (56 characters, starting with `C`); read it from the deploy artifact \
+             with `jq -r .router_contract_id config/deployments/testnet.json`. For SDEX-only \
+             local development set ALLOW_EMPTY_ROUTER=1."
+                .to_string(),
+        );
+    }
+
+    if !is_contract_id_shaped(value) {
+        return Err(format!(
+            "ROUTER_CONTRACT_ADDRESS is not a valid Soroban contract ID: expected {} base32 \
+             characters starting with `C`, got {} character(s). Read the correct value from the \
+             deploy artifact with `jq -r .router_contract_id config/deployments/testnet.json`.",
+            CONTRACT_ID_LEN,
+            value.len()
+        ));
+    }
+
+    Ok(Some(value.to_string()))
+}
+
 impl IndexerConfig {
     pub fn load() -> std::result::Result<Self, config::ConfigError> {
         let cfg = config::Config::builder()
@@ -196,12 +266,7 @@ impl IndexerConfig {
 
     /// Convenience constructor from environment variables.
     pub fn from_env() -> std::result::Result<Self, config::ConfigError> {
-        let required = [
-            "DATABASE_URL",
-            "STELLAR_HORIZON_URL",
-            "SOROBAN_RPC_URL",
-            "ROUTER_CONTRACT_ADDRESS",
-        ];
+        let required = ["DATABASE_URL", "STELLAR_HORIZON_URL", "SOROBAN_RPC_URL"];
         let mut missing = Vec::new();
         for key in required {
             match std::env::var(key) {
@@ -216,9 +281,103 @@ impl IndexerConfig {
             )));
         }
 
-        Self::load()
+        // Validated separately so the failure names the variable and says how to fix it.
+        let raw_router = std::env::var("ROUTER_CONTRACT_ADDRESS").ok();
+        let allow_empty = std::env::var("ALLOW_EMPTY_ROUTER")
+            .map(|v| {
+                matches!(
+                    v.trim().to_ascii_lowercase().as_str(),
+                    "1" | "true" | "yes" | "on"
+                )
+            })
+            .unwrap_or(false);
+        let is_production = std::env::var("STELLARROUTE_ENV")
+            .map(|v| v.trim().eq_ignore_ascii_case("production"))
+            .unwrap_or(false);
+
+        let router = check_router_contract_address(raw_router.as_deref(), allow_empty, is_production)
+            .map_err(config::ConfigError::Message)?;
+
+        let mut config = Self::load()?;
+        config.router_contract_address = router.unwrap_or_default();
+        Ok(config)
     }
 }
 
 // Optional alias if you still want it:
 pub type Config = IndexerConfig;
+
+#[cfg(test)]
+mod router_contract_tests {
+    use super::check_router_contract_address;
+
+    /// Shape-valid sample: `C` + 55 base32 characters.
+    const VALID_ID: &str = "CCJZ5DGCTUUYYUQZ7CQGDJEQZ7CQGDJEQZ7CQGDJEQZ7CQGDJEQZ7CQG";
+
+    #[test]
+    fn valid_sample_is_56_base32_chars() {
+        assert_eq!(VALID_ID.len(), 56);
+    }
+
+    #[test]
+    fn missing_router_contract_is_rejected() {
+        let err = check_router_contract_address(None, false, false).unwrap_err();
+        assert!(err.contains("ROUTER_CONTRACT_ADDRESS"));
+    }
+
+    #[test]
+    fn empty_router_contract_is_rejected() {
+        let err = check_router_contract_address(Some(""), false, false).unwrap_err();
+        assert!(err.contains("ROUTER_CONTRACT_ADDRESS"));
+    }
+
+    #[test]
+    fn whitespace_router_contract_is_rejected() {
+        let err = check_router_contract_address(Some("   \t "), false, false).unwrap_err();
+        assert!(err.contains("ROUTER_CONTRACT_ADDRESS"));
+    }
+
+    #[test]
+    fn malformed_router_contract_is_rejected() {
+        // Right length, wrong prefix.
+        let wrong_prefix = format!("G{}", &VALID_ID[1..]);
+        assert!(check_router_contract_address(Some(&wrong_prefix), false, false).is_err());
+
+        // Right prefix, wrong length.
+        assert!(check_router_contract_address(Some("CABC"), false, false).is_err());
+
+        // Lowercase is not valid base32 StrKey.
+        assert!(
+            check_router_contract_address(Some(&VALID_ID.to_ascii_lowercase()), false, false)
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn valid_router_contract_is_accepted_and_trimmed() {
+        let padded = format!("  {}  ", VALID_ID);
+        assert_eq!(
+            check_router_contract_address(Some(&padded), false, false).unwrap(),
+            Some(VALID_ID.to_string())
+        );
+    }
+
+    #[test]
+    fn allow_empty_router_is_a_dev_only_escape_hatch() {
+        assert_eq!(
+            check_router_contract_address(Some(""), true, false).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn allow_empty_router_is_refused_in_production() {
+        let err = check_router_contract_address(None, true, true).unwrap_err();
+        assert!(err.contains("STELLARROUTE_ENV=production"));
+    }
+
+    #[test]
+    fn allow_empty_router_does_not_excuse_a_malformed_id() {
+        assert!(check_router_contract_address(Some("not-a-contract-id"), true, false).is_err());
+    }
+}

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -127,8 +127,48 @@ This will:
 2. Optimize the WASM binary
 3. Deploy router + adapter contracts to testnet
 4. Initialize router with deployer as admin, 30 bps fee rate
-5. Save contract IDs to `config/deployment-testnet.json`
-6. Verify router deployment by calling `get_admin()`
+5. Save contract IDs to `config/deployment-testnet.json` (gitignored, local detail)
+6. Save the reviewable, non-secret artifact to `config/deployments/testnet.json` (committed)
+7. Verify router deployment by calling `get_admin()`
+
+#### The committed deploy artifact
+
+`config/deployments/testnet.json` is the repo's reviewable record of what is live.
+It contains public data only — contract IDs, the public RPC URL, a UTC timestamp,
+and the git SHA of the build:
+
+```json
+{
+  "network": "testnet",
+  "router_contract_id": "C...",
+  "constant_product_adapter_contract_id": "C...",
+  "deployed_at": "2026-01-01T00:00:00Z",
+  "git_sha": "abc1234...",
+  "rpc_url": "https://soroban-testnet.stellar.org:443"
+}
+```
+
+Point the indexer at it:
+
+```bash
+export ROUTER_CONTRACT_ADDRESS="$(jq -r .router_contract_id config/deployments/testnet.json)"
+```
+
+Commit the updated artifact so the deployed address is reviewable in git history.
+See [`config/deployments/README.md`](../../config/deployments/README.md) for the
+full schema. Mainnet has no committed artifact: those deploys stay manually gated
+and `config/pools-mainnet.json` is never auto-populated.
+
+#### Keeping secrets out of artifacts and logs
+
+- The artifact writer emits only the fields above. Secret keys, seed phrases, and
+  deployer identities are never written to it.
+- In CI the deployer secret is piped to `soroban keys add --secret-key stdin`, so it
+  never appears in `argv` or the job log. GitHub additionally masks any value
+  registered as a repository secret.
+- `config/deployment-*.json` stays gitignored because it records local build paths.
+- Before sharing a run log, confirm no step echoes `SOROBAN_DEPLOYER_SECRET`; scripts
+  in `scripts/` log contract IDs and tx hashes only.
 
 Environment and runtime options:
 ```bash
@@ -385,6 +425,10 @@ For planned upgrades, follow the testnet upgrade flow in [Upgrade Process](#upgr
 
 ### Manual Deploy (`deploy-testnet.yml`)
 - Trigger: GitHub Actions > "Deploy to Testnet" > Run workflow
+- Set the `deploy_router` input to deploy a fresh router; the job writes
+  `config/deployments/testnet.json`, smoke-checks the deployed ID with `get_admin`,
+  and **fails the run** if the contract does not answer (so a bad ID is never published)
+- The artifact is uploaded as `deployment-testnet` for review before committing
 - Supports dry-run mode (build + hash only, no deploy)
 - Requires `SOROBAN_DEPLOYER_SECRET` secret and `DEPLOY_ENABLED=true` variable
 - Automatically registers pools from `config/pools-testnet.json` after deployment

--- a/docs/development/SETUP.md
+++ b/docs/development/SETUP.md
@@ -335,6 +335,16 @@ cargo build
 
 Make sure `.env` exists in the project root (see `.env.example`). The API requires `DATABASE_URL`; the indexer additionally requires `STELLAR_HORIZON_URL`, `SOROBAN_RPC_URL`, and `ROUTER_CONTRACT_ADDRESS`. See the [Environment Variables Reference](./environment-variables.md) for required vs optional settings per service.
 
+`.env.example` ships one coherent block per network (testnet enabled, mainnet commented out). **Copy a whole block — never mix networks.** Pointing `STELLAR_HORIZON_URL` at mainnet while `SOROBAN_RPC_URL` points at testnet indexes SDEX and AMM liquidity from two different ledgers into the same tables, and no component errors on the mismatch.
+
+The indexer also validates `ROUTER_CONTRACT_ADDRESS` at startup and exits non-zero if it is missing, empty, or not a well-formed Soroban contract ID. Populate it from the committed deploy artifact:
+
+```bash
+export ROUTER_CONTRACT_ADDRESS="$(jq -r .router_contract_id config/deployments/testnet.json)"
+```
+
+For SDEX-only local development, set `ALLOW_EMPTY_ROUTER=1` instead (dev only; refused when `STELLARROUTE_ENV=production`).
+
 ---
 
 ## FAQ

--- a/docs/development/environment-variables.md
+++ b/docs/development/environment-variables.md
@@ -54,6 +54,19 @@ PostgreSQL connection strings and pool tuning. Used by the API, indexer, replay 
 
 ## Stellar / Horizon
 
+> **Mixed networks are unsupported.** `STELLAR_HORIZON_URL` and `SOROBAN_RPC_URL`
+> must resolve to the same Stellar network. Pairing (for example) mainnet Horizon
+> with testnet Soroban RPC makes the indexer write SDEX offers from one ledger and
+> AMM pools from another into the same tables — quotes then price against liquidity
+> that does not exist, and nothing in the pipeline errors. `.env.example` ships one
+> coherent block per network; copy a whole block rather than editing single URLs.
+> Canonical per-network URLs live in [`config/networks.json`](../../config/networks.json).
+
+| Network | `STELLAR_HORIZON_URL` | `SOROBAN_RPC_URL` | Network passphrase |
+|---------|-----------------------|-------------------|--------------------|
+| Testnet | `https://horizon-testnet.stellar.org` | `https://soroban-testnet.stellar.org:443` | `Test SDF Network ; September 2015` |
+| Mainnet | `https://horizon.stellar.org` | `https://soroban-rpc.mainnet.stellar.org:443` | `Public Global Stellar Network ; September 2015` |
+
 | Variable | Type | Default | Required | Service(s) | Description |
 |----------|------|---------|----------|------------|-------------|
 | `STELLAR_HORIZON_URL` | string (URL) | — | **Required** (indexer); optional (API health/lag) | Indexer, API | Stellar Horizon API base URL (e.g. `https://horizon.stellar.org` or `https://horizon-testnet.stellar.org`) |
@@ -68,7 +81,8 @@ PostgreSQL connection strings and pool tuning. Used by the API, indexer, replay 
 | Variable | Type | Default | Required | Service(s) | Description |
 |----------|------|---------|----------|------------|-------------|
 | `SOROBAN_RPC_URL` | string (URL) | — | **Required** (indexer); optional health check (API) | Indexer, API | Soroban RPC endpoint (e.g. `https://soroban-rpc.testnet.stellar.org`). When set, the API validates reachability at startup if `STARTUP_CREDENTIAL_CHECK=true` |
-| `ROUTER_CONTRACT_ADDRESS` | string (Stellar address) | — | **Required** (indexer) | Indexer | Deployed router contract ID for AMM pool discovery |
+| `ROUTER_CONTRACT_ADDRESS` | string (Soroban contract ID) | — | **Required** (indexer) | Indexer | Deployed router contract ID for AMM pool discovery. Validated at indexer startup: must be a 56-character contract ID starting with `C`. Missing, empty, or malformed values abort startup with a non-zero exit before any SDEX/AMM loop runs. Read it from the committed deploy artifact: `jq -r .router_contract_id config/deployments/testnet.json` |
+| `ALLOW_EMPTY_ROUTER` | boolean | `false` | Optional (**dev only**) | Indexer | Escape hatch that lets the indexer boot with an unset/empty `ROUTER_CONTRACT_ADDRESS` (SDEX-only, no AMM discovery). Refused when `STELLARROUTE_ENV=production` — startup fails instead. Never set this in a deployed environment |
 | `AMM_POOLS` | string (comma-separated) | — | Optional | Indexer | Additional AMM pool addresses to index, appended to DB-discovered pools |
 
 ---

--- a/docs/development/indexer-guide.md
+++ b/docs/development/indexer-guide.md
@@ -39,8 +39,32 @@ The indexer requires these variables:
 - `SOROBAN_RPC_URL`
 - `ROUTER_CONTRACT_ADDRESS`
 
+`STELLAR_HORIZON_URL` and `SOROBAN_RPC_URL` must point at the **same** network.
+Mixing them (mainnet Horizon with testnet Soroban, say) writes SDEX offers and AMM
+pools from two different ledgers into the same tables. Copy a whole network block
+from `.env.example` instead of editing individual URLs.
+
+### `ROUTER_CONTRACT_ADDRESS` is validated at startup
+
+The indexer refuses to start when `ROUTER_CONTRACT_ADDRESS` is missing, empty,
+whitespace-only, or not shaped like a Soroban contract ID (56 base32 characters
+beginning with `C`). It exits non-zero with a message naming the variable, and no
+SDEX or AMM loop is started. This prevents the confusing half-running state where
+the process looks healthy but the AMM side is silently empty.
+
+Read the value from the committed deploy artifact:
+
+```bash
+export ROUTER_CONTRACT_ADDRESS="$(jq -r .router_contract_id config/deployments/testnet.json)"
+```
+
+For SDEX-only local work you can set `ALLOW_EMPTY_ROUTER=1`, which permits an empty
+router and disables AMM discovery. It is a **development-only** hatch: when
+`STELLARROUTE_ENV=production` it is refused and startup still fails.
+
 Optional operational variables:
 
+- `ALLOW_EMPTY_ROUTER=1` — dev-only; boot SDEX-only with no router (refused in production)
 - `STARTUP_CREDENTIAL_CHECK=true` to run startup reachability checks for DB/Horizon/Soroban
 - `RUST_LOG=stellarroute_indexer=info` (or `debug`) for log verbosity
 - `LOG_FORMAT=json` for structured JSON logs
@@ -50,7 +74,7 @@ PowerShell example:
 ```powershell
 $env:DATABASE_URL = "postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarroute"
 $env:STELLAR_HORIZON_URL = "https://horizon-testnet.stellar.org"
-$env:SOROBAN_RPC_URL = "https://soroban-rpc.testnet.stellar.org"
+$env:SOROBAN_RPC_URL = "https://soroban-testnet.stellar.org:443"
 $env:ROUTER_CONTRACT_ADDRESS = "<your-router-contract-address>"
 $env:STARTUP_CREDENTIAL_CHECK = "true"
 ```
@@ -60,7 +84,7 @@ Bash example:
 ```bash
 export DATABASE_URL="postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarroute"
 export STELLAR_HORIZON_URL="https://horizon-testnet.stellar.org"
-export SOROBAN_RPC_URL="https://soroban-rpc.testnet.stellar.org"
+export SOROBAN_RPC_URL="https://soroban-testnet.stellar.org:443"
 export ROUTER_CONTRACT_ADDRESS="<your-router-contract-address>"
 export STARTUP_CREDENTIAL_CHECK=true
 ```

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -79,6 +79,7 @@ DEPLOYMENT_CONTRACTS_JSON=$(cat <<JSON
 JSON
 )
 save_deployment "${DEPLOYMENT_CONTRACTS_JSON}"
+save_public_deployment "${DEPLOYED_IDS[router]}" "${DEPLOYED_IDS[constant_product_adapter]}"
 
 # ── Step 5: Verify Deployment ─────────────────────────────────────────
 
@@ -105,3 +106,7 @@ log_ok "Admin:       ${ADMIN_ADDRESS}"
 log_ok "Fee Rate:    ${FEE_RATE} bps"
 log_ok "Dry Run:     ${DRY_RUN}"
 log_ok "Artifact:    $(deployment_file)"
+log_ok "Public:      $(public_deployment_file)"
+echo ""
+log_info "Set ROUTER_CONTRACT_ADDRESS from the committed artifact:"
+log_info "  export ROUTER_CONTRACT_ADDRESS=\"\$(jq -r .router_contract_id $(public_deployment_file))\""

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -72,6 +72,12 @@ deployment_file() {
     echo "${CONFIG_DIR}/deployment-${NETWORK}.json"
 }
 
+# Committed, reviewable, non-secret artifact. Contains contract IDs and public
+# metadata only — never keys, identities, or local filesystem paths.
+public_deployment_file() {
+    echo "${CONFIG_DIR}/deployments/${NETWORK}.json"
+}
+
 get_contract_id() {
     get_named_contract_id "router"
 }
@@ -108,6 +114,46 @@ save_deployment() {
 }
 ARTIFACT
     log_ok "Deployment artifact saved to ${file}"
+}
+
+# Write the committed, non-secret deploy artifact consumed by operators and by
+# ROUTER_CONTRACT_ADDRESS. Fields here are all public: contract IDs, the public
+# RPC URL, a UTC timestamp, and the git SHA that produced the build.
+save_public_deployment() {
+    local router_id="$1"
+    local adapter_id="${2:-}"
+    local file
+    file="$(public_deployment_file)"
+    mkdir -p "$(dirname "${file}")"
+
+    cat > "${file}" <<ARTIFACT
+{
+  "network": "${NETWORK}",
+  "router_contract_id": "${router_id}",
+  "constant_product_adapter_contract_id": "${adapter_id}",
+  "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "git_sha": "$(git -C "${REPO_ROOT}" rev-parse HEAD 2>/dev/null || echo 'unknown')",
+  "rpc_url": "$(get_rpc_url)"
+}
+ARTIFACT
+
+    log_ok "Public deployment artifact saved to ${file}"
+}
+
+# Post-deploy smoke call: prove the ID actually resolves on-chain before the
+# artifact is trusted. Fails (non-zero) if the contract does not answer.
+smoke_check_router() {
+    local router_id="$1"
+    log_info "Smoke-checking router ${router_id} via get_admin()..."
+    if ! soroban_cmd contract invoke \
+        --id "${router_id}" \
+        --source "${IDENTITY}" \
+        --network "${NETWORK}" \
+        -- get_admin; then
+        log_error "Smoke check FAILED: router ${router_id} did not respond to get_admin on ${NETWORK}"
+        return 1
+    fi
+    log_ok "Smoke check passed for ${router_id}"
 }
 
 # ── Soroban Helpers ───────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1026, closes #1038, closes #1039, closes #1040.

Four M3/M5 blockers on the live-router path, kept deliberately minimal — each change is the smallest thing that satisfies the acceptance criteria.

---

## #1040 — `.env.example` Horizon/Soroban network mismatch

**Before / after default URLs:**

| Variable | Before | After (testnet block) |
|---|---|---|
| `STELLAR_HORIZON_URL` | `https://horizon.stellar.org` *(mainnet)* | `https://horizon-testnet.stellar.org` |
| `SOROBAN_RPC_URL` | `https://soroban-rpc.testnet.stellar.org` *(testnet)* | `https://soroban-testnet.stellar.org:443` |

The shipped default paired **mainnet Horizon with testnet Soroban**. `.env.example` now has one coherent block per network — testnet active, mainnet commented out — each listing matching Horizon + Soroban URLs, `NEXT_PUBLIC_STELLAR_NETWORK`, the network passphrase for reference, and a placeholder `ROUTER_CONTRACT_ADDRESS`. URLs match `config/networks.json`.

`docs/development/environment-variables.md` gains an explicit "mixed networks are unsupported" warning plus a per-network URL table; `SETUP.md` says copy a whole block, never edit single URLs.

## #1039 — Indexer fails fast on empty/invalid `ROUTER_CONTRACT_ADDRESS`

`check_router_contract_address` validates format (56 base32 chars starting with `C`) and runs in `from_env`, before any loop is spawned. Missing / empty / whitespace / malformed all abort with a single actionable message naming the variable and exit non-zero.

`ALLOW_EMPTY_ROUTER=1` is a dev-only hatch that boots SDEX-only with AMM discovery disabled; it is **refused when `STELLARROUTE_ENV=production`**, and never excuses a malformed ID. 9 unit tests cover missing, empty, whitespace, valid-shaped, malformed, and both escape-hatch paths.

## #1038 — Testnet deploy pipeline emitting a reviewable artifact

`scripts/deploy.sh --network testnet` now also writes **`config/deployments/testnet.json`** — committed and non-secret, distinct from the gitignored `config/deployment-*.json` which holds local build paths:

```json
{
  "network": "testnet",
  "router_contract_id": "C...",
  "constant_product_adapter_contract_id": "C...",
  "deployed_at": "2026-01-01T00:00:00Z",
  "git_sha": "abc1234",
  "rpc_url": "https://soroban-testnet.stellar.org:443"
}
```

The `Deploy to Testnet` workflow gains an opt-in `deploy_router` input that deploys, writes the artifact, **smoke-checks the deployed ID via `get_admin` and fails the run if it does not answer**, then uploads it for review. The deployer secret is piped via `--secret-key stdin` so it never reaches argv or the log; scrubbing notes are in `docs/deployment/README.md`. Mainnet stays gated and `config/pools-mainnet.json` is never auto-filled.

The committed `testnet.json` currently has empty ID fields — it is the reviewable slot, filled by the first real deploy run.

## #1026 — Circuit breaker when dependencies unhealthy

Quote/swap routes (`/api/v1/quote`, `/route`, `/routes`, `/batch/quote`, `/simulate/route`) are grouped into a `live_path_routes` sub-router behind `dependency_breaker_guard`, which returns **503 `dependency_unavailable`** immediately when the Postgres, Soroban RPC, or Horizon breaker is open — instead of every request paying a full timeout against a dependency already known to be down. Health endpoints stay reachable so probes can close the breaker again.

Redis is **deliberately excluded**: it is a performance cache the API already degrades gracefully without, so an open Redis breaker must not reject traffic.

New metrics: `stellarroute_dependency_breaker_open{dependency}` and `stellarroute_dependency_fail_fast_total{dependency}`. The `/health/deps` Postgres probe now feeds the database breaker.

---

## Verification

```
cargo test -p stellarroute-indexer router_contract    # 9 passed
bash -n scripts/deploy.sh scripts/lib/common.sh        # OK
cargo check -p stellarroute-api                        # clean (see below)
```

**Two things reviewers should know:**

1. `cargo check -p stellarroute-api` was **already failing on `main`** with 4 `E0283` type-annotation errors in `src/metrics.rs` (`with_label_values(&[])` on label-less metrics). None of the API changes here were verifiable without fixing them, so this PR includes that one-line-each fix. Happy to split it out.

2. `cargo test -p stellarroute-api --lib` still does not compile — **14 pre-existing errors** in unrelated in-crate test modules (`graph.rs`, `quote.rs`: `Arc<CompactedGraph>` indexing, duplicate `midpoint`/`spread_bps`/`decision_graph` fields). Verified identical on `main` before these changes. **Consequence: the 4 new circuit-breaker tests in `dependency_health.rs` are written but have not been executed.** They will run as soon as that target builds; fixing those 14 was out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
