### PR TITLE
[962] [frontend] Fix xBull network detection for mainnet mismatch checks

### DIFF
--- a/frontend/components/shared/NetworkMismatchBanner.test.tsx
+++ b/frontend/components/shared/NetworkMismatchBanner.test.tsx
@@ -134,4 +134,20 @@ describe('NetworkMismatchBanner', () => {
     const link = screen.getByRole('link', { name: /how to switch network/i });
     expect(link).toHaveAttribute('href', 'https://xbull.app/docs');
   });
+
+  it('renders mismatch banner for xBull public vs app testnet', () => {
+    vi.mocked(WalletProvider.useWallet).mockReturnValue({
+      networkMismatch: true,
+      network: 'testnet',
+      walletNetwork: 'public',
+      walletId: 'xbull',
+      disconnect: vi.fn(),
+      setNetwork: vi.fn(),
+    } as any);
+
+    render(<NetworkMismatchBanner />);
+    expect(screen.getByText(/network mismatch detected/i)).toBeInTheDocument();
+    expect(screen.getByText(/public/i)).toBeInTheDocument();
+    expect(screen.getByRole('alert')).toHaveAttribute('aria-live', 'assertive');
+  });
 });

--- a/frontend/docs/wallet-production-readiness.md
+++ b/frontend/docs/wallet-production-readiness.md
@@ -13,13 +13,13 @@ This document maps every wallet-related code path to its current status — **st
 | **Connect (Albedo)**           | `connectWallet("albedo")` in `lib/wallet/index.ts`                                  | ✅ Production ready | Uses the Albedo `public_key` intent through `window.albedo` or the hosted intent client                                                                                         |
 | **Detect installed wallets**   | `getAvailableWallets()` in `lib/wallet/index.ts`                                    | ✅ Production ready | Freighter: `isAllowed()` API; xBull: `window.xbull` presence check; Albedo: browser-hosted intent client                                                                        |
 | **View address**               | `getAddress()` (Freighter) / `connect().publicKey` (xBull) / `publicKey()` (Albedo) | ✅ Production ready | Called during `connectWallet` and `refreshWalletSession`                                                                                                                        |
-| **View network**               | `getNetworkDetails()` (Freighter) / app network fallback (xBull, Albedo)            | ⚠️ Partial          | xBull and Albedo do not expose passive network checks in this adapter; app network fallback is used for session state                                                           |
+| **View network**               | `getNetworkDetails()` (Freighter) / `getNetwork()` (xBull) / app network fallback (Albedo) | ✅ Production ready | xBull reports the selected network via `getNetwork()` (window.xbull or xBullSDK); Albedo still uses app network fallback for session state |
 | **Sign transaction**           | `signTransactionWithWallet(xdr, walletId)` in `lib/wallet/index.ts`                 | ✅ Production ready | Freighter: `signTransaction()`; xBull: `window.xbull.sign()`; Albedo: `tx` intent returning signed envelope XDR                                                                 |
 | **Sign transaction stub**      | `signTransactionStub(xdr)` in `lib/wallet/index.ts`                                 | 🔴 Stub only        | Returns `{ ok: false }` — used in tests and out-of-scope flows. **Never call in production.**                                                                                   |
 | **Spendable balance**          | `useWalletBalance` in `hooks/useWalletBalance.ts`                                   | ✅ Production ready | Fetches `GET /accounts/{address}` from Horizon; native spendable balance subtracts `XLM_FEE_RESERVE`; consumed by `SwapCard` for balance display, loading/error states, and MAX |
 | **Auto-reconnect**             | `WalletProvider` effect in `wallet-provider.tsx`                                    | ✅ Production ready | Reads `stellarroute.wallet.lastWalletId` from `localStorage`, respects `autoReconnectPreferred` flag                                                                            |
 | **Reconnect on focus/online**  | `WalletProvider` window event listeners                                             | ✅ Production ready | Throttled to 5 s to avoid hammering the wallet extension                                                                                                                        |
