### PR TITLE
[1006] [frontend] Mobile-responsive swap confirm and wallet connect polish

### DIFF
--- a/docs/architecture/responsive-layout.md
+++ b/docs/architecture/responsive-layout.md
@@ -120,8 +120,22 @@ On tablets (768px–1024px, i.e. `md` breakpoint range), the following rules app
 | `frontend/components/swap/MobileRouteBottomSheet.tsx` | Mobile bottom-sheet for route details |
 | `frontend/components/swap/RouteDisplay.tsx` | Route panel content |
 | `frontend/components/swap/OrderbookDepthPanel.tsx` | In-swap compact orderbook |
+| `frontend/components/swap/TransactionConfirmationModal.tsx` | Swap confirm dialog — 90vw / max-h 90dvh, scrollable body, 48px CTAs |
+| `frontend/components/modals/WalletConnectionOnboarding.tsx` | Wallet connect dialog — same mobile width/height guards so content is not clipped |
 | `frontend/app/swap/SwapPageClient.tsx` | Swap page entry point with lazy-loaded components |
 | `frontend/app/orderbook/OrderbookPageClient.tsx` | Full orderbook page |
 | `frontend/components/layout/app-shell.tsx` | Root layout shell |
 | `frontend/hooks/useMediaQuery.ts` | Media query hook for JS-driven responsive behavior |
 | `frontend/hooks/useSplitView.ts` | Split view toggle state + localStorage persistence |
+| `frontend/e2e/mobile-swap.spec.ts` | Playwright smoke: confirm + wallet connect at 375px |
+
+---
+
+## Swap Confirm & Wallet Connect (Mobile)
+
+At 375px (and down to 320px):
+
+| Surface | Layout rules |
+|---------|--------------|
+| **Swap confirm modal** | `w-[min(100%,90vw)]`, `max-h-[min(90dvh,90vh)]`, scrollable body, sticky footer with safe-area padding, primary actions `min-h-[48px]` |
+| **Wallet connect dialog** | Same width/height budget; inner scroll container so long onboarding steps are not clipped by the viewport |

--- a/frontend/components/modals/WalletConnectionOnboarding.test.tsx
+++ b/frontend/components/modals/WalletConnectionOnboarding.test.tsx
@@ -45,4 +45,24 @@ describe('WalletConnectionOnboarding', () => {
     await user.click(screen.getByRole('button', { name: /mainnet/i }));
     expect(onNetworkSelection).toHaveBeenCalledWith('mainnet');
   });
+
+  it('wallet connect dialog uses mobile clip-safe layout classes (#1006)', () => {
+    render(
+      <WalletConnectionOnboarding
+        open
+        onOpenChange={vi.fn()}
+        availableWallets={[]}
+        isLoading={false}
+        error={null}
+        onConnect={vi.fn()}
+        appNetwork="testnet"
+        walletNetwork={null}
+      />,
+    );
+
+    const dialog = screen.getByTestId('wallet-connect-dialog');
+    expect(dialog.className).toMatch(/90vw/);
+    expect(dialog.className).toMatch(/90dvh|90vh/);
+    expect(dialog.className).toMatch(/overflow-hidden/);
+  });
 });

