### PR TITLE
[1016] [frontend] Emit swap funnel analytics for live debugging

### DIFF
--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -50,7 +50,7 @@ import { cn } from '@/lib/utils';
 import { toast } from 'sonner';
 import { useSwapI18n } from '@/lib/swap-i18n';
 import { useRoutes } from '@/hooks/useApi';
-import { emitRouteEvent } from '@/lib/telemetry';
+import { emitRouteEvent, emitSwapFunnelEvent, getPriceImpactTier } from '@/lib/telemetry';
 import { SwapWarningCenter, type SwapWarning } from './SwapWarningCenter';
 import { quoteExportToCsv, type QuoteExportPayload } from '@/lib/quote-export';
 import { getTraderErrorCopy, toTraderErrorLine } from '@/lib/api/trader-error-copy';
@@ -717,6 +717,14 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
     const finalToAmount = selectedRoute?.expectedAmount
       ? selectedRoute.expectedAmount.replace('≈ ', '')
       : toAmount;
+    emitSwapFunnelEvent('confirm_clicked', {
+      quoteId: quote.requestId ?? undefined,
+      routeId: selectedRoute?.id,
+      fromAssetCode: fromToken,
+      toAssetCode: toToken,
+      hopCount: selectedRoute?.rawPath?.length ?? quote.data?.path?.length ?? 1,
+      priceImpactTier: getPriceImpactTier(quote.priceImpact),
+    });
     optimistic.initiateSwap({
       fromAsset: fromToken,
       fromAmount,

--- a/frontend/docs/telemetry-schema.md
+++ b/frontend/docs/telemetry-schema.md
@@ -37,6 +37,45 @@ Telemetry is used to understand user interactions and route selection behavior w
 
 ---
 
+## 3. Swap Funnel Events
+
+* **Event Name**: `stellarroute:swap-funnel`
+* **Trigger**: Fired at key live-swap debugging checkpoints (quote → confirm → submit → settle).
+* **Environment Guard**: Respects `NEXT_PUBLIC_TELEMETRY_ENABLED`. If set to `false`, no telemetry events are dispatched.
+
+### `eventName` values
+
+| eventName | When |
+|---|---|
+| `quote_requested` | A quote HTTP request is about to be sent |
+| `confirm_clicked` | User confirms the swap (post high-impact gate if any) |
+| `swap_submitted` | Signed envelope handed to Horizon broadcast |
+| `swap_finalized` | Horizon submit returns a transaction hash (confirmed) |
+| `swap_failed` | Build, sign, or submit path fails |
+
+### Envelope
+
+| Field | Type | Description |
+|---|---|---|
+| `version` | `'1.0.0'` | Schema version |
+| `eventName` | `SwapFunnelEventName` | One of the funnel stages above |
+| `timestamp` | `number` | Epoch ms when the event was emitted |
+| `payload` | `SwapFunnelPayload` | PII-safe context (see below) |
+
+### Payload Fields
+
+| Field | Type | Description |
+|---|---|---|
+| `quoteId` | `string` | Opaque quote/request id when known |
+| `routeId` | `string` | Selected route id when known |
+| `fromAssetCode` | `string` | Source asset code / native identifier |
+| `toAssetCode` | `string` | Destination asset code / native identifier |
+| `hopCount` | `number` | Path length |
+| `priceImpactTier` | `'low' \| 'medium' \| 'high' \| 'severe'` | Categorized impact (never raw %) |
+| `failureStage` | `string` | Coarse stage only (`build`, `sign`, `submit`, `config`) on `swap_failed` |
+
+---
+
 ## Sensitive Data Stripping
 
 The payload intentionally excludes:
@@ -44,3 +83,4 @@ The payload intentionally excludes:
 - Wallet addresses or public keys
 - Identifiable network IP information
 - Raw price impact numbers (categorized into tiers instead)
+- Full error strings that may embed account ids or XDR

--- a/frontend/hooks/useProgressiveLoadingTransition.ts
+++ b/frontend/hooks/useProgressiveLoadingTransition.ts
@@ -45,11 +45,22 @@ export function useProgressiveLoadingTransition(
       enterTimerRef.current = null;
     }
 
+    const clearTimers = () => {
+      if (revealTimerRef.current) {
+        clearTimeout(revealTimerRef.current);
+        revealTimerRef.current = null;
+      }
+      if (enterTimerRef.current) {
+        clearTimeout(enterTimerRef.current);
+        enterTimerRef.current = null;
+      }
+    };
+
     if (isLoading) {
       loadingStartedAtRef.current = Date.now();
       setShowSkeleton(true);
       setIsEntering(false);
-      return;
+      return clearTimers;
     }
 
     if (!showSkeleton) {
@@ -57,7 +68,7 @@ export function useProgressiveLoadingTransition(
       enterTimerRef.current = setTimeout(() => {
         setIsEntering(false);
       }, enterDurationMs);
-      return;
+      return clearTimers;
     }
 
     const loadingStartedAt = loadingStartedAtRef.current ?? Date.now();
@@ -72,16 +83,7 @@ export function useProgressiveLoadingTransition(
       }, enterDurationMs);
     }, waitMs);
 