-| **Network mismatch detection** | `networkMismatch` in `WalletProvider`                                               | ✅ Production ready | Compares app `network` state with `walletNetwork` returned by wallet                                                                                                            |
+| **Network mismatch detection** | `networkMismatch` in `WalletProvider`                                               | ✅ Production ready | Compares app `network` state with `walletNetwork` returned by wallet (Freighter + xBull real network; Albedo app fallback)                                                      |
 | **Capability check**           | `refreshCapabilities()` / `checkWalletCapabilities()`                               | ⚠️ Mock             | `refreshCapabilities` in the provider sets `{ statuses: [] }` — wire to `checkWalletCapabilities` from `lib/wallet/index.ts` for Phase B                                        |
 | **Account switch detection**   | `accountSwitchState` in `WalletProvider`                                            | ✅ Production ready | Detects address change after `refreshAccount()`                                                                                                                                 |
 | **Sync mismatch / resync**     | `syncMismatch` + `resyncWallet()` in `WalletProvider`                               | ✅ Production ready | Calls `refreshAccount()` and clears the mismatch flag                                                                                                                           |
@@ -42,7 +42,7 @@ This document maps every wallet-related code path to its current status — **st
 
 | Path                              | Gap                                                               | Action needed                                                                                               |
 | --------------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
-| xBull/Albedo network detection    | Uses app network fallback instead of passive wallet network reads | Implement wallet-specific network APIs if exposed; keep capability checks constrained to supported networks |
+| Albedo network detection          | Uses app network fallback instead of passive wallet network reads | Implement wallet-specific network APIs if exposed; keep capability checks constrained to supported networks |
 | Transaction lifecycle submit step | `useTransactionLifecycle` calls sign but not broadcast            | Wire the signed XDR into `submitTransaction` once it POSTs to Horizon                                       |
 
 ---
@@ -54,7 +54,7 @@ Before enabling real on-chain swaps (Phase B):
 - [x] **Replace `stubSpendableBalance`** — `useWalletBalance` fetches live balance from Horizon `accounts/{address}`; native MAX subtracts fee reserve (future: `buying_liabilities` / `selling_liabilities` for trustline holds)
 - [ ] **Implement `submitTransaction`** in `lib/wallet/submit.ts` — POST signed XDR to Horizon `/transactions`; handle `400 tx_bad_auth`, `400 op_underfunded`, and network timeouts
 - [ ] **Wire `refreshCapabilities`** in `WalletProvider` — replace mock with `checkWalletCapabilities(walletId, network)` so `WalletCapabilitiesBanner` reflects real status
-- [ ] **Fix xBull/Albedo passive network detection** — replace app network fallback with real wallet API calls if available so `networkMismatch` works independently of app settings
+- [x] **Fix xBull passive network detection** — `connectWallet`/`refreshWalletSession` call xBull `getNetwork()` so `networkMismatch` works for public + testnet; Albedo still uses app fallback
 - [ ] **Remove all `signTransactionWithWallet` call sites** — search for `signTransactionWithWallet` and ensure only `signTransactionWithWallet` is used in non-test code
 - [ ] **Validate network passphrase mapping** — ensure `networkPassphrase` passed to `signTransaction` matches Stellar's canonical values (`Test SDF Network ; September 2015` / `Public Global Stellar Network ; September 2015`)
 - [ ] **Test Freighter + xBull on testnet end-to-end** — confirm sign → broadcast → Horizon confirmation flow with real wallets
@@ -81,11 +81,12 @@ return res.signedTxXdr;
 
 ### xBull
 
-xBull injects `window.xbull`. There is no npm package — detect via `typeof window !== "undefined" && !!window.xbull`.
+xBull injects `window.xbull` and/or SEP-43 `window.xBullSDK`. Detect via either client.
 
 ```ts
-const xbull = (window as any).xbull;
+const xbull = (window as any).xbull ?? (window as any).xBullSDK;
 const { publicKey } = await xbull.connect();
+const networkRes = await xbull.getNetwork?.(); // { network, networkPassphrase }
 const signedXdr = await xbull.sign({ xdr, network: 'testnet' });
 ```
 

--- a/frontend/lib/wallet/index.test.ts
+++ b/frontend/lib/wallet/index.test.ts
@@ -119,6 +119,70 @@ describe('signTransactionWithWallet - Albedo', () => {
   });
 });
 
