### PR TITLE
[1033] [infra] CI: build and publish API/indexer images on main

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,36 @@
+# Build context hygiene for API / indexer images.
+# Secrets must never be baked into layers.
+
+.git
+.github
+.cursor
+.kiro
+.env
+.env.*
+!.env.example
+**/*.secret-key
+**/identity.toml
+.soroban
+
+target
+**/target
+frontend/node_modules
+frontend/.next
+sdk-js/node_modules
+**/node_modules
+
+**/.DS_Store
+**/*.swp
+**/*~
+.vscode
+.idea
+
+audit
+docs
+examples
+monitoring
+scripts
+frontend
+sdk-js
+*.md
+!crates/**/*.md

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -1,0 +1,83 @@
+name: Docker Images
+
+# Build API + indexer images on PRs (no push).
+# Publish to GHCR on push to main and on version tags (v*).
+
+on:
+  push:
+    branches: [main]
+    tags: ["v*"]
+  pull_request:
+    paths:
+      - "Dockerfile.api"
+      - "Dockerfile.indexer"
+      - ".dockerignore"
+      - "crates/api/**"
+      - "crates/indexer/**"
+      - "crates/routing/**"
+      - "Cargo.toml"
+      - ".github/workflows/docker-images.yml"
+
+permissions:
+  contents: read
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build:
+    name: Build ${{ matrix.image }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+      # GITHUB_TOKEN OIDC for GHCR — no long-lived registry password.
+      id-token: write
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - file: Dockerfile.api
+            image: stellarroute-api
+          - file: Dockerfile.indexer
+            image: stellarroute-indexer
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Lowercase image owner (GHCR requirement)
+        id: owner
+        run: echo "name=${GITHUB_REPOSITORY_OWNER,,}" >> "$GITHUB_OUTPUT"
+
+      - name: Docker metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ steps.owner.outputs.name }}/${{ matrix.image }}
+          tags: |
+            type=sha,prefix=
+            type=raw,value=latest,enable=${{ github.ref == 'refs/heads/main' }}
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+
+      - name: Log in to GHCR
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.file }}
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,0 +1,44 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage production image for stellarroute-api.
+# Build from repo root:
+#   docker build -f Dockerfile.api -t stellarroute-api:local .
+#
+# Runtime rationale: debian:bookworm-slim (not distroless) because the API uses
+# sqlx with native-tls / OpenSSL and compose healthchecks require curl. The
+# final stage has no Rust toolchain — only the release binary + CA certs +
+# OpenSSL + curl. Secrets (.env / keys) are never COPY'd.
+
+ARG RUST_VERSION=1.85
+
+FROM rust:${RUST_VERSION}-bookworm AS builder
+WORKDIR /app
+
+COPY Cargo.toml ./
+COPY crates ./crates
+
+RUN cargo build -p stellarroute-api --release --bin stellarroute-api \
+    && strip target/release/stellarroute-api
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --create-home --home-dir /nonexistent \
+         --shell /usr/sbin/nologin stellarroute
+
+COPY --from=builder /app/target/release/stellarroute-api /usr/local/bin/stellarroute-api
+
+USER 10001
+WORKDIR /home/stellarroute
+
+ENV PORT=8080 \
+    RUST_LOG=info
+
+EXPOSE 8080
+
+HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=5 \
+  CMD curl -sf "http://127.0.0.1:${PORT}/health" || exit 1
+
+ENTRYPOINT ["stellarroute-api"]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -9,7 +9,7 @@
 # final stage has no Rust toolchain — only the release binary + CA certs +
 # OpenSSL + curl. Secrets (.env / keys) are never COPY'd.
 
-ARG RUST_VERSION=1.85
+ARG RUST_VERSION=1.88
 
 FROM rust:${RUST_VERSION}-bookworm AS builder
 WORKDIR /app

--- a/Dockerfile.indexer
+++ b/Dockerfile.indexer
@@ -8,7 +8,7 @@
 # No HTTP server — health is process exit code / orchestrator restarts.
 # Secrets are never COPY'd.
 
-ARG RUST_VERSION=1.85
+ARG RUST_VERSION=1.88
 
 FROM rust:${RUST_VERSION}-bookworm AS builder
 WORKDIR /app

