### PR TITLE
Wire quote refresh animation and screen reader announcements

### DIFF
--- a/frontend/components/swap/SwapCard.test.tsx
+++ b/frontend/components/swap/SwapCard.test.tsx
@@ -360,6 +360,20 @@ describe('SwapCard network resilience and states', () => {
     });
   });
 
+  it('announces quote refreshes via the polite live region (#673)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<SwapCard />);
+
+    await connectWalletAndWaitForBalance(user);
+
+    const payInput = screen.getByLabelText(/you pay/i);
+    fireEvent.change(payInput, { target: { value: '10' } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/quote updated/i)).toBeInTheDocument();
+    });
+  });
+
   it('shows high price impact warning for large amounts', async () => {
     configureQuoteRefresh({ total: '50', priceImpact: '15.0' });
 

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -17,6 +17,7 @@ import { SettingsPanel } from '../settings/SettingsPanel';
 import { HighImpactConfirmModal } from './HighImpactConfirmModal';
 import { TransactionConfirmationModal } from './TransactionConfirmationModal';
 import { QuoteStreamStatusIndicator } from './QuoteStreamStatusIndicator';
+import { QuoteRefreshLiveRegion } from './QuoteRefreshLiveRegion';
 import { SessionRecoveryModal } from './SessionRecoveryModal';
 import { useSwapState } from '@/hooks/useSwapState';
 import { useOptimisticSwap } from '@/hooks/useOptimisticSwap';
@@ -37,6 +38,8 @@ import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import type { QuoteRequestItem } from '@/lib/api/client';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useQuoteStreamStatus } from '@/hooks/useQuoteStreamStatus';
+import { useQuoteRefreshAnnouncements } from '@/hooks/useQuoteRefreshAnnouncements';
+import { useQuoteRefreshTransition } from '@/hooks/useQuoteRefreshTransition';
 import { useCompactMode } from '@/hooks/useCompactMode';
 import { useShareableQuote } from '@/hooks/useShareableQuote';
 import { ShareQuoteButton } from './ShareQuoteButton';
@@ -724,6 +727,24 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
   const displayToAmount = storyPresentation?.toAmount ?? toAmount;
   const displayFormattedRate =
     storyPresentation?.formattedRate ?? formattedRate;
+
+  // Animated quote refresh feedback: pulse the receive amount when it
+  // changes, and announce the outcome for screen reader users.
+  const receiveAmount = selectedRoute?.expectedAmount ?? displayToAmount;
+  const { isRefreshing: isReceiveAmountRefreshing, transitionStyle: receiveAmountTransitionStyle } =
+    useQuoteRefreshTransition(receiveAmount);
+  const { politeMessage: quoteRefreshPoliteMessage, assertiveMessage: quoteRefreshAssertiveMessage } =
+    useQuoteRefreshAnnouncements({
+      canAnnounce: parseFloat(fromAmount) > 0,
+      loading: quote.loading,
+      error: quote.error,
+      isRecovering: quote.isRecovering,
+      hasPendingRetry: quote.hasPendingRetry,
+      lastQuotedAtMs: quote.lastQuotedAtMs,
+      requestKey: `${fromToken}:${toToken}:${fromAmount}`,
+      rateSummary: displayFormattedRate,
+      t,
+    });
   const displayIsModalOpen = storyPresentation?.confirmModalOpen ?? isModalOpen;
   const displayOptimisticStatus =
     storyPresentation?.optimisticStatus ?? optimistic.status;
@@ -1223,15 +1244,19 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
           {/* Receive Section */}
           <div className={cn('space-y-2', isCompact && 'space-y-1')}>
             <div
+              data-testid="receive-section"
+              aria-live="off"
               className={cn(
-                'bg-muted/30 rounded-2xl border border-border/20',
-                isCompact ? 'p-3 rounded-xl' : 'p-4'
+                'rounded-2xl border border-border/20',
+                isCompact ? 'p-3 rounded-xl' : 'p-4',
+                isReceiveAmountRefreshing ? 'bg-primary/5' : 'bg-muted/30'
               )}
+              style={receiveAmountTransitionStyle}
             >
               <div className="flex justify-between items-start mb-1">
                 <AmountInput
                   label={t('swap.pair.youReceive')}
-                  value={selectedRoute?.expectedAmount ?? displayToAmount}
+                  value={receiveAmount}
                   readOnly
                   placeholder="0.00"
                   className="flex-1"
@@ -1245,6 +1270,11 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
               </div>
             </div>
           </div>
+
+          <QuoteRefreshLiveRegion
+            politeMessage={quoteRefreshPoliteMessage}
+            assertiveMessage={quoteRefreshAssertiveMessage}
+          />
 
           {/* Info Panels (Conditional) */}
           {(parseFloat(fromAmount) > 0 ||


### PR DESCRIPTION
## Summary

`.kiro/specs/quote-stream-status/design.md` describes refresh feedback for the swap quote, but users currently have no signal when an auto-refreshed quote updates.

Investigation showed the supporting pieces already existed with full test coverage but were never wired into `SwapCard`:

- `useQuoteRefreshTransition` (motion-safe transition hook, already used by `QuoteSummary`)
- `useQuoteRefreshAnnouncements` + `QuoteRefreshLiveRegion` (aria-live announcer, covered by existing unit tests and `docs/QUOTE_REFRESH_SCREEN_READER_TESTING.md`)

## Changes

- `SwapCard` now pulses the "you receive" amount box (`bg-primary/5` flash) whenever the displayed quote value changes, using the existing `useQuoteRefreshTransition` hook.
- Because that hook zeroes the transition duration under `prefers-reduced-motion`, the pulse degrades to an instant, static update automatically — no separate reduced-motion branch needed.
- `QuoteRefreshLiveRegion` is now rendered in `SwapCard`, driven by `useQuoteRefreshAnnouncements`, so screen readers get a polite "Quote updated" (with the new rate) on success and an assertive failure announcement on hard errors, deduped per request.
- Added an integration test in `SwapCard.test.tsx` asserting the polite announcement appears after a quote is fetched.

## Acceptance criteria

- [x] Pulse or fade on quote value change
- [x] Static update when reduced-motion preferred
- [x] Screen reader announces refresh via live region

## Test plan

- `npx vitest run components/swap/SwapCard.test.tsx` — 20/20 passing, including the new announcement test
- `npx vitest run` — full suite, 1084 passing / 5 pre-existing skips
- `npx tsc --noEmit` — no new type errors

closes #673