+describe('connectWallet - xBull', () => {
+  const mockConnect = vi.fn();
+  const mockGetNetwork = vi.fn();
+
+  beforeEach(() => {
+    mockConnect.mockReset();
+    mockGetNetwork.mockReset();
+    (window as unknown as Record<string, unknown>).xbull = {
+      connect: mockConnect,
+      sign: vi.fn(),
+      getNetwork: mockGetNetwork,
+    };
+  });
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).xbull;
+    delete (window as unknown as Record<string, unknown>).xBullSDK;
+  });
+
+  it('returns the real public network from getNetwork for mismatch checks', async () => {
+    mockConnect.mockResolvedValue({ publicKey: MOCK_PUBLIC_KEY });
+    mockGetNetwork.mockResolvedValue({
+      network: 'PUBLIC',
+      networkPassphrase: PUBLIC_PASSPHRASE,
+    });
+
+    const session = await connectWallet('xbull');
+
+    expect(session).toMatchObject({
+      walletId: 'xbull',
+      address: MOCK_PUBLIC_KEY,
+      network: 'public',
+      isConnected: true,
+    });
+    expect(mockGetNetwork).toHaveBeenCalledOnce();
+  });
+
+  it('returns testnet when xBull reports TESTNET', async () => {
+    mockConnect.mockResolvedValue({ publicKey: MOCK_PUBLIC_KEY });
+    mockGetNetwork.mockResolvedValue({
+      network: 'TESTNET',
+      networkPassphrase: TEST_PASSPHRASE,
+    });
+
+    const session = await connectWallet('xbull');
+
+    expect(session.network).toBe('testnet');
+  });
+
+  it('reads getNetwork from xBullSDK when window.xbull is absent', async () => {
+    delete (window as unknown as Record<string, unknown>).xbull;
+    (window as unknown as Record<string, unknown>).xBullSDK = {
+      connect: mockConnect,
+      getNetwork: mockGetNetwork,
+    };
+    mockConnect.mockResolvedValue({ publicKey: MOCK_PUBLIC_KEY });
+    mockGetNetwork.mockResolvedValue({ network: 'public' });
+
+    const session = await connectWallet('xbull');
+
+    expect(session.network).toBe('public');
+  });
+});
+
 describe('signTransactionWithWallet - xBull', () => {
   const mockSign = vi.fn();
 
@@ -175,18 +239,55 @@ describe('signTransactionWithWallet - xBull', () => {
 });
 
 describe('checkWalletCapabilities - xBull', () => {
-  it('denies sign_transaction on mainnet with testnet resolution', async () => {
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).xbull;
+  });
+
+  it('flags network mismatch when wallet is on public and app expects testnet', async () => {
+    (window as unknown as Record<string, unknown>).xbull = {
+      connect: vi.fn(),
+      sign: vi.fn(),
+      getNetwork: vi.fn().mockResolvedValue({
+        network: 'PUBLIC',
+        networkPassphrase: PUBLIC_PASSPHRASE,
+      }),
+    };
+
+    const caps = await checkWalletCapabilities('xbull', 'testnet');
+    const netCap = caps.statuses.find((s) => s.capability === 'view_network');
+    const signCap = caps.statuses.find(
+      (s) => s.capability === 'sign_transaction'
+    );
+
+    expect(netCap?.allowed).toBe(false);
+    expect(netCap?.reason).toMatch(/Wallet on public/i);
+    expect(signCap?.allowed).toBe(false);
+    expect(signCap?.reason).toBe('Network mismatch');
+  });
+
+  it('allows sign_transaction on mainnet when wallet reports public', async () => {
+    (window as unknown as Record<string, unknown>).xbull = {
+      connect: vi.fn(),
+      sign: vi.fn(),
+      getNetwork: vi.fn().mockResolvedValue({ network: 'public' }),
+    };
+
     const caps = await checkWalletCapabilities('xbull', 'mainnet');
     const signCap = caps.statuses.find(
       (s) => s.capability === 'sign_transaction'
     );
 
-    expect(signCap?.allowed).toBe(false);
-    expect(signCap?.reason).toBe('xBull only supports testnet');
-    expect(signCap?.resolution).toBe('Switch app to testnet');
+    expect(signCap?.allowed).toBe(true);
+    expect(signCap?.reason).toBeUndefined();
   });
 
-  it('allows sign_transaction on testnet', async () => {
+  it('allows sign_transaction on testnet when networks match', async () => {
+    (window as unknown as Record<string, unknown>).xbull = {
+      connect: vi.fn(),
+      sign: vi.fn(),
+      getNetwork: vi.fn().mockResolvedValue({ network: 'testnet' }),
+    };
+
     const caps = await checkWalletCapabilities('xbull', 'testnet');
     const signCap = caps.statuses.find(
       (s) => s.capability === 'sign_transaction'

--- a/frontend/lib/wallet/index.ts
+++ b/frontend/lib/wallet/index.ts
@@ -41,6 +41,74 @@ function getWindowRecord(): Record<string, unknown> | null {
     : (window as unknown as Record<string, unknown>);
 }
 
+type XBullClient = {
+  connect: () => Promise<{ publicKey: string }>;
+  sign?: (opts: {
+    xdr: string;
+    network?: string;
+    publicKey?: string;
+  }) => Promise<string>;
+  getNetwork?: () => Promise<
+    | { network: string; networkPassphrase?: string; error?: undefined }
+    | { error: { message?: string; code?: number }; network?: undefined }
+  >;
+};
+
+/** Resolve the injected xBull client (`window.xbull` or SEP-43 `window.xBullSDK`). */
+function getXBullClient(): XBullClient | undefined {
+  const win = getWindowRecord();
+  if (!win) return undefined;
+  const client = (win.xbull ?? win.xBullSDK) as XBullClient | undefined;
+  return client?.connect ? client : undefined;
+}
+
+/**
+ * Map xBull network identifiers (PUBLIC/TESTNET, public/testnet, passphrases)
+ * onto Freighter-compatible session network strings.
+ */
+function normalizeXbullNetworkName(
+  network: string,
+  networkPassphrase?: string
+): string {
+  const key = network.trim().toLowerCase();
+  if (
+    key === 'public' ||
+    key === 'pubnet' ||
+    key === 'mainnet' ||
+    key === 'production'
+  ) {
+    return 'public';
+  }
+  if (key === 'testnet' || key === 'test') {
+    return 'testnet';
+  }
+  if (networkPassphrase?.includes('Public Global Stellar Network')) {
+    return 'public';
+  }
+  if (networkPassphrase?.includes('Test SDF Network')) {
+    return 'testnet';
+  }
+  return key;
+}
+
+/**
+ * Read the wallet's currently selected network via getNetwork when available.
+ * Falls back to the app-configured network only when the API is missing.
+ */
+async function resolveXbullNetwork(xbull: XBullClient): Promise<string> {
+  if (typeof xbull.getNetwork === 'function') {
+    try {
+      const res = await xbull.getNetwork();
+      if (res && !res.error && res.network) {
+        return normalizeXbullNetworkName(res.network, res.networkPassphrase);
+      }
+    } catch {
+      // Fall through to app network fallback.
+    }
+  }
+  return process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
+}
+
 function getInjectedAlbedo(): AlbedoClient | null {
   if (typeof window === 'undefined') return null;
   return window.albedo ?? null;
@@ -100,9 +168,8 @@ export async function getAvailableWallets(): Promise<AvailableWallet[]> {
     wallets.push({ id: 'freighter', label: 'Freighter', installed: false });
   }
 
-  // xBull — detected via window.xbull
-  const xbullInstalled =
-    typeof window !== 'undefined' && !!(getWindowRecord() ?? {}).xbull;
+  // xBull — detected via window.xbull or SEP-43 window.xBullSDK
+  const xbullInstalled = !!getXBullClient();
   wallets.push({ id: 'xbull', label: 'xBull', installed: xbullInstalled });
 
   // Albedo works as a hosted intent wallet and may also inject window.albedo.
@@ -144,19 +211,18 @@ export async function connectWallet(
   }
 
   if (walletId === 'xbull') {
-    const xbull = (getWindowRecord() ?? {}).xbull as
-      | { connect: () => Promise<{ publicKey: string }> }
-      | undefined;
+    const xbull = getXBullClient();
 
     if (!xbull) {
       throw new Error('xBull not installed');
     }
 
     const result = await xbull.connect();
+    const network = await resolveXbullNetwork(xbull);
     return {
       walletId,
       address: result.publicKey,
-      network: process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet',
+      network,
       isConnected: true,
     };
   }
@@ -279,25 +345,71 @@ export async function checkWalletCapabilities(
           : undefined,
     });
   } else if (walletId === 'xbull') {
+    const xbull = getXBullClient();
+    const installed = !!xbull;
     statuses.push({
       capability: 'request_access',
-      allowed: true,
+      allowed: installed,
+      reason: installed ? undefined : 'xBull not installed',
+      resolution: installed ? undefined : 'Install the xBull extension',
     });
     statuses.push({
       capability: 'view_address',
-      allowed: true,
+      allowed: installed,
+      reason: installed ? undefined : 'xBull not installed',
+      resolution: installed
+        ? undefined
+        : getCapabilityResolution('view_address'),
     });
+
+    let walletNetwork: string | null = null;
+    if (xbull && typeof xbull.getNetwork === 'function') {
+      try {
+        const res = await xbull.getNetwork();
+        if (res && !res.error && res.network) {
+          walletNetwork = normalizeXbullNetworkName(
+            res.network,
+            res.networkPassphrase
+          );
+        }
+      } catch {
+        walletNetwork = null;
+      }
+    }
+
+    const supportedNetwork =
+      network === 'testnet' || network === 'mainnet' || network === 'public';
+    const normalizedExpected =
+      network === 'mainnet' || network === 'public' ? 'public' : network;
+    const networkMatch =
+      walletNetwork !== null
+        ? normalizeXbullNetworkName(walletNetwork) === normalizedExpected
+        : supportedNetwork;
+
     statuses.push({
       capability: 'view_network',
-      allowed: true,
-      reason: network === 'testnet' ? undefined : 'xBull only supports testnet',
-      resolution: network !== 'testnet' ? 'Switch app to testnet' : undefined,
+      allowed: networkMatch,
+      reason: networkMatch
+        ? undefined
+        : walletNetwork
+          ? `Wallet on ${walletNetwork}, expected ${network}`
+          : `xBull supports testnet/public, expected ${network}`,
+      resolution: networkMatch
+        ? undefined
+        : 'Switch wallet network to match the app',
     });
     statuses.push({
       capability: 'sign_transaction',
-      allowed: network === 'testnet',
-      reason: network === 'testnet' ? undefined : 'xBull only supports testnet',
-      resolution: network !== 'testnet' ? 'Switch app to testnet' : undefined,
+      allowed: Boolean(installed && networkMatch),
+      reason: !installed
+        ? 'xBull not installed'
+        : !networkMatch
+          ? 'Network mismatch'
+          : undefined,
+      resolution:
+        !installed || !networkMatch
+          ? getCapabilityResolution('sign_transaction')
+          : undefined,
     });
   } else if (walletId === 'albedo') {
     const supportedNetwork =
@@ -375,17 +487,9 @@ export async function signTransactionWithWallet(
   }
 
   if (walletId === 'xbull') {
-    const xbull = (getWindowRecord() ?? {}).xbull as
-      | {
-          sign: (opts: {
-            xdr: string;
-            network?: string;
-            publicKey?: string;
-          }) => Promise<string>;
-        }
-      | undefined;
+    const xbull = getXBullClient();
 
-    if (!xbull) {
+    if (!xbull?.sign) {
       throw new Error('xBull not installed');
     }
 
@@ -483,19 +587,18 @@ export async function refreshWalletSession(
   }
 
   if (walletId === 'xbull') {
-    const xbull = (getWindowRecord() ?? {}).xbull as
-      | { connect: () => Promise<{ publicKey: string }> }
-      | undefined;
+    const xbull = getXBullClient();
 
     if (!xbull) {
       throw new Error('xBull not installed');
     }
 
     const result = await xbull.connect();
+    const network = await resolveXbullNetwork(xbull);
     return {
       walletId,
       address: result.publicKey,
-      network: process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet',
+      network,
       isConnected: true,
     };
   }


### PR DESCRIPTION
## Summary
- Call xBull `getNetwork()` (`window.xbull` / `xBullSDK`) on connect/refresh so session network is real, not app-fallback.
- Capability checks allow public+testnet and surface true network mismatches for `networkMismatch`.
- Updated wallet-production-readiness checklist and mismatch banner coverage.

Closes #962

## Test plan
- [x] `npm --prefix frontend run test -- wallet`
- [x] Full frontend unit suite green