### PR TITLE
Unify SwapButton loading, disabled and tooltip visual language

### DIFF
--- a/frontend/components/swap/SwapButton.stories.tsx
+++ b/frontend/components/swap/SwapButton.stories.tsx
@@ -1,0 +1,111 @@
+import type { Story } from '@ladle/react';
+import '@/app/globals.css';
+import { SwapButton, type SwapButtonState } from './SwapButton';
+
+function Frame({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="dark min-h-screen bg-background text-foreground p-8">
+      <div className="max-w-sm mx-auto">{children}</div>
+    </div>
+  );
+}
+
+const states: Array<[SwapButtonState, string]> = [
+  ['no_wallet', 'No Wallet'],
+  ['no_amount', 'No Amount'],
+  ['insufficient_balance', 'Insufficient Balance'],
+  ['high_price_impact', 'High Price Impact'],
+  ['high_impact_warning', 'High Impact Warning'],
+  ['slippage_ack_required', 'Slippage Ack Required'],
+  ['refreshing_quote', 'Refreshing Quote'],
+  ['ready', 'Ready'],
+  ['executing', 'Executing'],
+  ['error', 'Error'],
+  ['permission_blocked', 'Permission Blocked'],
+];
+
+export const NoWallet: Story = () => (
+  <Frame>
+    <SwapButton state="no_wallet" onSwap={() => {}} onConnectWallet={() => {}} />
+  </Frame>
+);
+
+export const NoAmount: Story = () => (
+  <Frame>
+    <SwapButton state="no_amount" onSwap={() => {}} />
+  </Frame>
+);
+
+export const InsufficientBalance: Story = () => (
+  <Frame>
+    <SwapButton state="insufficient_balance" onSwap={() => {}} />
+  </Frame>
+);
+
+export const HighPriceImpact: Story = () => (
+  <Frame>
+    <SwapButton state="high_price_impact" onSwap={() => {}} />
+  </Frame>
+);
+
+export const HighImpactWarning: Story = () => (
+  <Frame>
+    <SwapButton state="high_impact_warning" onSwap={() => {}} />
+  </Frame>
+);
+
+export const SlippageAckRequired: Story = () => (
+  <Frame>
+    <SwapButton state="slippage_ack_required" onSwap={() => {}} />
+  </Frame>
+);
+
+export const RefreshingQuote: Story = () => (
+  <Frame>
+    <SwapButton state="refreshing_quote" onSwap={() => {}} />
+  </Frame>
+);
+
+export const Ready: Story = () => (
+  <Frame>
+    <SwapButton state="ready" onSwap={() => {}} />
+  </Frame>
+);
+
+export const Executing: Story = () => (
+  <Frame>
+    <SwapButton state="executing" onSwap={() => {}} />
+  </Frame>
+);
+
+export const ErrorState: Story = () => (
+  <Frame>
+    <SwapButton state="error" onSwap={() => {}} />
+  </Frame>
+);
+
+export const PermissionBlocked: Story = () => (
+  <Frame>
+    <SwapButton state="permission_blocked" onSwap={() => {}} />
+  </Frame>
+);
+
+/** Full state matrix at a glance, with disabled states showing their tooltip reason on hover. */
+export const StateMatrix: Story = () => (
+  <div className="dark min-h-screen bg-background text-foreground p-8">
+    <div className="grid gap-6 max-w-sm mx-auto">
+      {states.map(([state, label]) => (
+        <section key={state} className="space-y-2">
+          <h3 className="text-sm font-semibold text-muted-foreground uppercase tracking-wider">
+            {label}
+          </h3>
+          <SwapButton
+            state={state}
+            onSwap={() => {}}
+            onConnectWallet={() => {}}
+          />
+        </section>
+      ))}
+    </div>
+  </div>
+);

--- a/frontend/components/swap/SwapButton.test.tsx
+++ b/frontend/components/swap/SwapButton.test.tsx
@@ -1,5 +1,5 @@
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { SwapButton } from "./SwapButton";
 
@@ -7,15 +7,32 @@ describe("SwapButton", () => {
   afterEach(() => cleanup());
 
   it("gates submission while high slippage is unacknowledged", () => {
-    render(
-      <SwapButton
-        state="slippage_ack_required"
-        onSwap={() => {}}
-      />,
-    );
+    const onSwap = vi.fn();
+    render(<SwapButton state="slippage_ack_required" onSwap={onSwap} />);
 
-    expect(
-      screen.getByRole("button", { name: /acknowledge slippage/i }),
-    ).toBeDisabled();
+    const button = screen.getByRole("button", { name: /acknowledge slippage/i });
+    expect(button).toBeDisabled();
+    expect(button).toHaveAttribute("aria-disabled", "true");
+
+    fireEvent.click(button);
+    expect(onSwap).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the disabled reason via a tooltip for blocked states", () => {
+    render(<SwapButton state="insufficient_balance" onSwap={() => {}} />);
+
+    const button = screen.getByRole("button", { name: /insufficient/i });
+    expect(button).toHaveAttribute("aria-disabled", "true");
+  });
+
+  it("allows submission when ready", () => {
+    const onSwap = vi.fn();
+    render(<SwapButton state="ready" onSwap={onSwap} />);
+
+    const button = screen.getByRole("button", { name: /review swap/i });
+    expect(button).toHaveAttribute("aria-disabled", "false");
+
+    fireEvent.click(button);
+    expect(onSwap).toHaveBeenCalledTimes(1);
   });
 });