--- a/frontend/components/modals/WalletConnectionOnboarding.tsx
+++ b/frontend/components/modals/WalletConnectionOnboarding.tsx
@@ -165,7 +165,11 @@ export function WalletConnectionOnboarding({
 
   return (
     <Dialog open={open} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-[425px] md:max-w-[600px]">
+      <DialogContent
+        data-testid="wallet-connect-dialog"
+        className="flex w-[min(100%,90vw)] max-h-[min(90dvh,90vh)] flex-col gap-0 overflow-hidden p-4 sm:p-6 sm:max-w-[425px] md:max-w-[600px] pb-[max(1rem,env(safe-area-inset-bottom))]"
+      >
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain">
         {step === 'welcome' && (
           <>
             <DialogHeader>
@@ -443,6 +447,7 @@ export function WalletConnectionOnboarding({
             </div>
           </>
         )}
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/frontend/components/swap/TransactionConfirmationModal.test.tsx
+++ b/frontend/components/swap/TransactionConfirmationModal.test.tsx
@@ -90,6 +90,28 @@ describe('TransactionConfirmationModal — reduced-motion', () => {
   });
 });
 
+describe('TransactionConfirmationModal — mobile layout (#1006)', () => {
+  it('uses viewport-bounded dialog classes for 375px usability', () => {
+    render(<TransactionConfirmationModal {...BASE_PROPS} status="review" />);
+    const dialog = screen.getByTestId('swap-confirm-dialog');
+    expect(dialog.className).toMatch(/90vw/);
+    expect(dialog.className).toMatch(/90dvh|90vh/);
+    expect(dialog.className).toMatch(/overflow-hidden/);
+  });
+
+  it('confirm and cancel buttons meet 48px min height', () => {
+    render(<TransactionConfirmationModal {...BASE_PROPS} status="review" />);
+    const confirm = screen.getByRole('button', {
+      name: '[swap.confirm.cta.confirmSwap]',
+    });
+    const cancel = screen.getByRole('button', {
+      name: '[swap.confirm.cta.cancel]',
+    });
+    expect(confirm.className).toMatch(/min-h-\[48px\]/);
+    expect(cancel.className).toMatch(/min-h-\[48px\]/);
+  });
+});
+
 // ---------------------------------------------------------------------------
 // Property-based tests
 // ---------------------------------------------------------------------------

--- a/frontend/components/swap/TransactionConfirmationModal.tsx
+++ b/frontend/components/swap/TransactionConfirmationModal.tsx
@@ -173,7 +173,8 @@ export function TransactionConfirmationModal({
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
       <DialogContent
-        className="sm:max-w-[420px] p-0 overflow-hidden border-border/40 bg-background/95 backdrop-blur-xl rounded-[32px] shadow-2xl"
+        data-testid="swap-confirm-dialog"
+        className="flex w-[min(100%,90vw)] max-h-[min(90dvh,90vh)] flex-col gap-0 overflow-hidden p-0 border-border/40 bg-background/95 backdrop-blur-xl rounded-2xl sm:rounded-[32px] shadow-2xl sm:max-w-[420px]"
         aria-describedby="tcm-state-desc"
       >
         {/* Visually hidden state description for aria-describedby */}
@@ -186,7 +187,7 @@ export function TransactionConfirmationModal({
           {config.announcement}
         </div>
 
-        <div className="p-8 space-y-6">
+        <div className="min-h-0 flex-1 overflow-y-auto overscroll-contain p-4 sm:p-8 space-y-6">
           <DialogHeader>
             <div
               className={cn(
@@ -206,7 +207,7 @@ export function TransactionConfirmationModal({
             <DialogTitle className="text-2xl font-bold text-center tracking-tight">
               {config.heading}
             </DialogTitle>
-            <DialogDescription className="text-center text-muted-foreground pt-2">
+            <DialogDescription className="text-center text-muted-foreground pt-2 break-words">
               {status === 'failed' && failedCopy ? (
                 <span className="space-y-1 block">
                   <span className="block font-medium text-foreground">
@@ -233,21 +234,21 @@ export function TransactionConfirmationModal({
           {/* Trade summary (shown in review and confirmed states) */}
           {tradeParams && (status === 'review' || status === 'confirmed') && (
             <div className="bg-muted/30 rounded-2xl p-4 border border-border/20 space-y-2 text-sm">
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">{t('swap.confirm.summary.youPay')}</span>
-                <span className="font-medium">
+              <div className="flex justify-between gap-3 min-w-0">
+                <span className="text-muted-foreground shrink-0">{t('swap.confirm.summary.youPay')}</span>
+                <span className="font-medium text-right break-words min-w-0">
                   {tradeParams.fromAmount} {tradeParams.fromAsset}
                 </span>
               </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">{t('swap.confirm.summary.youReceive')}</span>
-                <span className="font-medium">
+              <div className="flex justify-between gap-3 min-w-0">
+                <span className="text-muted-foreground shrink-0">{t('swap.confirm.summary.youReceive')}</span>
+                <span className="font-medium text-right break-words min-w-0">
                   {tradeParams.toAmount} {tradeParams.toAsset}
                 </span>
               </div>
-              <div className="flex justify-between">
-                <span className="text-muted-foreground">{t('swap.confirm.summary.minReceived')}</span>
-                <span className="font-medium">{tradeParams.minReceived}</span>
+              <div className="flex justify-between gap-3 min-w-0">
+                <span className="text-muted-foreground shrink-0">{t('swap.confirm.summary.minReceived')}</span>
+                <span className="font-medium text-right break-words min-w-0">{tradeParams.minReceived}</span>
               </div>
             </div>
           )}
@@ -263,20 +264,20 @@ export function TransactionConfirmationModal({
           )}
         </div>
 
-        <DialogFooter className="flex flex-col sm:flex-row gap-3 p-8 bg-muted/10 border-t border-border/20">
+        <DialogFooter className="shrink-0 flex flex-col sm:flex-row gap-3 p-4 sm:p-8 bg-muted/10 border-t border-border/20 pb-[max(1rem,env(safe-area-inset-bottom))] sm:pb-8">
           {status === 'review' && (
             <>
               <Button
                 ref={primaryActionRef}
                 onClick={onConfirm}
-                className="flex-1 h-12 rounded-xl font-bold shadow-lg"
+                className="flex-1 min-h-[48px] h-12 rounded-xl font-bold shadow-lg"
               >
                 {t('swap.confirm.cta.confirmSwap')}
               </Button>
               <Button
                 variant="outline"
                 onClick={onCancel}
-                className="flex-1 h-12 rounded-xl font-bold"
+                className="flex-1 min-h-[48px] h-12 rounded-xl font-bold"
               >
                 {t('swap.confirm.cta.cancel')}
               </Button>
@@ -288,7 +289,7 @@ export function TransactionConfirmationModal({
               ref={primaryActionRef}
               variant="outline"
               onClick={onCancel}
-              className="flex-1 h-12 rounded-xl font-bold"
+              className="flex-1 min-h-[48px] h-12 rounded-xl font-bold"
             >
               {t('swap.confirm.cta.cancel')}
             </Button>
@@ -299,7 +300,7 @@ export function TransactionConfirmationModal({
               ref={primaryActionRef}
               variant="outline"
               disabled
-              className="flex-1 h-12 rounded-xl font-bold opacity-50"
+              className="flex-1 min-h-[48px] h-12 rounded-xl font-bold opacity-50"
             >
               {t('swap.confirm.cta.processing')}
             </Button>
@@ -309,7 +310,7 @@ export function TransactionConfirmationModal({
             <Button
               ref={primaryActionRef}
               onClick={onDone}
-              className="flex-1 h-12 rounded-xl font-bold shadow-lg shadow-green-500/20"
+              className="flex-1 min-h-[48px] h-12 rounded-xl font-bold shadow-lg shadow-green-500/20"
             >
               {t('swap.confirm.cta.done')}
             </Button>
@@ -320,14 +321,14 @@ export function TransactionConfirmationModal({
               <Button
                 ref={primaryActionRef}
                 onClick={onTryAgain}
-                className="flex-1 h-12 rounded-xl font-bold"
+                className="flex-1 min-h-[48px] h-12 rounded-xl font-bold"
               >
                 {t('swap.confirm.cta.tryAgain')}
               </Button>
               <Button
                 variant="outline"
                 onClick={onDismiss}
-                className="flex-1 h-12 rounded-xl font-bold"
+                className="flex-1 min-h-[48px] h-12 rounded-xl font-bold"
               >
                 {t('swap.confirm.cta.dismiss')}
               </Button>
@@ -339,14 +340,14 @@ export function TransactionConfirmationModal({
               <Button
                 ref={primaryActionRef}
                 onClick={onResubmit}
-                className="flex-1 h-12 rounded-xl font-bold"
+                className="flex-1 min-h-[48px] h-12 rounded-xl font-bold"
               >
                 {t('swap.confirm.cta.resubmit')}
               </Button>
               <Button
                 variant="outline"
                 onClick={onDismiss}
-                className="flex-1 h-12 rounded-xl font-bold"
+                className="flex-1 min-h-[48px] h-12 rounded-xl font-bold"
               >
                 {t('swap.confirm.cta.dismiss')}
               </Button>

--- a/frontend/e2e/mobile-swap.spec.ts
+++ b/frontend/e2e/mobile-swap.spec.ts
@@ -1,0 +1,95 @@
+import { test, expect, type Page } from '@playwright/test';
+
+/**
+ * Mobile smoke for swap confirm + wallet connect (#1006).
+ * Verify: npm --prefix frontend run test:e2e -- mobile-swap
+ */
+
+async function gotoSwap(page: Page) {
+  await page.goto('/swap');
+  await page.waitForSelector(
+    '[data-testid="swap-card"], form, [class*="Card"]',
+    { timeout: 15_000 }
+  );
+}
+
+test.describe('mobile-swap smoke @375px', () => {
+  test.use({ viewport: { width: 375, height: 812 } });
+
+  test('wallet connect dialog fits viewport without clipping', async ({
+    page,
+  }) => {
+    await gotoSwap(page);
+
+    const connectBtn = page.getByRole('button', { name: /connect wallet/i }).first();
+    await expect(connectBtn).toBeVisible();
+    await connectBtn.click();
+
+    const dialog = page.getByTestId('wallet-connect-dialog');
+    await expect(dialog).toBeVisible({ timeout: 5_000 });
+
+    const box = await dialog.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(box.width).toBeLessThanOrEqual(375);
+      expect(box.height).toBeLessThanOrEqual(812);
+      expect(box.x).toBeGreaterThanOrEqual(0);
+      expect(box.y).toBeGreaterThanOrEqual(0);
+      expect(box.x + box.width).toBeLessThanOrEqual(375 + 1);
+      expect(box.y + box.height).toBeLessThanOrEqual(812 + 1);
+    }
+
+    await expect(dialog.getByText(/connect your wallet/i)).toBeVisible();
+  });
+
+  test('swap confirm modal is usable at 375px when opened', async ({
+    page,
+  }) => {
+    await gotoSwap(page);
+
+    // Best-effort: open review modal if the CTA is available in this env.
+    const payInput = page.locator('input[placeholder="0.00"]').first();
+    if (await payInput.isVisible().catch(() => false)) {
+      await payInput.fill('1');
+      await page.waitForTimeout(500);
+    }
+
+    const swapCta = page
+      .locator(
+        'button:has-text("Review"), button:has-text("Swap"), button[type="submit"]'
+      )
+      .first();
+    if (await swapCta.isVisible().catch(() => false)) {
+      await swapCta.click({ trial: true }).catch(() => undefined);
+      await swapCta.click().catch(() => undefined);
+    }
+
+    const dialog = page.getByTestId('swap-confirm-dialog');
+    const opened = await dialog
+      .waitFor({ state: 'visible', timeout: 3_000 })
+      .then(() => true)
+      .catch(() => false);
+
+    if (!opened) {
+      // Still assert the page itself does not overflow at 375px.
+      const scrollWidth = await page.evaluate(() => document.body.scrollWidth);
+      const clientWidth = await page.evaluate(() => document.body.clientWidth);
+      expect(scrollWidth).toBeLessThanOrEqual(clientWidth);
+      return;
+    }
+
+    const box = await dialog.boundingBox();
+    expect(box).not.toBeNull();
+    if (box) {
+      expect(box.width).toBeLessThanOrEqual(375);
+      expect(box.height).toBeLessThanOrEqual(812);
+      expect(box.width / 375).toBeGreaterThanOrEqual(0.85);
+    }
+
+    const confirm = dialog.getByRole('button', { name: /confirm swap/i });
+    if (await confirm.isVisible().catch(() => false)) {
+      const btnBox = await confirm.boundingBox();
+      expect(btnBox?.height ?? 0).toBeGreaterThanOrEqual(48);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Bound swap confirm + wallet connect dialogs to 90vw/90dvh with scrollable bodies and 48px CTAs for 375px usability.
- Add Playwright `mobile-swap` smoke and document layout rules.

Closes #1006

## Test plan
- [x] `npx vitest run` TransactionConfirmationModal + WalletConnectionOnboarding
- [x] Full unit suite green (one unrelated flaky SimulationPanel teardown observed once)

Made with [Cursor](https://cursor.com)