### PR TITLE
[989] [infra] Secrets management for Horizon keys, admin tokens, webhooks

### DIFF
--- a/docs/deployment/README.md
+++ b/docs/deployment/README.md
@@ -18,6 +18,12 @@ For public launch, use the staged **limited pairs → full markets** plan (metri
 
 ## Key Management
 
+The complete production secret inventory — every secret, its store, its
+consumer, and its rotation procedure — is documented in
+[`docs/deployment/secrets-management.md`](./secrets-management.md).
+Step-by-step rotation procedures for API keys, admin tokens, and webhook
+signing secrets are in [`docs/key_rotation.md`](../key_rotation.md).
+
 ### Local Development
 ```bash
 # Generate a new identity (stored in ~/.config/soroban/identity/)

--- a/docs/deployment/secrets-management.md
+++ b/docs/deployment/secrets-management.md
@@ -1,0 +1,124 @@
+# Secrets Management
+
+This document is the single source of truth for **where every production
+secret lives, who consumes it, and how it is rotated**. It covers Horizon /
+Soroban RPC configuration, admin API tokens, integrator API keys, webhook
+secrets, deployer keys, and datastore credentials.
+
+Related documents:
+
+- [`docs/key_rotation.md`](../key_rotation.md) — step-by-step rotation
+  procedures for API keys, admin tokens, and webhook signing secrets.
+- [`deploy/secrets.checklist.md`](../../deploy/secrets.checklist.md) —
+  operator checklist to work through before the first deploy.
+- [`docs/deployment/README.md`](./README.md) — deployment runbook, including
+  the deployer key management and secret rotation checklist sections.
+
+## Principles
+
+1. **No secrets in git.** Secret material (tokens, keys, seed phrases,
+   connection strings with passwords) is never committed — not in source, not
+   in config files, not in deployment artifacts. `.gitignore` excludes
+   `.env`, `.env.prod`, `.soroban/`, `*.secret-key`, and `identity.toml`, and
+   the deploy artifact writer emits only non-secret fields.
+2. **One secret store per environment.** Each runtime environment has exactly
+   one authoritative secret store (see the inventory below). Copies elsewhere
+   (developer machines, CI caches) are prohibited.
+3. **Separate secrets per environment.** Testnet and mainnet never share
+   deployer keys, admin tokens, or API keys. Staging never reuses production
+   values.
+4. **Least privilege.** CI jobs and services only receive the secrets they
+   need. The indexer does not get `ADMIN_AUTH_TOKEN`; the API does not get
+   the deployer secret key.
+5. **Rotation is routine.** Every secret has an owner and a rotation
+   procedure that works without downtime. Rotation is exercised on a
+   schedule, not only after an incident.
+
+## Secret stores by environment
+
+| Environment | Authoritative store | Notes |
+|---|---|---|
+| Production / staging (Render) | Render dashboard → service → **Environment** (secret env vars / secret files) | `sync: false` keys in `render.yaml` are injected here at deploy time; never written to the repo |
+| Production (self-hosted Compose) | `.env.prod` on the host, permissions `600`, never committed | Passed via `--env-file`; see `deploy/secrets.checklist.md` |
+| CI/CD (GitHub Actions) | GitHub **repository secrets** (`Settings → Secrets and variables → Actions`) | Non-secret toggles use repository *variables* (`vars.*`); secret material uses `secrets.*` only |
+| Local development | Developer-local `.env` (gitignored), based on `.env.example` | `.env.example` contains placeholders only, never real values |
+| Consumer webhook signing secrets | Postgres table `consumer_quote_expiration_webhooks` | Managed per consumer via the admin API, not via env vars |
+
+## Production secret inventory
+
+Every production secret, its consumer, its store, and its rotation procedure:
+
+| Secret | Consumed by | Store | Rotation procedure |
+|---|---|---|---|
+| `DATABASE_URL` (Postgres credentials) | API, indexer | Render (auto-wired from managed Postgres) / `.env.prod` | [Secret Rotation Checklist](./README.md#secret-rotation-checklist) |
+| `REDIS_URL` / `REDIS_PASSWORD` | API | Render (auto-wired from managed Redis) / `.env.prod` | [Secret Rotation Checklist](./README.md#secret-rotation-checklist) |
+| `API_KEYS` (integrator API keys) | API | Render env / `.env.prod` | [`docs/key_rotation.md` — API keys](../key_rotation.md#rotating-integrator-api-keys-api_keys) |
+| `ADMIN_AUTH_TOKEN` (admin/operator token) | API (`/api/v1/admin/*`, `/api/v1/system/*`, production `/metrics` + `/api/v1/replay/*`) | Render env / `.env.prod` | [`docs/key_rotation.md` — admin token](../key_rotation.md#rotating-the-admin-token-admin_auth_token) |
+| Webhook signing secrets (per consumer) | API webhook dispatcher (HMAC-SHA256 `x-stellarroute-signature`) | Postgres `consumer_quote_expiration_webhooks.signing_secret` | [`docs/key_rotation.md` — webhook secrets](../key_rotation.md#rotating-webhook-signing-secrets) |
+| `LIQUIDITY_THINNESS_ALERT_WEBHOOK_URL` | API alerting | Render env / `.env.prod` | Issue a new webhook URL at the receiver, update the env var, redeploy, revoke the old URL |
+| `TTL_ALERT_WEBHOOK_URL` | TTL monitoring scripts | Render env / cron host env | Same as above |
+| `STELLAR_HORIZON_URL` (incl. any keyed/paid Horizon endpoint) | Indexer | Render env / `.env.prod` | [`docs/key_rotation.md` — Horizon/RPC](../key_rotation.md#rotating-horizon--soroban-rpc-credentials) |
+| `SOROBAN_RPC_URL` (incl. any provider API key in the URL) | API (optional), indexer | Render env / `.env.prod` | [`docs/key_rotation.md` — Horizon/RPC](../key_rotation.md#rotating-horizon--soroban-rpc-credentials) |
+| `SOROBAN_DEPLOYER_SECRET` (testnet deployer key) | CI deploy workflow | GitHub Actions repository secret | [Deployer key rotation](../key_rotation.md#rotating-deployer-keys) |
+| `SOROBAN_MAINNET_DEPLOYER_SECRET` (mainnet deployer key) | CI mainnet deploy workflow | GitHub Actions repository secret | [Deployer key rotation](../key_rotation.md#rotating-deployer-keys) |
+| Router **admin key** (on-chain admin) | Contract operations | Hardware wallet or encrypted vault — never in env vars or CI | On-chain `set_admin()` / multisig governance; see `audit/assumptions.md` |
+| `OTEL_EXPORTER_OTLP_ENDPOINT` (if the collector URL embeds a token) | API, indexer | Render env / `.env.prod` | Issue new collector token, update env var, redeploy |
+
+Non-secret deployment configuration (`SOROBAN_CONTRACT_ID`, `DEPLOY_ENABLED`,
+`DEPLOY_MAINNET_ENABLED`, `STELLARROUTE_ENV`, rate-limit knobs, etc.) is kept
+in GitHub repository **variables** or plain env vars, so the secret store
+stays small and auditable.
+
+## CI/CD policy (GitHub Actions)
+
+- **Secrets come from the platform, never from committed files.** Workflows
+  reference `${{ secrets.* }}` exclusively; there are no encrypted blobs,
+  `.env` files, or key files checked into the repository. This is asserted in
+  review for every workflow change.
+- **Secrets never appear in argv or logs.** The deploy workflows pipe
+  `SOROBAN_DEPLOYER_SECRET` to `soroban keys add --secret-key stdin` so the
+  key never hits process arguments or the run log. GitHub additionally masks
+  registered secret values in workflow output.
+- **Short-lived credentials via OIDC where supported.** For any future cloud
+  integrations (e.g. AWS/GCP object storage for audit-log export, container
+  registries), prefer GitHub's OIDC federation (`permissions: id-token:
+  write` + the provider's official auth action) over long-lived static keys,
+  so CI holds no persistent cloud credentials at all. Static repository
+  secrets are the fallback only when the target platform (e.g. Render,
+  Soroban deployer identities) does not support OIDC federation.
+- **Least-privilege workflow tokens.** Workflows use the default read-only
+  `GITHUB_TOKEN` unless a job explicitly needs more (e.g.
+  `packages: write` for pushing Docker images).
+- **Environment gating.** Mainnet deploys are gated behind the
+  `DEPLOY_MAINNET_ENABLED` repository variable and a manual
+  `workflow_dispatch` trigger, and use a dedicated mainnet-only secret.
+
+## Handling a leaked secret
+
+1. **Rotate immediately** using the matching procedure from the inventory
+   table above — do not wait for a deploy window. All documented rotations
+   are zero-downtime.
+2. **Revoke the leaked value** at the source (delete the GitHub secret /
+   Render env var, deregister the API key, disable the webhook registration,
+   move funds off a leaked deployer account and retire it).
+3. **Purge from history if committed.** If a secret was ever committed,
+   rotation is mandatory even after a history rewrite — treat the value as
+   permanently public.
+4. **Audit for use.** Check API logs (admin endpoints are covered by the
+   admin audit log), Render deploy history, and on-chain activity of deployer
+   accounts for unauthorized use during the exposure window.
+5. **Record the incident** as a GitHub issue labelled `security` with the
+   exposure window, blast radius, and remediation steps taken.
+
+## Verification
+
+```bash
+# Rotation and secret-store docs exist and cross-reference each other
+rg -n 'rotat|secret' docs/key_rotation.md docs/deployment
+
+# No committed .env files with real values
+git ls-files | rg '^\.env$|\.env\.prod'   # should print nothing
+
+# Workflows only consume platform secrets
+rg -n 'secrets\.' .github/workflows
+```

--- a/docs/key_rotation.md
+++ b/docs/key_rotation.md
@@ -1,17 +1,27 @@
-# API Key Rotation
+# Secret & Key Rotation
 
-StellarRoute uses a simple environment-variable based system for API keys.
+This document contains the step-by-step rotation procedures for every
+runtime secret. The full inventory of production secrets — where each one is
+stored and who consumes it — lives in
+[`docs/deployment/secrets-management.md`](deployment/secrets-management.md).
+Deployer-key handling and the generic datastore rotation checklist are in
+[`docs/deployment/README.md`](deployment/README.md#key-management).
 
-## Configuring Keys
-API keys are provided via the `API_KEYS` environment variable as a comma-separated list.
+All procedures below are zero-downtime: the new credential is introduced
+alongside the old one, verified, and only then is the old one revoked.
+
+## Rotating integrator API keys (`API_KEYS`)
+
+API keys are provided via the `API_KEYS` environment variable as a
+comma-separated list.
 
 ```bash
 export API_KEYS="secret-key-1,secret-key-2"
 export REQUIRE_AUTH="true"
 ```
 
-## Rotating Keys
 To rotate an API key without downtime:
+
 1. Append the new key to the `API_KEYS` environment variable:
    `API_KEYS="old-key,new-key"`
 2. Restart the application servers or trigger a rolling deployment so the new key becomes active.
@@ -19,3 +29,103 @@ To rotate an API key without downtime:
 4. Once the client has completely switched to `new-key`, remove `old-key` from `API_KEYS`:
    `API_KEYS="new-key"`
 5. Perform another rolling deployment to revoke `old-key`.
+
+## Rotating the admin token (`ADMIN_AUTH_TOKEN`)
+
+`ADMIN_AUTH_TOKEN` gates `/api/v1/admin/*`, `/api/v1/system/*`, and (in
+production) `/metrics` and `/api/v1/replay/*`. It is a single-value token, so
+rotation is a swap rather than an append:
+
+1. Generate a new high-entropy token (at least 32 random bytes):
+   `openssl rand -base64 32`
+2. Update `ADMIN_AUTH_TOKEN` in the secret store for the environment (Render
+   dashboard env var, or `.env.prod` for Compose). Do **not** unset it — in
+   production the API refuses to boot without it, and admin endpoints deny
+   all requests while it is missing.
+3. Trigger a rolling deployment. Instances pick up the new token at boot.
+4. Update operator tooling (dashboards, scripts, on-call runbook secrets) to
+   send the new token via `x-admin-token` or `Authorization: Bearer`.
+5. Verify: a request with the old token must now receive `401 Unauthorized`,
+   and a request with the new token must succeed. Check the admin audit log
+   for any use of the old token after the rotation point.
+
+Because admin mutations are audited (see `crates/api/src/admin_audit.rs`),
+rotate immediately and review the audit log if the token may have leaked.
+
+## Rotating webhook signing secrets
+
+Outbound quote-expiration webhooks are signed with HMAC-SHA256 using a
+**per-consumer** `signing_secret` stored in Postgres
+(`consumer_quote_expiration_webhooks`), managed via
+`POST /api/v1/integrator/webhooks/quote-expiration`. To rotate one consumer's
+secret:
+
+1. Generate a new signing secret: `openssl rand -hex 32`
+2. Coordinate with the consumer: they configure their receiver to accept
+   signatures from **both** the old and the new secret during the cutover.
+3. Upsert the registration with the new secret (same `consumer_id` and
+   `webhook_url`):
+
+   ```bash
+   curl -X POST "$API_URL/api/v1/integrator/webhooks/quote-expiration" \
+     -H "x-api-key: $INTEGRATOR_KEY" \
+     -H "content-type: application/json" \
+     -d '{"consumer_id":"acme","webhook_url":"https://consumer.example/hook","signing_secret":"<new-secret>","enabled":true}'
+   ```
+
+4. Deliveries are signed with the new secret from the next dispatch onward
+   (`x-stellarroute-signature` header). The consumer verifies a live delivery
+   against the new secret, then drops the old secret from their receiver.
+5. If the old secret leaked, disable the registration (`"enabled": false`)
+   first, rotate, then re-enable.
+
+Inbound alert webhooks (`LIQUIDITY_THINNESS_ALERT_WEBHOOK_URL`,
+`TTL_ALERT_WEBHOOK_URL`) embed their credential in the URL. Rotate by issuing
+a new webhook URL at the receiving service (Slack/PagerDuty/etc.), updating
+the env var, redeploying, and revoking the old URL.
+
+## Rotating Horizon / Soroban RPC credentials
+
+`STELLAR_HORIZON_URL` and `SOROBAN_RPC_URL` may point at keyed or paid
+provider endpoints where the access key is part of the URL or an associated
+header. To rotate:
+
+1. Issue a new key/endpoint at the provider while the old one is still valid.
+2. Update the env var(s) in the secret store (Render dashboard / `.env.prod`).
+3. Restart the indexer first, then the API, one instance at a time.
+4. Confirm `GET /health/deps` stays healthy and the indexer resumes ingesting
+   (offer/pool timestamps keep advancing).
+5. Revoke the old provider key.
+
+The public Stellar endpoints carry no credential; this section applies as
+soon as a rate-limited or paid provider is used in production.
+
+## Rotating deployer keys
+
+The Soroban deployer secret keys live only in GitHub Actions repository
+secrets (`SOROBAN_DEPLOYER_SECRET` for testnet,
+`SOROBAN_MAINNET_DEPLOYER_SECRET` for mainnet — never shared between
+networks). To rotate:
+
+1. Generate a new identity: `soroban keys generate deployer-new --network <net>`
+2. Fund the new account (Friendbot on testnet; XLM transfer on mainnet).
+3. If the current deployer is the router admin, transfer contract admin to
+   the new account (`set_admin()` / governance proposal) **before** retiring
+   the old key.
+4. Replace the GitHub repository secret with the new secret key.
+5. Run the deploy workflow in dry-run mode to confirm the new identity works.
+6. Move remaining funds off the old account and retire it.
+
+## Rotation schedule
+
+| Secret | Cadence | Also rotate when |
+|---|---|---|
+| `API_KEYS` entries | 90 days | An integrator off-boards or a key leaks |
+| `ADMIN_AUTH_TOKEN` | 90 days | An operator off-boards; any suspected leak |
+| Webhook signing secrets | 180 days | Consumer requests it; any suspected leak |
+| Horizon / RPC provider keys | Provider default | Provider incident; any suspected leak |
+| Deployer keys | Yearly | Any suspected compromise (rotate immediately) |
+| Postgres / Redis credentials | 180 days | Any suspected leak |
+
+Rotations are tracked as recurring GitHub issues labelled `security` so the
+schedule is auditable.


### PR DESCRIPTION
## Summary

- Adds `docs/deployment/secrets-management.md`: the authoritative inventory of every production secret (Horizon/Soroban RPC endpoints, `ADMIN_AUTH_TOKEN`, `API_KEYS`, webhook signing secrets, deployer keys, datastore credentials), the secret store for each environment (Render dashboard, GitHub Actions secrets, `.env.prod`, Postgres for per-consumer webhook secrets), the CI secrets policy (platform secrets only, OIDC preferred for cloud federation, never committed files), and a leaked-secret response procedure.
- Expands `docs/key_rotation.md` with zero-downtime rotation procedures for the admin token (`ADMIN_AUTH_TOKEN`), per-consumer webhook signing secrets (HMAC, via `POST /api/v1/integrator/webhooks/quote-expiration`), Horizon/Soroban RPC provider keys, and deployer keys, plus a rotation schedule.
- Links both documents from the Key Management section of `docs/deployment/README.md`.

## Acceptance criteria

- [x] Document secret store (platform vault/env) for all prod secrets
- [x] Rotation steps for admin API keys and webhook secrets
- [x] CI uses OIDC/secrets, never committed files

## Verify

```bash
rg -n 'rotat|secret' docs/key_rotation.md docs/deployment
```

Closes #989