--- a/frontend/components/swap/SwapButton.tsx
+++ b/frontend/components/swap/SwapButton.tsx
@@ -1,12 +1,19 @@
 'use client';
 
+import { AlertCircle, Wallet, ShieldOff } from "lucide-react";
 import { Button } from "@/components/ui/button";
-import { Loader2, AlertCircle, Wallet, ShieldOff } from "lucide-react";
+import { Spinner } from "@/components/ui/spinner";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
 import { cn } from "@/lib/utils";
 import { useSwapI18n } from "@/lib/swap-i18n";
 import { useReducedMotion } from "@/hooks/useReducedMotion";
 
-export type SwapButtonState = 
+export type SwapButtonState =
   | "no_wallet"
   | "no_amount"
   | "insufficient_balance"
@@ -36,7 +43,7 @@ export function SwapButton({
 }: SwapButtonProps) {
   const { t } = useSwapI18n();
   const prefersReducedMotion = useReducedMotion();
-  
+
   const getButtonProps = () => {
     switch (state) {
       case "no_wallet":
@@ -52,6 +59,7 @@ export function SwapButton({
         return {
           label: t("swap.cta.enterAmount"),
           disabled: true,
+          disabledReason: "Enter an amount to see available routes.",
           variant: "secondary" as const,
           className: "bg-muted/50 text-muted-foreground",
         };
@@ -59,13 +67,16 @@ export function SwapButton({
         return {
           label: t("swap.cta.insufficientBalance"),
           disabled: true,
+          disabledReason: "Your wallet balance is too low to complete this swap.",
           variant: "destructive" as const,
+          icon: <AlertCircle className="mr-2 h-5 w-5" />,
           className: "bg-destructive/10 text-destructive border-destructive/20 border",
         };
       case "high_price_impact":
         return {
           label: t("swap.simulation.highImpactTitle"),
           disabled: true,
+          disabledReason: "This trade's price impact is too high to execute safely.",
           variant: "destructive" as const,
           icon: <AlertCircle className="mr-2 h-5 w-5" />,
           className: "bg-destructive shadow-destructive/20",
@@ -75,8 +86,9 @@ export function SwapButton({
           label: t("swap.cta.swapAnyway"),
           onClick: onSwap,
           disabled: isLoading,
+          disabledReason: isLoading ? "Transaction is being submitted to the network." : undefined,
           variant: "destructive" as const,
-          icon: isLoading ? <Loader2 className={cn("mr-2 h-5 w-5", !prefersReducedMotion && "animate-spin")} /> : <AlertCircle className="mr-2 h-5 w-5" />,
+          icon: isLoading ? <Spinner className="mr-2" label={t("swap.cta.swapping")} /> : <AlertCircle className="mr-2 h-5 w-5" />,
           className: cn(
             "bg-destructive hover:bg-destructive/90 shadow-lg shadow-destructive/20",
             !prefersReducedMotion && "animate-pulse"
@@ -86,6 +98,7 @@ export function SwapButton({
         return {
           label: "Acknowledge Slippage",
           disabled: true,
+          disabledReason: "Acknowledge the slippage warning before continuing.",
           variant: "destructive" as const,
           icon: <AlertCircle className="mr-2 h-5 w-5" />,
           className: "bg-destructive/10 text-destructive border-destructive/20 border",
@@ -94,28 +107,33 @@ export function SwapButton({
         return {
           label: t("swap.cta.swapping"),
           disabled: true,
+          disabledReason: "Transaction is being submitted to the network.",
           variant: "default" as const,
-          icon: <Loader2 className={cn("mr-2 h-5 w-5", !prefersReducedMotion && "animate-spin")} />,
+          icon: <Spinner className="mr-2" label={t("swap.cta.swapping")} />,
         };
       case "refreshing_quote":
         return {
           label: t("swap.cta.loadingQuote"),
           disabled: true,
+          disabledReason: "Waiting for a fresh quote before you can swap.",
           variant: "outline" as const,
-          icon: <Loader2 className={cn("mr-2 h-5 w-5", !prefersReducedMotion && "animate-spin")} />,
+          icon: <Spinner className="mr-2" label={t("swap.cta.loadingQuote")} />,
           className: "border-primary/40 text-primary",
         };
       case "error":
         return {
           label: t("swap.cta.errorFetchingQuote"),
           disabled: true,
+          disabledReason: "Unable to fetch a quote. Try again shortly.",
           variant: "outline" as const,
+          icon: <AlertCircle className="mr-2 h-5 w-5" />,
           className: "border-destructive/50 text-destructive",
         };
       case "permission_blocked":
         return {
           label: "Wallet permissions required",
           disabled: true,
+          disabledReason: "Your wallet has not granted the required permissions.",
           variant: "destructive" as const,
           icon: <ShieldOff className="mr-2 h-5 w-5" />,
           className: "bg-destructive/10 text-destructive border border-destructive/20",
@@ -126,8 +144,9 @@ export function SwapButton({
           label: t("swap.cta.reviewSwap"),
           onClick: onSwap,
           disabled: isLoading,
+          disabledReason: isLoading ? "Transaction is being submitted to the network." : undefined,
           variant: "default" as const,
-          icon: isLoading ? <Loader2 className={cn("mr-2 h-5 w-5", !prefersReducedMotion && "animate-spin")} /> : null,
+          icon: isLoading ? <Spinner className="mr-2" label={t("swap.cta.swapping")} /> : null,
           className: cn(
             "bg-primary hover:bg-primary/90 shadow-lg shadow-primary/20 hover:shadow-primary/30",
             !prefersReducedMotion && "active:scale-[0.98] transition-all"
@@ -138,12 +157,13 @@ export function SwapButton({
 
   const props = getButtonProps();
 
-  return (
+  const button = (
     <Button
       size="lg"
       variant={props.variant}
       disabled={props.disabled}
-      onClick={props.onClick}
+      aria-disabled={props.disabled}
+      onClick={props.disabled ? undefined : props.onClick}
       className={cn(
         "h-14 w-full text-lg font-bold rounded-2xl shadow-md",
         !prefersReducedMotion && "transition-all duration-300",
@@ -154,5 +174,20 @@ export function SwapButton({
       {props.icon}
       {props.label}
     </Button>
+  );
+
+  if (!props.disabled || !props.disabledReason) {
+    return button;
+  }
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{button}</TooltipTrigger>
+        <TooltipContent className="max-w-[240px] text-xs leading-relaxed">
+          {props.disabledReason}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
   );
 }

--- a/frontend/components/ui/spinner.tsx
+++ b/frontend/components/ui/spinner.tsx
@@ -1,0 +1,27 @@
+import { Loader2 } from "lucide-react";
+
+import { cn } from "@/lib/utils";
+import { useReducedMotion } from "@/hooks/useReducedMotion";
+
+interface SpinnerProps {
+  className?: string;
+  /** Accessible label announced by screen readers. Defaults to "Loading". */
+  label?: string;
+}
+
+/**
+ * Shared loading indicator. Spins unless the user prefers reduced motion,
+ * in which case it renders statically to avoid triggering vestibular
+ * discomfort while still communicating a busy state visually and via ARIA.
+ */
+export function Spinner({ className, label = "Loading" }: SpinnerProps) {
+  const prefersReducedMotion = useReducedMotion();
+
+  return (
+    <Loader2
+      role="status"
+      aria-label={label}
+      className={cn("h-5 w-5", !prefersReducedMotion && "animate-spin", className)}
+    />
+  );
+}


### PR DESCRIPTION
## Summary

`SwapButton` states (connecting, quoting, confirming, insufficient balance, etc) each hand-rolled their own loading icon and disabled styling, and gave the user no explanation for why an action was unavailable.

## Changes

- Extracted a shared `Spinner` component (`frontend/components/ui/spinner.tsx`) that every loading state now uses, instead of four separate inline `Loader2` + `animate-spin` blocks. Reduced-motion handling now lives in one place.
- Disabled states set both the native `disabled` attribute and `aria-disabled`, and are wrapped in a `Tooltip` (reusing the existing shadcn/Radix tooltip primitive) that surfaces the specific reason the action is unavailable, e.g. "Your wallet balance is too low to complete this swap."
- Added `SwapButton.stories.tsx` (Ladle, this repo's Storybook equivalent) covering every `SwapButtonState`, plus a state matrix story for visual review.
- Expanded `SwapButton.test.tsx` to cover the aria-disabled/click-guard behavior and the ready/submit path, not just the single slippage-ack case it previously had.

## Acceptance criteria

- [x] Shared loading spinner component
- [x] Disabled reasons reflected in aria-disabled + tooltip
- [x] Storybook stories for all states

## Test plan

- `npx vitest run components/swap/SwapButton.test.tsx` — 3/3 passing
- `npx vitest run components/swap` — 30 files / 213 tests passing (no regressions in consumers of SwapButton, e.g. SwapCard)
- `npx tsc --noEmit` — no new type errors
- `npx eslint components/swap/SwapButton.tsx components/swap/SwapButton.stories.tsx components/ui/spinner.tsx` — no errors

closes #675