-    return () => {
-      if (revealTimerRef.current) {
-        clearTimeout(revealTimerRef.current);
-        revealTimerRef.current = null;
-      }
-      if (enterTimerRef.current) {
-        clearTimeout(enterTimerRef.current);
-        enterTimerRef.current = null;
-      }
-    };
+    return clearTimers;
   }, [isLoading, showSkeleton, minimumSkeletonMs, enterDurationMs]);
 
   return {

--- a/frontend/hooks/useQuoteRefresh.ts
+++ b/frontend/hooks/useQuoteRefresh.ts
@@ -21,6 +21,7 @@ import {
   type QuoteRetryRequestContext,
   type QuoteRetryTelemetryEvent,
 } from '@/lib/quote-retry';
+import { emitSwapFunnelEvent } from '@/lib/telemetry';
 import {
   isQuoteStale,
   QUOTE_AMOUNT_DEBOUNCE_MS,
@@ -233,6 +234,11 @@ export function useQuoteRefresh(
     // Same pattern as `useFetch` in useApi.ts: set loading before starting the request.
     // eslint-disable-next-line react-hooks/set-state-in-effect -- intentional loading transition before async getQuote
     setState((prev) => ({ ...prev, loading: true, error: null }));
+
+    emitSwapFunnelEvent('quote_requested', {
+      fromAssetCode: base,
+      toAssetCode: quoteAsset,
+    });
 
     client
       .getQuote(base, quoteAsset, debouncedAmount, type, {

--- a/frontend/hooks/useTransactionLifecycle.ts
+++ b/frontend/hooks/useTransactionLifecycle.ts
@@ -9,6 +9,24 @@ import {
   type NotificationPreference,
 } from "@/lib/notifications";
 import { XdrBuildError } from "@/lib/wallet/xdr-builder";
+import {
+  emitSwapFunnelEvent,
+  getPriceImpactTier,
+  type SwapFunnelPayload,
+} from "@/lib/telemetry";
+
+function funnelPayloadFromTrade(
+  params: TradeParams,
+  extra: Partial<SwapFunnelPayload> = {},
+): SwapFunnelPayload {
+  return {
+    fromAssetCode: params.fromAsset,
+    toAssetCode: params.toAsset,
+    hopCount: params.routePath?.length || 1,
+    priceImpactTier: getPriceImpactTier(params.priceImpact),
+    ...extra,
+  };
+}
 
 export interface TradeParams {
   fromAsset: string;
@@ -152,16 +170,28 @@ export function useTransactionLifecycle(
             "Transaction could not be built. Please refresh and try again."
           );
           setStatus("failed");
+          emitSwapFunnelEvent(
+            "swap_failed",
+            funnelPayloadFromTrade(params, { failureStage: "config" }),
+          );
           return;
         }
         if (isDefaultSignTransaction(signTransaction)) {
           setErrorMessage("Wallet not ready for signing.");
           setStatus("failed");
+          emitSwapFunnelEvent(
+            "swap_failed",
+            funnelPayloadFromTrade(params, { failureStage: "config" }),
+          );
           return;
         }
         if (isDefaultSubmitTransaction(submitTransaction)) {
           setErrorMessage("Transaction submission is not configured.");
           setStatus("failed");
+          emitSwapFunnelEvent(
+            "swap_failed",
+            funnelPayloadFromTrade(params, { failureStage: "config" }),
+          );
           return;
         }
       }
@@ -199,6 +229,10 @@ export function useTransactionLifecycle(
             : err instanceof Error ? err.message : 'Failed to build transaction';
           setErrorMessage(msg);
           setStatus("failed");
+          emitSwapFunnelEvent(
+            "swap_failed",
+            funnelPayloadFromTrade(params, { failureStage: "build" }),
+          );
           updateTransactionStatus(tempId, "failed", { errorMessage: msg });
           dispatchTransactionNotification(
             {
@@ -232,6 +266,10 @@ export function useTransactionLifecycle(
           : msg;
         setErrorMessage(userFacingMsg);
         setStatus("failed");
+        emitSwapFunnelEvent(
+          "swap_failed",
+          funnelPayloadFromTrade(params, { failureStage: "sign" }),
+        );
         updateTransactionStatus(tempId, "failed", {
           errorMessage: userFacingMsg,
         });
@@ -253,6 +291,7 @@ export function useTransactionLifecycle(
 
       // Step 2: Submit
       setStatus("submitted");
+      emitSwapFunnelEvent("swap_submitted", funnelPayloadFromTrade(params));
       updateTransactionStatus(tempId, "submitted");
 
       // Start deadline timer
@@ -286,6 +325,7 @@ export function useTransactionLifecycle(
         const hash = result.hash;
         setTxHash(hash);
         setStatus("confirmed");
+        emitSwapFunnelEvent("swap_finalized", funnelPayloadFromTrade(params));
         updateTransactionStatus(tempId, "confirmed", { hash });
         dispatchTransactionNotification(
           {
@@ -307,6 +347,10 @@ export function useTransactionLifecycle(
           err instanceof Error ? err.message : "Transaction submission failed";
         setErrorMessage(msg);
         setStatus("failed");
+        emitSwapFunnelEvent(
+          "swap_failed",
+          funnelPayloadFromTrade(params, { failureStage: "submit" }),
+        );
         updateTransactionStatus(tempId, "failed", { errorMessage: msg });
         dispatchTransactionNotification(
           {

--- a/frontend/lib/telemetry.test.ts
+++ b/frontend/lib/telemetry.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  SWAP_FUNNEL_EVENT_NAME,
+  emitSwapFunnelEvent,
+  getPriceImpactTier,
+} from './telemetry';
+
+describe('swap funnel telemetry (#1016)', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it('maps price impact into safe tiers', () => {
+    expect(getPriceImpactTier(0.1)).toBe('low');
+    expect(getPriceImpactTier(0.5)).toBe('medium');
+    expect(getPriceImpactTier(2)).toBe('high');
+    expect(getPriceImpactTier(5)).toBe('severe');
+  });
+
+  it('emits quote_requested / confirm / submit / finalize / fail events', () => {
+    const listener = vi.fn();
+    window.addEventListener(SWAP_FUNNEL_EVENT_NAME, listener as EventListener);
+
+    try {
+      for (const name of [
+        'quote_requested',
+        'confirm_clicked',
+        'swap_submitted',
+        'swap_finalized',
+        'swap_failed',
+      ] as const) {
+        emitSwapFunnelEvent(name, {
+          quoteId: 'q1',
+          routeId: 'r1',
+          fromAssetCode: 'XLM',
+          toAssetCode: 'USDC',
+          hopCount: 1,
+          priceImpactTier: 'low',
+          ...(name === 'swap_failed' ? { failureStage: 'submit' } : {}),
+        });
+      }
+
+      expect(listener).toHaveBeenCalledTimes(5);
+      const names = listener.mock.calls.map(
+        ([event]) => (event as CustomEvent).detail.eventName,
+      );
+      expect(names).toEqual([
+        'quote_requested',
+        'confirm_clicked',
+        'swap_submitted',
+        'swap_finalized',
+        'swap_failed',
+      ]);
+
+      const failed = (listener.mock.calls[4][0] as CustomEvent).detail;
+      expect(failed.payload).not.toHaveProperty('walletAddress');
+      expect(failed.payload).not.toHaveProperty('amountIn');
+      expect(failed.payload.failureStage).toBe('submit');
+    } finally {
+      window.removeEventListener(SWAP_FUNNEL_EVENT_NAME, listener as EventListener);
+    }
+  });
+
+  it('does not emit when NEXT_PUBLIC_TELEMETRY_ENABLED is false', () => {
+    vi.stubEnv('NEXT_PUBLIC_TELEMETRY_ENABLED', 'false');
+    const listener = vi.fn();
+    window.addEventListener(SWAP_FUNNEL_EVENT_NAME, listener as EventListener);
+
+    try {
+      emitSwapFunnelEvent('quote_requested', { fromAssetCode: 'XLM' });
+      expect(listener).not.toHaveBeenCalled();
+    } finally {
+      window.removeEventListener(SWAP_FUNNEL_EVENT_NAME, listener as EventListener);
+    }
+  });
+});

--- a/frontend/lib/telemetry.ts
+++ b/frontend/lib/telemetry.ts
@@ -1,4 +1,5 @@
 export const ROUTE_SELECTED_EVENT_NAME = 'stellarroute:route-selected';
+export const SWAP_FUNNEL_EVENT_NAME = 'stellarroute:swap-funnel';
 
 export interface RouteTelemetryEvent {
   venue: string;
@@ -16,6 +17,13 @@ export const telemetryConfig: TelemetryConfig = {
 export type TelemetryEventVersion = '1.0.0';
 export type RouteEventName = 'route_view' | 'route_select' | 'route_confirm';
 
+export type SwapFunnelEventName =
+  | 'quote_requested'
+  | 'confirm_clicked'
+  | 'swap_submitted'
+  | 'swap_finalized'
+  | 'swap_failed';
+
 export interface RouteTelemetryPayload {
   fromAssetCode?: string;
   toAssetCode?: string;
@@ -27,11 +35,30 @@ export interface RouteTelemetryPayload {
   hopCount?: number;
 }
 
+/** PII-safe swap funnel payload — no wallet addresses or exact trade amounts. */
+export interface SwapFunnelPayload {
+  quoteId?: string;
+  routeId?: string;
+  fromAssetCode?: string;
+  toAssetCode?: string;
+  hopCount?: number;
+  priceImpactTier?: RouteTelemetryPayload['priceImpactTier'];
+  /** Coarse failure class only (e.g. build | sign | submit | config). */
+  failureStage?: string;
+}
+
 export interface TelemetryEvent {
   version: TelemetryEventVersion;
   eventName: RouteEventName;
   timestamp: number;
   payload: RouteTelemetryPayload;
+}
+
+export interface SwapFunnelTelemetryEvent {
+  version: TelemetryEventVersion;
+  eventName: SwapFunnelEventName;
+  timestamp: number;
+  payload: SwapFunnelPayload;
 }
 
 export function getPriceImpactTier(impactPct: string | number): RouteTelemetryPayload['priceImpactTier'] {
@@ -43,8 +70,12 @@ export function getPriceImpactTier(impactPct: string | number): RouteTelemetryPa
   return 'low';
 }
 
+function isTelemetryEnabled(): boolean {
+  return process.env.NEXT_PUBLIC_TELEMETRY_ENABLED !== 'false';
+}
+
 export function emitRouteEvent(venue: string, hopCount: number): void {
-  if (process.env.NEXT_PUBLIC_TELEMETRY_ENABLED === 'false') {
+  if (!isTelemetryEnabled()) {
     return;
   }
 
@@ -55,6 +86,32 @@ export function emitRouteEvent(venue: string, hopCount: number): void {
   window.dispatchEvent(
     new CustomEvent<RouteTelemetryEvent>(ROUTE_SELECTED_EVENT_NAME, {
       detail: { venue, hopCount },
+    }),
+  );
+}
+
+export function emitSwapFunnelEvent(
+  eventName: SwapFunnelEventName,
+  payload: SwapFunnelPayload = {},
+): void {
+  if (!isTelemetryEnabled()) {
+    return;
+  }
+
+  if (typeof window === 'undefined' || typeof CustomEvent === 'undefined') {
+    return;
+  }
+
+  const detail: SwapFunnelTelemetryEvent = {
+    version: '1.0.0',
+    eventName,
+    timestamp: Date.now(),
+    payload,
+  };
+
+  window.dispatchEvent(
+    new CustomEvent<SwapFunnelTelemetryEvent>(SWAP_FUNNEL_EVENT_NAME, {
+      detail,
     }),
   );
 }


### PR DESCRIPTION
## Summary
- Add `emitSwapFunnelEvent` for `quote_requested`, `confirm_clicked`, `swap_submitted`, `swap_finalized`, `swap_failed` with PII-safe payloads.
- Wire emits in quote refresh, SwapCard confirm, and lifecycle submit paths; document schema.

Closes #1016

## Test plan
- [x] `vitest` telemetry + quote refresh + lifecycle signing/notification
- [x] Full unit suite green

Made with [Cursor](https://cursor.com)