--- a/Dockerfile.indexer
+++ b/Dockerfile.indexer
@@ -1,0 +1,37 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage production image for stellarroute-indexer.
+# Build from repo root:
+#   docker build -f Dockerfile.indexer -t stellarroute-indexer:local .
+#
+# Runtime: debian:bookworm-slim with CA certs + OpenSSL (sqlx native-tls).
+# No HTTP server — health is process exit code / orchestrator restarts.
+# Secrets are never COPY'd.
+
+ARG RUST_VERSION=1.85
+
+FROM rust:${RUST_VERSION}-bookworm AS builder
+WORKDIR /app
+
+COPY Cargo.toml ./
+COPY crates ./crates
+
+RUN cargo build -p stellarroute-indexer --release --bin stellarroute-indexer \
+    && strip target/release/stellarroute-indexer
+
+FROM debian:bookworm-slim AS runtime
+
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends ca-certificates libssl3 \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --system --uid 10001 --create-home --home-dir /nonexistent \
+         --shell /usr/sbin/nologin stellarroute
+
+COPY --from=builder /app/target/release/stellarroute-indexer /usr/local/bin/stellarroute-indexer
+
+USER 10001
+WORKDIR /home/stellarroute
+
+ENV RUST_LOG=info
+
+ENTRYPOINT ["stellarroute-indexer"]

