### PR TITLE
Harden arithmetic, add proptests, document freshness SLO, and integrate swap activity API

### DIFF
--- a/crates/contracts/src/constant_product_adapter.rs
+++ b/crates/contracts/src/constant_product_adapter.rs
@@ -54,7 +54,9 @@ impl PoolAdapterTrait for ConstantProductAdapter {
             panic!("division by zero: empty pool reserves");
         }
 
-        numerator / denominator
+        numerator
+            .checked_div(denominator)
+            .unwrap_or_else(|| panic!("overflow: division"))
     }
 
     fn get_rsrvs(e: Env) -> (i128, i128) {

--- a/crates/contracts/src/router.rs
+++ b/crates/contracts/src/router.rs
@@ -172,7 +172,8 @@ impl StellarRoute {
             let mut amount = (total_balance
                 .checked_mul(rec.share_bps as i128)
                 .unwrap_or(i128::MAX))
-                / 10000;
+                .checked_div(10000)
+                .unwrap_or(0);
 
             // Add rounding dust to treasury or last recipient
             if (found_treasury && i == treasury_idx) || (!found_treasury && i == num_recipients - 1)
@@ -680,7 +681,8 @@ impl StellarRoute {
         let fee_amount = (current_amount
             .checked_mul(fee_rate as i128)
             .ok_or(ContractError::Overflow)?)
-            / 10000;
+            .checked_div(10000)
+            .ok_or(ContractError::Overflow)?;
         let final_output = current_amount
             .checked_sub(fee_amount)
             .ok_or(ContractError::Overflow)?;
@@ -881,7 +883,8 @@ impl StellarRoute {
         let fee_amount = (current_input_amount
             .checked_mul(fee_rate as i128)
             .ok_or(ContractError::Overflow)?)
-            / 10000;
+            .checked_div(10000)
+            .ok_or(ContractError::Overflow)?;
         let final_output = current_input_amount
             .checked_sub(fee_amount)
             .ok_or(ContractError::Overflow)?;
@@ -901,7 +904,8 @@ impl StellarRoute {
                     .checked_sub(final_output)
                     .ok_or(ContractError::Overflow)?;
                 diff.checked_mul(10000).ok_or(ContractError::Overflow)?
-                    / params.route.estimated_output
+                    .checked_div(params.route.estimated_output)
+                    .ok_or(ContractError::Overflow)?
             } else {
                 0
             };

--- a/crates/contracts/src/test.rs
+++ b/crates/contracts/src/test.rs
@@ -1561,6 +1561,60 @@ mod property_fuzz_tests {
                 prop_assert!(result.is_ok());
             }
         }
+
+        #[test]
+        fn execute_swap_output_is_bounded_and_slippage_enforced(
+            amount_in in 10i128..=10_000_000_i128,
+            fee_rate in 0u32..=1000u32,
+            slippage_factor in 0i128..20i128,
+        ) {
+            let env = setup_env();
+            let admin = Address::generate(&env);
+            let fee_to = Address::generate(&env);
+            let id = env.register_contract(None, StellarRoute);
+            let client = StellarRouteClient::new(&env, &id);
+            client.initialize(&admin, &fee_rate, &fee_to, &None, &None, &None, &None, &None);
+
+            let pool = deploy_mock_pool(&env);
+            client.register_pool(&pool);
+
+            let route = make_route(&env, &pool, 1);
+
+            // Compute expected output based on MockAmmPool returning 99% and router fee_rate
+            let pool_out = amount_in * 99 / 100;
+            let fee = pool_out * (fee_rate as i128) / 10000;
+            let expected_output = pool_out - fee;
+
+            // Scenario 1: min_amount_out is <= expected_output (should succeed)
+            let min_out_ok = expected_output - (expected_output * slippage_factor / 100);
+            let min_out_ok = min_out_ok.max(0);
+
+            let params_ok = swap_params_for(
+                &env,
+                route.clone(),
+                amount_in,
+                min_out_ok,
+                current_seq(&env) + 100,
+            );
+
+            let result = client.try_execute_swap(&Address::generate(&env), &params_ok);
+            prop_assert!(result.is_ok(), "Expected swap to succeed with min_out = {}, got error: {:?}", min_out_ok, result);
+            let swap_res = result.unwrap();
+            prop_assert!(swap_res.amount_out <= amount_in, "Output amount {} cannot exceed input amount {}", swap_res.amount_out, amount_in);
+            prop_assert_eq!(swap_res.amount_out, expected_output, "Output amount {} should match expected {}", swap_res.amount_out, expected_output);
+
+            // Scenario 2: min_amount_out is > expected_output (should fail with SlippageExceeded)
+            let min_out_fail = expected_output + 1;
+            let params_fail = swap_params_for(
+                &env,
+                route,
+                amount_in,
+                min_out_fail,
+                current_seq(&env) + 100,
+            );
+            let result_fail = client.try_execute_swap(&Address::generate(&env), &params_fail);
+            prop_assert_eq!(result_fail, Err(Ok(ContractError::SlippageExceeded)), "Expected SlippageExceeded error when min_out = {}", min_out_fail);
+        }
     }
 }
 

--- a/docs/api/error_taxonomy.md
+++ b/docs/api/error_taxonomy.md
@@ -77,6 +77,16 @@ WebSocket endpoints use the same error codes as REST endpoints, plus additional 
 
 See [WebSocket Quote Stream API](websocket.md) for complete WebSocket protocol documentation and error handling guidance.
 
+## Freshness SLO & Configuration Knobs
+
+To prevent execution on stale rates, the StellarRoute API implements strict freshness checks:
+- **SLO**: Market quotes/routes are rejected if the underlying data sources (SDEX offers or Soroban pool reserves) have not been updated within configured thresholds.
+- **Error**: Rejections return HTTP 422 with the code `stale_market_data` containing details about the stale vs. fresh inputs.
+- **Config Knobs**:
+  - `freshness_threshold_secs.sdex`: Maximum age of SDEX offer data (default: 60s) before it is considered stale.
+  - `freshness_threshold_secs.amm`: Maximum age of Soroban AMM state (default: 30s) before it is considered stale.
+  - `staleness_threshold_secs`: Ultimate cutoff beyond which any source is rejected (default: 300s).
+
 ## Integration guidance
 
 For practical retry semantics, backoff guidance, SDK helper examples, and frontend messaging recommendations, see [API Integrator Error Guide](integrator-error-guide.md).

--- a/frontend/hooks/useTradeActivity.ts
+++ b/frontend/hooks/useTradeActivity.ts
@@ -1,6 +1,7 @@
 // frontend/hooks/useTradeActivity.ts
-import { useState, useMemo } from 'react';
+import { useState, useMemo, useEffect } from 'react';
 import { TradeRecord } from '../types/trade';
+import { useStellarRouteClient } from './useStellarRouteClient';
 
 interface UseTradeActivityProps {
   address?: string;
@@ -8,11 +9,59 @@ interface UseTradeActivityProps {
 }
 
 export function useTradeActivity({ address, initialData = [] }: UseTradeActivityProps) {
-  const [data] = useState<TradeRecord[]>(initialData);
+  const client = useStellarRouteClient();
+  const [data, setData] = useState<TradeRecord[]>(initialData);
   const [page, setPage] = useState(1);
   const [sortField, setSortField] = useState<keyof TradeRecord>('timestamp');
   const [sortDirection, setSortDirection] = useState<'desc' | 'asc'>('desc');
-  
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  // Configuration knob to toggle between mock/offline and live data fetching (Issue #983)
+  const useLiveData = true;
+
+  useEffect(() => {
+    if (!address || !useLiveData) {
+      setData(initialData);
+      setIsLoading(false);
+      return;
+    }
+
+    let active = true;
+    setIsLoading(true);
+    setError(null);
+
+    client.getSwapActivity({ limit: 100 })
+      .then((res) => {
+        if (!active) return;
+        
+        // Map SwapActivityItem -> TradeRecord
+        const mapped: TradeRecord[] = res.swaps
+          .filter((swap) => swap.sender.toLowerCase() === address.toLowerCase())
+          .map((swap) => ({
+            id: swap.event_id,
+            txHash: swap.paging_token,
+            timestamp: swap.ledger_closed_at ? new Date(swap.ledger_closed_at) : new Date(),
+            action: 'SWAP',
+            amount: swap.amount_in,
+            asset: `${swap.source_asset || 'Unknown'} → ${swap.destination_asset || 'Unknown'}`,
+          }));
+
+        setData(mapped);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        if (!active) return;
+        console.error('Failed to fetch swap activity:', err);
+        setError(err instanceof Error ? err : new Error(String(err)));
+        setIsLoading(false);
+      });
+
+    return () => {
+      active = false;
+    };
+  }, [address, client, useLiveData, initialData]);
+
   const itemsPerPage = 10;
 
   const sortedData = useMemo(() => {
@@ -61,7 +110,8 @@ export function useTradeActivity({ address, initialData = [] }: UseTradeActivity
     handleSort,
     sortField,
     sortDirection,
-    isLoading: !address,
-    isEmpty: data.length === 0,
+    isLoading: isLoading || (!address && data.length === 0),
+    isEmpty: data.length === 0 && !isLoading,
+    error,
   };
 }

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -20,6 +20,8 @@ import type {
   QuoteType,
   ApiErrorCode,
   RoutesResponse,
+  SwapActivityItem,
+  SwapActivityResponse,
 } from '@/types';
 
 // ---------------------------------------------------------------------------
@@ -328,6 +330,23 @@ export class StellarRouteClient {
   /** GET /api/v1/pairs — list all trading pairs */
   getPairs(opts?: FetchOptions): Promise<PairsResponse> {
     return this.request<PairsResponse>('/api/v1/pairs', opts);
+  }
+
+  /** GET /api/v1/activity/swaps — list recent swap activity */
+  async getSwapActivity(
+    params?: { limit?: number; before_ledger?: number },
+    opts?: FetchOptions,
+  ): Promise<SwapActivityResponse> {
+    const query = new URLSearchParams();
+    if (params?.limit !== undefined) query.set('limit', String(params.limit));
+    if (params?.before_ledger !== undefined) query.set('before_ledger', String(params.before_ledger));
+    const qs = query.toString();
+    const path = `/api/v1/activity/swaps${qs ? `?${qs}` : ''}`;
+    const body = await this.request<ApiResponse<SwapActivityResponse> | SwapActivityResponse>(
+      path,
+      opts,
+    );
+    return unwrapEnvelope<SwapActivityResponse>(body);
   }
 
   /**

--- a/frontend/types/index.ts
+++ b/frontend/types/index.ts
@@ -231,4 +231,23 @@ export interface PoolStatsResponse {
   replica?: PoolStats;
 }
 
+export interface SwapActivityItem {
+  event_id: string;
+  contract_id: string;
+  ledger: number;
+  ledger_closed_at?: string;
+  paging_token: string;
+  sender: string;
+  amount_in: string;
+  amount_out: string;
+  fee_amount: string;
+  route: unknown;
+  source_asset?: string;
+  destination_asset?: string;
+}
+
+export interface SwapActivityResponse {
+  swaps: SwapActivityItem[];
+}
+
 export * from './route';


### PR DESCRIPTION
This PR closes issues
closes #970, 
closes #980, 
closes #983, and 
closes #1028.

### Changes
- Hardened division arithmetic operations in router contract and constant product adapter with checked_div.
- Added property-based fuzz tests in test.rs for swap amount output bounds and slippage tolerance.
- Documented quote freshness SLO and configuration knobs in docs/api/error_taxonomy.md.
- Added SwapActivity backend mapping types and API getSwapActivity client implementation, integrating them with the frontend useTradeActivity hook.