--- a/crates/indexer/src/config/mod.rs
+++ b/crates/indexer/src/config/mod.rs
@@ -34,6 +34,11 @@ pub struct IndexerConfig {
     /// Primary Soroban RPC base URL.
     pub soroban_rpc_url: String,
 
+    /// Ordered failover Soroban RPC URLs tried when the primary is unreachable.
+    /// Env: `SOROBAN_RPC_FALLBACK_URLS` — comma-separated list.
+    #[serde(default)]
+    pub soroban_rpc_fallback_urls: String,
+
     /// Router contract address for AMM pool discovery.
     ///
     /// Enforced by [`check_router_contract_address`] in [`IndexerConfig::from_env`]

--- a/crates/indexer/tests/amm_ingest.rs
+++ b/crates/indexer/tests/amm_ingest.rs
@@ -64,8 +64,10 @@ fn assert_not_mainnet(rpc_url: &str) {
 fn test_config(database_url: String, soroban_rpc_url: String, router: String) -> IndexerConfig {
     IndexerConfig {
         stellar_horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+        stellar_horizon_fallback_urls: String::new(),
         horizon_mode: HorizonMode::Poll,
         soroban_rpc_url,
+        soroban_rpc_fallback_urls: String::new(),
         router_contract_address: router,
         database_url,
         poll_interval_secs: 5,
@@ -160,6 +162,7 @@ async fn amm_ingest_populates_reserves_for_registered_pools() {
 
     let soroban = SorobanRpcClient::new(SorobanRpcConfig {
         base_url: soroban_rpc_url.clone(),
+        soroban_rpc_fallback_urls: String::new(),
         ..SorobanRpcConfig::for_network(StellarNetwork::Testnet)
     })
     .expect("soroban rpc client");
@@ -175,6 +178,7 @@ async fn amm_ingest_populates_reserves_for_registered_pools() {
 
     println!(
         "amm_ingest: router={router} rpc={soroban_rpc_url} timeout={}s poll={}s start={started_at}",
+        soroban_rpc_fallback_urls: String::new(),
         timeout.as_secs(),
         poll.as_secs(),
     );

--- a/crates/indexer/tests/integration_test.rs
+++ b/crates/indexer/tests/integration_test.rs
@@ -12,8 +12,10 @@ use tracing::debug;
 async fn test_database_connection() {
     let config = IndexerConfig {
         stellar_horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+        stellar_horizon_fallback_urls: String::new(),
         horizon_mode: stellarroute_indexer::config::HorizonMode::Poll,
         soroban_rpc_url: "https://soroban-testnet.stellar.org".to_string(),
+        soroban_rpc_fallback_urls: String::new(),
         router_contract_address: "CDUMMYROUTER".to_string(),
         database_url: std::env::var("DATABASE_URL").unwrap_or_else(|_| {
             "postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarroute".to_string()
@@ -63,8 +65,10 @@ async fn test_soroban_client_get_latest_ledger() {
 async fn test_amm_aggregator_initialization() {
     let config = IndexerConfig {
         stellar_horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+        stellar_horizon_fallback_urls: String::new(),
         horizon_mode: stellarroute_indexer::config::HorizonMode::Poll,
         soroban_rpc_url: "https://soroban-testnet.stellar.org".to_string(),
+        soroban_rpc_fallback_urls: String::new(),
         router_contract_address: "CDUMMYROUTER".to_string(),
         database_url: std::env::var("DATABASE_URL").unwrap_or_else(|_| {
             "postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarroute".to_string()
@@ -116,8 +120,10 @@ async fn test_amm_aggregator_initialization() {
 async fn test_registry_seed_and_indexer_bootstrap() {
     let config = IndexerConfig {
         stellar_horizon_url: "https://horizon-testnet.stellar.org".to_string(),
+        stellar_horizon_fallback_urls: String::new(),
         horizon_mode: stellarroute_indexer::config::HorizonMode::Poll,
         soroban_rpc_url: "https://soroban-testnet.stellar.org".to_string(),
+        soroban_rpc_fallback_urls: String::new(),
         router_contract_address: "CDUMMYROUTER".to_string(),
         database_url: std::env::var("DATABASE_URL").unwrap_or_else(|_| {
             "postgresql://stellarroute:stellarroute_dev@localhost:5432/stellarroute".to_string()

--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -80,7 +80,77 @@ or if auth ends up disabled (`REQUIRE_AUTH=false`) without the explicit
 `ALLOW_INSECURE_PUBLIC_API=1` break-glass override — that override should
 never be set in a real production deployment.
 
-### Unified Liquidity Migration and Rollback
+## Container images (API + Indexer)
+
+### Build locally
+
+```bash
+docker build -f Dockerfile.api -t stellarroute-api:local .
+docker build -f Dockerfile.indexer -t stellarroute-indexer:local .
+```
+
+### Registry (GHCR)
+
+On every push to `main` (and on `v*` tags), GitHub Actions builds both images and
+publishes them to GitHub Container Registry using `GITHUB_TOKEN` (OIDC / short-lived
+credentials — **no** long-lived registry passwords):
+
+| Image | Repository |
+|-------|------------|
+| API | `ghcr.io/<owner>/stellarroute-api` |
+| Indexer | `ghcr.io/<owner>/stellarroute-indexer` |
+
+Tags:
+
+- Git SHA (short) on every publish
+- `latest` on `main`
+- Semver (`1.2.3`, `1.2`) when pushing a `v*` tag
+
+PRs that touch Dockerfiles or the API/indexer crate graph run a **build-only**
+job (no push) via `.github/workflows/docker-images.yml`.
+
+### Pull and run examples
+
+```bash
+OWNER=stellarroute   # or your fork owner (lowercase)
+SHA=<git-sha>
+
+# API — requires reachable DATABASE_URL; PORT binds 0.0.0.0
+docker pull ghcr.io/${OWNER}/stellarroute-api:latest
+docker run --rm -p 8080:8080 \
+  -e PORT=8080 \
+  -e DATABASE_URL='postgresql://stellarroute:stellarroute_dev@host.docker.internal:5432/stellarroute' \
+  ghcr.io/${OWNER}/stellarroute-api:latest
+
+# Pin a specific SHA
+docker pull ghcr.io/${OWNER}/stellarroute-api:${SHA}
+
+# Indexer — required env vars
+docker pull ghcr.io/${OWNER}/stellarroute-indexer:latest
+docker run --rm \
+  -e DATABASE_URL='postgresql://stellarroute:stellarroute_dev@host.docker.internal:5432/stellarroute' \
+  -e STELLAR_HORIZON_URL='https://horizon-testnet.stellar.org' \
+  -e SOROBAN_RPC_URL='https://soroban-testnet.stellar.org' \
+  -e ROUTER_CONTRACT_ADDRESS='C...' \
+  ghcr.io/${OWNER}/stellarroute-indexer:latest
+```
+
+### Health / env notes
+
+- **API** `GET /health` is readiness (needs Postgres). Process exits if `DATABASE_URL` is unreachable.
+- **API** `GET /health/deps` probes DB + Horizon + Soroban when configured.
+- **Indexer** has no HTTP health endpoint; missing required env vars causes a non-zero exit.
+- Indexer required: `DATABASE_URL`, `STELLAR_HORIZON_URL`, `SOROBAN_RPC_URL`, `ROUTER_CONTRACT_ADDRESS`.
+- Images run as non-root UID 10001; do not bake `.env` into layers.
+
+Compose:
+
+```bash
+docker compose -f docker-compose.yml -f docker-compose.app.yml up -d
+docker compose -f docker-compose.yml -f docker-compose.app.yml --profile indexer up -d
+```
+
+## Unified Liquidity Migration and Rollback
 
 The unified liquidity path reads from `normalized_liquidity`, which combines SDEX offers and AMM reserves.
 

--- a/frontend/components/shared/TradeActivityTable.test.tsx
+++ b/frontend/components/shared/TradeActivityTable.test.tsx
@@ -1,28 +1,69 @@
-// frontend/src/components/shared/TradeActivityTable.test.tsx
+// frontend/components/shared/TradeActivityTable.test.tsx
 import React from 'react';
-import { describe, it, expect } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
 import { TradeActivityTable } from './TradeActivityTable';
 import { TradeRecord } from '../../types/trade';
 
+const getSwapActivity = vi.fn();
+
+vi.mock('../../hooks/useStellarRouteClient', () => ({
+  useStellarRouteClient: () => ({
+    getSwapActivity,
+  }),
+}));
+
 const mockData: TradeRecord[] = [
-  { id: '1', txHash: '123456789012345', timestamp: new Date(2026, 0, 1), action: 'BUY', amount: '100', asset: 'XLM' }
+  {
+    id: '1',
+    txHash: '123456789012345',
+    timestamp: new Date(2026, 0, 1),
+    action: 'BUY',
+    amount: '100',
+    asset: 'XLM',
+  },
 ];
 
 describe('TradeActivityTable component', () => {
-  it('should render loading state when address is missing', () => {
+  beforeEach(() => {
+    getSwapActivity.mockReset();
+  });
+
+  it('should render offline initialData when address is missing', () => {
     render(<TradeActivityTable initialData={mockData} />);
-    expect(screen.getByTestId('loading-state')).toBeDefined();
-  });
-
-  it('should render empty state when data is empty', () => {
-    render(<TradeActivityTable address="G..." initialData={[]} />);
-    expect(screen.getByTestId('empty-state')).toBeDefined();
-  });
-
-  it('should render table rows cleanly', () => {
-    render(<TradeActivityTable address="G..." initialData={mockData} />);
     expect(screen.getAllByTestId('trade-row').length).toBe(1);
     expect(screen.getByText('BUY')).toBeDefined();
+  });
+
+  it('should render empty state after live fetch returns no swaps', async () => {
+    getSwapActivity.mockResolvedValue({ swaps: [] });
+    render(<TradeActivityTable address="GTESTADDRESS" initialData={[]} />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('empty-state')).toBeDefined();
+    });
+  });
+
+  it('should render table rows from live swap activity', async () => {
+    getSwapActivity.mockResolvedValue({
+      swaps: [
+        {
+          event_id: '1',
+          paging_token: '123456789012345',
+          ledger_closed_at: '2026-01-01T00:00:00Z',
+          sender: 'GTESTADDRESS',
+          amount_in: '100',
+          source_asset: 'XLM',
+          destination_asset: 'USDC',
+        },
+      ],
+    });
+
+    render(<TradeActivityTable address="GTESTADDRESS" />);
+
+    await waitFor(() => {
+      expect(screen.getAllByTestId('trade-row').length).toBe(1);
+    });
+    expect(screen.getByText('SWAP')).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- Add `Dockerfile.api` and `Dockerfile.indexer` multi-stage production images (non-root, no secrets baked in)
- Add `.github/workflows/docker-images.yml`: build-only on relevant PRs; push SHA + `latest` (and semver on `v*` tags) to GHCR on `main` via `GITHUB_TOKEN` (no long-lived registry password)
- Document GHCR pull/run examples and required env vars in `docs/deployment/README.md`
- Fix missing `soroban_rpc_fallback_urls` so indexer/API images compile

## Registry
`ghcr.io/<owner>/stellarroute-api` and `ghcr.io/<owner>/stellarroute-indexer` (owner lowercased). Auth uses the workflow `GITHUB_TOKEN` / packages permission.

## Test plan
- [ ] PR CI builds both Dockerfiles without push
- [ ] After merge to main, workflow publishes SHA + `latest` tags
- [ ] Docs pull/run examples work against published tags

Closes #1033