### PR TITLE
fix(cctp): restore green CI and expose execution UI

### DIFF
--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -16,7 +16,7 @@ WORKDIR /app
 
 # Copy the full workspace needed to compile stellarroute-api and its path deps.
 # .dockerignore excludes .env, target/, frontend/, secrets, etc.
-COPY Cargo.toml ./
+COPY Cargo.toml Cargo.lock ./
 COPY crates ./crates
 
 RUN cargo build -p stellarroute-api --release --bin stellarroute-api \

--- a/crates/api/src/broadcast/mod.rs
+++ b/crates/api/src/broadcast/mod.rs
@@ -95,11 +95,11 @@ pub fn map_horizon_result_codes(
             "tx_failed" => {
                 // Inspect ops below.
             }
+            "tx_too_late" | "tx_insufficient_balance" => {
+                return Some(BroadcastError::Permanent(code.to_string()));
+            }
             other if other.starts_with("tx_") => {
                 // Unknown tx_* codes are permanent unless clearly retryable.
-                if other == "tx_too_late" || other == "tx_insufficient_balance" {
-                    return Some(BroadcastError::Permanent(other.to_string()));
-                }
             }
             _ => {}
         }

--- a/crates/api/src/cctp/expectations.rs
+++ b/crates/api/src/cctp/expectations.rs
@@ -7,8 +7,8 @@
 use thiserror::Error;
 
 use crate::cctp::config::{
-    CctpConfig, FINALITY_STANDARD, SEPOLIA_DOMAIN, SEPOLIA_TOKEN_MESSENGER, SEPOLIA_USDC, STELLAR_CCTP_FORWARDER, STELLAR_MESSAGE_TRANSMITTER,
-    STELLAR_TESTNET_DOMAIN,
+    CctpConfig, FINALITY_STANDARD, SEPOLIA_DOMAIN, SEPOLIA_TOKEN_MESSENGER, SEPOLIA_USDC,
+    STELLAR_CCTP_FORWARDER, STELLAR_MESSAGE_TRANSMITTER, STELLAR_TESTNET_DOMAIN,
 };
 use crate::cctp::encoding::{
     build_forwarder_hook_data_recipient, decimal_to_cctp_subunits, evm_address_to_bytes32,

--- a/crates/api/src/cctp/prepare_lock.rs
+++ b/crates/api/src/cctp/prepare_lock.rs
@@ -84,6 +84,28 @@ fn validate_reservation(reservation: &CctpActivePrepare) -> Result<(), CctpPrepa
     Ok(())
 }
 
+fn is_pg_unique_violation(err: &sqlx::Error) -> bool {
+    matches!(
+        err,
+        sqlx::Error::Database(db_err) if db_err.code().as_deref() == Some("23505")
+    )
+}
+
+fn map_active_row_conflict(
+    active: CctpActivePrepare,
+    reservation: &CctpActivePrepare,
+) -> Result<PrepareAcquireResult, CctpPrepareLockError> {
+    if active.transfer_id == reservation.transfer_id {
+        if active.payload_hash == reservation.payload_hash {
+            return Ok(PrepareAcquireResult::Idempotent(active));
+        }
+        return Err(CctpPrepareLockError::PayloadHashMismatch);
+    }
+    Ok(PrepareAcquireResult::ConflictOtherTransfer {
+        holder_transfer_id: active.transfer_id,
+    })
+}
+
 #[async_trait]
 pub trait CctpPrepareLockStore: Send + Sync {
     async fn expire_stale_for_source(
@@ -305,28 +327,14 @@ impl CctpPrepareLockStore for PgCctpPrepareLockStore {
 
         if let Some(row) = existing {
             let active = Self::map_row(row.0, row.1, row.2, row.3, row.4, row.5, row.6);
-            if active.transfer_id == reservation.transfer_id {
-                if active.payload_hash == reservation.payload_hash {
-                    tx.commit()
-                        .await
-                        .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
-                    return Ok(PrepareAcquireResult::Idempotent(active));
-                }
-                tx.rollback()
-                    .await
-                    .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
-                return Err(CctpPrepareLockError::PayloadHashMismatch);
-            }
             tx.rollback()
                 .await
                 .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
-            return Ok(PrepareAcquireResult::ConflictOtherTransfer {
-                holder_transfer_id: active.transfer_id,
-            });
+            return map_active_row_conflict(active, reservation);
         }
 
         let now = Utc::now();
-        sqlx::query(
+        let insert_result = sqlx::query(
             r#"
             INSERT INTO cctp_active_prepares (
                 source_account, transfer_id, prepare_kind, payload_hash,
@@ -342,13 +350,63 @@ impl CctpPrepareLockStore for PgCctpPrepareLockStore {
         .bind(reservation.expires_at)
         .bind(now)
         .execute(&mut *tx)
-        .await
-        .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+        .await;
 
-        tx.commit()
-            .await
-            .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
-        Ok(PrepareAcquireResult::Acquired)
+        match insert_result {
+            Ok(_) => {
+                tx.commit()
+                    .await
+                    .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                Ok(PrepareAcquireResult::Acquired)
+            }
+            Err(e) if is_pg_unique_violation(&e) => {
+                let row = sqlx::query_as::<
+                    _,
+                    (
+                        String,
+                        Uuid,
+                        String,
+                        String,
+                        Option<String>,
+                        DateTime<Utc>,
+                        DateTime<Utc>,
+                    ),
+                >(
+                    r#"
+                    SELECT source_account, transfer_id, prepare_kind, payload_hash,
+                           prepared_payload, expires_at, updated_at
+                    FROM cctp_active_prepares
+                    WHERE source_account = $1 AND expires_at > NOW()
+                    FOR UPDATE
+                    "#,
+                )
+                .bind(&reservation.source_account)
+                .fetch_optional(&mut *tx)
+                .await
+                .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+
+                if let Some(row) = row {
+                    let active = Self::map_row(row.0, row.1, row.2, row.3, row.4, row.5, row.6);
+                    tx.rollback()
+                        .await
+                        .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                    map_active_row_conflict(active, reservation)
+                } else {
+                    tx.rollback()
+                        .await
+                        .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                    Err(CctpPrepareLockError::Database(
+                        "unique violation without active row".into(),
+                    ))
+                }
+            }
+            Err(e) => {
+                tx.rollback()
+                    .await
+                    .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                Err(CctpPrepareLockError::Database(e.to_string()))
+            }
+        }
     }
 
     async fn release(

--- a/crates/api/src/cctp/readiness.rs
+++ b/crates/api/src/cctp/readiness.rs
@@ -228,8 +228,7 @@ impl CctpRuntime {
         }
 
         let evm_sender = "0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0";
-        let stellar_recipient =
-            "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        let stellar_recipient = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
 
         Self {
             stellar_mint_builder: Arc::new(HarnessStellarMintBuilder(payload_hash.clone())),

--- a/crates/api/src/cctp/stellar_burn_verifier.rs
+++ b/crates/api/src/cctp/stellar_burn_verifier.rs
@@ -342,18 +342,30 @@ mod live_diag {
         let probe = probe_stellar_contracts(&cfg).await;
         eprintln!("probe={probe:?} all_ok={}", probe.all_ok());
         let rpc = StellarRpcClient::new(&cfg).expect("rpc");
-        eprintln!("rpc_ready={} latest={:?}", rpc.is_ready(), rpc.latest_ledger().await);
+        eprintln!(
+            "rpc_ready={} latest={:?}",
+            rpc.is_ready(),
+            rpc.latest_ledger().await
+        );
         let mut v = StellarRpcBurnVerifier::new(&cfg).await.expect("verifier");
-        eprintln!("constructed probe_ok={} is_ready={}", v.probe_ok, v.is_ready());
+        eprintln!(
+            "constructed probe_ok={} is_ready={}",
+            v.probe_ok,
+            v.is_ready()
+        );
         // Bypass probe for diagnosis
         v.probe_ok = true;
-        let hash = std::env::var("CCTP_DIAG_BURN_HASH")
-            .unwrap_or_else(|_| "951714911af3ea05180704e365dbb6e98b93dbcd56a72dffdd9920fa0af5abde".into());
+        let hash = std::env::var("CCTP_DIAG_BURN_HASH").unwrap_or_else(|_| {
+            "951714911af3ea05180704e365dbb6e98b93dbcd56a72dffdd9920fa0af5abde".into()
+        });
         match v.verify_burn(&hash).await {
             Ok(facts) => {
                 eprintln!(
                     "OK amount={} sender={} domains={}->{} recipient={:?}",
-                    facts.amount_cctp_subunits, facts.sender, facts.source_domain, facts.destination_domain,
+                    facts.amount_cctp_subunits,
+                    facts.sender,
+                    facts.source_domain,
+                    facts.destination_domain,
                     hex::encode(facts.mint_recipient_bytes32)
                 );
             }

--- a/crates/api/src/cctp/stellar_mint_verifier.rs
+++ b/crates/api/src/cctp/stellar_mint_verifier.rs
@@ -343,7 +343,7 @@ impl StellarMintVerifier for StellarRpcMintVerifier {
             message,
             nonce,
             recipient,
-            amount_cctp as u128,
+            amount_cctp,
             quoted_finality,
         )
         .await

--- a/crates/api/src/liquidity_alerts.rs
+++ b/crates/api/src/liquidity_alerts.rs
@@ -160,13 +160,7 @@ impl LiquidityThinnessAlerts {
         thresholds: HashMap<String, PairThinnessThreshold>,
         webhook_url: Option<String>,
     ) -> Self {
-        let webhook_url = webhook_url.and_then(|url| {
-            if reqwest::Url::parse(&url).is_ok() {
-                Some(url)
-            } else {
-                None
-            }
-        });
+        let webhook_url = webhook_url.filter(|url| reqwest::Url::parse(url).is_ok());
         Self {
             thresholds: thresholds
                 .into_iter()

--- a/crates/api/tests/cctp_live_iris_attestation.rs
+++ b/crates/api/tests/cctp_live_iris_attestation.rs
@@ -84,12 +84,10 @@ async fn verify_known_stellar_burn_iris_payload() {
     let burn_hash = std::env::var("CCTP_DIAG_BURN_HASH").unwrap_or_else(|_| {
         "26514bc123354d8c2ff72f73ad56da48824b03e851c33b2772f2df0f13a96c3d".into()
     });
-    let recipient = std::env::var("CCTP_DIAG_EVM_RECIPIENT").unwrap_or_else(|_| {
-        "0xB94E6a26CA0b75cF98c0441c80072957dc9CC533".into()
-    });
-    let sender = std::env::var("CCTP_DIAG_STELLAR_SENDER").unwrap_or_else(|_| {
-        "GBH24C7D2IFM4RF7SDWPLREQYQ3CL32PCJJEATMYIPWBKB6PPGTNAAIX".into()
-    });
+    let recipient = std::env::var("CCTP_DIAG_EVM_RECIPIENT")
+        .unwrap_or_else(|_| "0xB94E6a26CA0b75cF98c0441c80072957dc9CC533".into());
+    let sender = std::env::var("CCTP_DIAG_STELLAR_SENDER")
+        .unwrap_or_else(|_| "GBH24C7D2IFM4RF7SDWPLREQYQ3CL32PCJJEATMYIPWBKB6PPGTNAAIX".into());
 
     let mut cfg = CctpConfig::default_testnet();
     cfg.enabled = true;

--- a/frontend/components/HeroSection.test.tsx
+++ b/frontend/components/HeroSection.test.tsx
@@ -55,6 +55,60 @@ describe('HeroSection — reduced-motion', () => {
     expect(screen.getByTestId('hero-gradient-1')).toBeInTheDocument();
     expect(screen.getByTestId('hero-gradient-2')).toBeInTheDocument();
   });
+
+  it('does not render motion classes when reduced motion is active', () => {
+    setReducedMotion(true);
+    const { container } = render(<HeroSection />);
+    expect(container.querySelectorAll('[class*="animate-"]')).toHaveLength(0);
+  });
+});
+
+describe('HeroSection — product positioning', () => {
+  afterEach(() => setReducedMotion(false));
+
+  it('positions StellarRoute as a non-custodial Stellar execution layer', () => {
+    render(<HeroSection />);
+    expect(
+      screen.getByRole('heading', {
+        level: 1,
+        name: /Stellar-native execution\. A proven route beyond it\./i,
+      })
+    ).toBeInTheDocument();
+    expect(screen.getByText(/Non-custodial execution layer/i)).toBeInTheDocument();
+    expect(
+      screen.getAllByText(/Stellar SDEX and Soroban AMMs/i)
+    ).not.toHaveLength(0);
+  });
+
+  it('links both primary calls to action directly to the swap deck', () => {
+    render(<HeroSection />);
+    const links = screen.getAllByRole('link', {
+      name: /Open execution deck/i,
+    });
+    expect(links).toHaveLength(2);
+    links.forEach((link) => expect(link).toHaveAttribute('href', '/swap'));
+  });
+
+  it('labels the live corridor as testnet and states its limits', () => {
+    render(<HeroSection />);
+    expect(screen.getAllByText('TESTNET CORRIDOR')).not.toHaveLength(0);
+    expect(screen.getAllByText(/Stellar → Ethereum Sepolia/i)).not.toHaveLength(0);
+    expect(
+      screen.getByText(/CCTP is disabled by default at the API layer/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(/does not claim mainnet availability/i)
+    ).toBeInTheDocument();
+  });
+
+  it('shows the signed-live testnet evidence metrics', () => {
+    render(<HeroSection />);
+    expect(screen.getByText('Signed-live / testnet evidence')).toBeInTheDocument();
+    expect(screen.getByText('Total saga')).toBeInTheDocument();
+    expect(screen.getByText('Burn → attestation')).toBeInTheDocument();
+    expect(screen.getByText('63')).toBeInTheDocument();
+    expect(screen.getByText('33')).toBeInTheDocument();
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/frontend/components/HeroSection.tsx
+++ b/frontend/components/HeroSection.tsx
@@ -1,111 +1,439 @@
 'use client';
 
-import { useMemo } from 'react';
 import { Button } from '@/components/ui/button';
-import { ArrowRight } from 'lucide-react';
+import {
+  Activity,
+  ArrowRight,
+  CheckCircle2,
+  CircleIcon,
+  Compass,
+  Layers,
+  Lock,
+  Route,
+  ShieldCheck,
+  Wallet,
+} from 'lucide-react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 import { useReducedMotion } from '@/hooks/useReducedMotion';
 
-export function HeroSection() {
-  const featuredPair = {
-    from: 'BTC:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS',
-    to: 'EXT:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS',
-    amount: '1',
-  };
+const routeSteps = [
+  {
+    label: 'Stellar wallet',
+    detail: 'You authorize',
+    icon: Wallet,
+  },
+  {
+    label: 'SDEX + Soroban',
+    detail: 'Best route selected',
+    icon: Layers,
+  },
+  {
+    label: 'Circle CCTP',
+    detail: 'Native USDC burn',
+    icon: Compass,
+  },
+  {
+    label: 'Sepolia',
+    detail: 'USDC minted',
+    icon: CircleIcon,
+  },
+];
 
+const capabilities = [
+  {
+    eyebrow: '01 / ROUTE',
+    title: 'Stellar liquidity routing',
+    description:
+      'Compare executable liquidity across the Stellar SDEX and Soroban AMMs from one route engine.',
+    icon: Route,
+  },
+  {
+    eyebrow: '02 / SIGN',
+    title: 'Non-custodial execution',
+    description:
+      'StellarRoute builds the path. Your connected wallet reviews and signs the execution.',
+    icon: Lock,
+  },
+  {
+    eyebrow: '03 / BRIDGE',
+    title: 'Cross-chain USDC',
+    description:
+      'A Circle CCTP corridor now carries native USDC from Stellar Testnet to Ethereum Sepolia.',
+    icon: Compass,
+  },
+];
+
+export function HeroSection() {
   const prefersReducedMotion = useReducedMotion();
 
-  const swapUrl = useMemo(
-    () =>
-      `/swap?from=${encodeURIComponent(featuredPair.from)}&to=${encodeURIComponent(featuredPair.to)}&amount=${featuredPair.amount}&ts=${Date.now()}`,
-    [featuredPair.from, featuredPair.to, featuredPair.amount]
-  );
+  const reveal = (delay = '') =>
+    !prefersReducedMotion &&
+    cn('animate-in fade-in slide-in-from-bottom-3 duration-700', delay);
 
   return (
-    <section className="relative min-h-[calc(100vh-8rem)] overflow-hidden">
-      {/* Chart atmosphere layers — keep testids for reduced-motion suite */}
+    <div className="relative isolate overflow-hidden">
+      {/* Chart atmosphere layers — keep testids for reduced-motion suite. */}
       <div className="absolute inset-0 -z-10">
         <div
           data-testid="hero-gradient-1"
           className={cn(
-            'absolute -left-10 top-16 h-[28rem] w-[28rem] rounded-[40%] bg-primary/15',
+            'absolute -left-40 top-20 h-[36rem] w-[36rem] rounded-full bg-primary/10 blur-3xl',
             !prefersReducedMotion && 'animate-pulse'
           )}
         />
         <div
           data-testid="hero-gradient-2"
           className={cn(
-            'absolute -right-16 bottom-10 h-[24rem] w-[24rem] rounded-[35%] bg-signal/15',
+            'absolute -right-48 top-[36rem] h-[32rem] w-[32rem] rounded-full bg-signal/10 blur-3xl',
             !prefersReducedMotion && 'animate-pulse delay-700'
           )}
         />
         <div
           className={cn(
-            'absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/50 to-transparent',
+            'absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary/60 to-transparent',
             !prefersReducedMotion && 'animate-in fade-in duration-700'
           )}
         />
       </div>
 
-      <div className="container mx-auto flex min-h-[calc(100vh-8rem)] flex-col justify-center px-4 py-16 sm:px-6 lg:px-8">
-        <div className="max-w-3xl space-y-8">
-          <p
-            className={cn(
-              'brand-wordmark text-5xl leading-none text-foreground sm:text-7xl lg:text-8xl',
-              !prefersReducedMotion && 'animate-in fade-in slide-in-from-bottom-3 duration-700'
-            )}
-          >
-            StellarRoute
-          </p>
+      <section
+        aria-labelledby="landing-title"
+        className="container mx-auto px-4 pb-24 pt-14 sm:px-6 sm:pb-32 sm:pt-20 lg:px-8 lg:pt-24"
+      >
+        <div className="grid items-start gap-16 lg:grid-cols-[minmax(0,1.03fr)_minmax(28rem,0.97fr)] lg:gap-12">
+          <div className="max-w-3xl">
+            <div
+              className={cn(
+                'mb-10 flex flex-wrap items-center gap-3',
+                reveal()
+              )}
+            >
+              <span className="inline-flex items-center gap-2 rounded-full border border-signal/60 bg-signal/10 px-3 py-1.5 font-mono text-[0.68rem] font-semibold tracking-[0.18em] text-foreground">
+                <span className="h-2 w-2 rounded-full bg-signal" aria-hidden="true" />
+                TESTNET CORRIDOR
+              </span>
+              <span className="font-mono text-[0.68rem] uppercase tracking-[0.16em] text-muted-foreground">
+                Stellar → Ethereum Sepolia
+              </span>
+            </div>
 
-          <h1
-            className={cn(
-              'max-w-xl text-xl font-medium tracking-tight text-foreground/90 sm:text-2xl',
-              !prefersReducedMotion && 'animate-in fade-in slide-in-from-bottom-3 duration-700 delay-150'
-            )}
-          >
-            Chart the best path across SDEX and Soroban AMMs.
-          </h1>
+            <p
+              className={cn(
+                'mb-5 font-mono text-xs font-medium uppercase tracking-[0.24em] text-primary',
+                reveal('delay-100')
+              )}
+            >
+              Non-custodial execution layer
+            </p>
+            <h1
+              id="landing-title"
+              className={cn(
+                'font-display max-w-3xl text-5xl font-semibold leading-[0.98] tracking-[-0.055em] text-foreground sm:text-6xl lg:text-[5rem]',
+                reveal('delay-150')
+              )}
+            >
+              Stellar-native execution.{' '}
+              <span className="text-muted-foreground">A proven route beyond it.</span>
+            </h1>
+            <p
+              className={cn(
+                'mt-7 max-w-2xl text-lg leading-relaxed text-muted-foreground sm:text-xl',
+                reveal('delay-300')
+              )}
+            >
+              Compare and execute across the Stellar SDEX and Soroban AMMs,
+              then move native USDC through Circle CCTP — without giving up
+              custody.
+            </p>
 
-          <p
-            className={cn(
-              'max-w-lg text-base text-muted-foreground sm:text-lg',
-              !prefersReducedMotion && 'animate-in fade-in slide-in-from-bottom-3 duration-700 delay-300'
-            )}
-          >
-            One route deck for Stellar liquidity — sharper fills, clearer
-            venue signal, less guesswork before you sign.
-          </p>
+            <div
+              className={cn(
+                'mt-9 flex flex-col gap-4 sm:flex-row sm:items-center',
+                reveal('delay-500')
+              )}
+            >
+              <Button
+                asChild
+                size="lg"
+                className="h-12 min-h-11 rounded-lg px-7 text-base font-semibold"
+              >
+                <Link href="/swap">
+                  Open execution deck
+                  <ArrowRight className="h-5 w-5" aria-hidden="true" />
+                </Link>
+              </Button>
+              <a
+                href="#live-proof"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-lg px-4 text-sm font-semibold text-foreground underline decoration-border underline-offset-8 hover:decoration-primary focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              >
+                Inspect signed-live proof
+              </a>
+            </div>
+
+            <div
+              className={cn(
+                'mt-10 flex items-start gap-3 border-l-2 border-signal/70 pl-4 text-sm leading-relaxed text-muted-foreground',
+                reveal('delay-500')
+              )}
+            >
+              <ShieldCheck
+                className="mt-0.5 h-4 w-4 shrink-0 text-signal"
+                aria-hidden="true"
+              />
+              <p>
+                <strong className="font-semibold text-foreground">
+                  Testnet proof, production gated.
+                </strong>{' '}
+                CCTP is disabled by default at the API layer until an operator
+                configures it.
+              </p>
+            </div>
+          </div>
 
           <div
             className={cn(
-              'flex flex-col gap-3 pt-2 sm:flex-row sm:items-center',
-              !prefersReducedMotion && 'animate-in fade-in slide-in-from-bottom-3 duration-700 delay-500'
+              'relative lg:mt-9',
+              reveal('delay-300')
             )}
           >
-            <Button
-              asChild
-              size="lg"
-              className="h-12 min-h-11 rounded-lg px-7 text-base font-semibold"
-            >
-              <Link href={swapUrl}>
-                Start with BTC → EXT
-                <ArrowRight className="ml-2 h-5 w-5" />
-              </Link>
-            </Button>
+            <div className="chart-panel relative overflow-hidden rounded-2xl p-5 sm:p-7">
+              <div
+                className="pointer-events-none absolute inset-0 opacity-40"
+                aria-hidden="true"
+                style={{
+                  backgroundImage:
+                    'linear-gradient(color-mix(in srgb, var(--border) 45%, transparent) 1px, transparent 1px), linear-gradient(90deg, color-mix(in srgb, var(--border) 45%, transparent) 1px, transparent 1px)',
+                  backgroundSize: '32px 32px',
+                  maskImage:
+                    'linear-gradient(to bottom, black, transparent 90%)',
+                }}
+              />
 
+              <div className="relative flex items-center justify-between border-b border-border/70 pb-5">
+                <div>
+                  <p className="font-mono text-[0.65rem] uppercase tracking-[0.2em] text-muted-foreground">
+                    Route constellation / 001
+                  </p>
+                  <p className="mt-1 font-display text-lg font-semibold text-foreground">
+                    USDC outbound rail
+                  </p>
+                </div>
+                <span className="rounded-md border border-signal/60 bg-signal/10 px-2 py-1 font-mono text-[0.6rem] font-semibold tracking-[0.16em] text-foreground">
+                  TESTNET
+                </span>
+              </div>
+
+              <div
+                role="img"
+                aria-label="Testnet execution route from a Stellar wallet through SDEX and Soroban routing, Circle CCTP, and into Ethereum Sepolia"
+                className="relative mt-8 grid gap-7 md:grid-cols-4 md:gap-3"
+              >
+                <div
+                  className="absolute bottom-5 left-5 top-5 w-px bg-gradient-to-b from-primary via-primary to-signal md:bottom-auto md:left-[12.5%] md:right-[12.5%] md:top-5 md:h-px md:w-auto"
+                  aria-hidden="true"
+                />
+                {routeSteps.map((step, index) => {
+                  const Icon = step.icon;
+                  return (
+                    <div
+                      key={step.label}
+                      className="relative z-10 flex min-w-0 items-center gap-4 md:flex-col md:items-center md:gap-3 md:text-center"
+                    >
+                      <div
+                        className={cn(
+                          'flex h-10 w-10 shrink-0 items-center justify-center rounded-full border bg-card',
+                          index < 2
+                            ? 'border-primary/70 text-primary'
+                            : 'border-signal/70 text-signal'
+                        )}
+                      >
+                        <Icon className="h-4 w-4" aria-hidden="true" />
+                      </div>
+                      <div className="min-w-0">
+                        <p className="text-sm font-semibold text-foreground">
+                          {step.label}
+                        </p>
+                        <p className="mt-0.5 font-mono text-[0.6rem] uppercase tracking-[0.08em] text-muted-foreground">
+                          {step.detail}
+                        </p>
+                      </div>
+                    </div>
+                  );
+                })}
+              </div>
+
+              <div className="relative mt-8 grid grid-cols-2 border-t border-border/70 pt-5">
+                <div>
+                  <p className="font-mono text-[0.6rem] uppercase tracking-[0.14em] text-muted-foreground">
+                    Source domain
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-foreground">
+                    Stellar Testnet
+                  </p>
+                </div>
+                <div className="border-l border-border/70 pl-5">
+                  <p className="font-mono text-[0.6rem] uppercase tracking-[0.14em] text-muted-foreground">
+                    Destination
+                  </p>
+                  <p className="mt-1 text-sm font-semibold text-foreground">
+                    Ethereum Sepolia
+                  </p>
+                </div>
+              </div>
+            </div>
+
+            <div
+              className="absolute -bottom-5 -right-2 hidden items-center gap-2 border border-border bg-background px-3 py-2 font-mono text-[0.6rem] uppercase tracking-[0.14em] text-muted-foreground shadow-lg sm:flex"
+              aria-hidden="true"
+            >
+              <CheckCircle2 className="h-3.5 w-3.5 text-primary" />
+              signed route observed
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        aria-labelledby="capabilities-title"
+        className="border-y border-border/70 bg-card/35"
+      >
+        <div className="container mx-auto px-4 py-24 sm:px-6 sm:py-28 lg:px-8">
+          <div className="grid gap-10 lg:grid-cols-[0.72fr_1.28fr] lg:gap-20">
+            <div>
+              <p className="font-mono text-xs font-medium uppercase tracking-[0.22em] text-primary">
+                Execution coordinates
+              </p>
+              <h2
+                id="capabilities-title"
+                className="font-display mt-4 max-w-md text-4xl font-semibold leading-tight tracking-[-0.04em] sm:text-5xl"
+              >
+                One intent. Three critical systems.
+              </h2>
+            </div>
+
+            <div>
+              {capabilities.map((capability) => {
+                const Icon = capability.icon;
+                return (
+                  <article
+                    key={capability.title}
+                    className="grid gap-4 border-t border-border py-7 first:pt-5 sm:grid-cols-[7rem_1fr_auto] sm:items-start sm:gap-6"
+                  >
+                    <p className="font-mono text-[0.64rem] font-semibold tracking-[0.16em] text-primary">
+                      {capability.eyebrow}
+                    </p>
+                    <div>
+                      <h3 className="font-display text-xl font-semibold tracking-tight text-foreground">
+                        {capability.title}
+                      </h3>
+                      <p className="mt-2 max-w-xl leading-relaxed text-muted-foreground">
+                        {capability.description}
+                      </p>
+                    </div>
+                    <div className="hidden h-10 w-10 items-center justify-center rounded-full border border-border text-muted-foreground sm:flex">
+                      <Icon className="h-4 w-4" aria-hidden="true" />
+                    </div>
+                  </article>
+                );
+              })}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section
+        id="live-proof"
+        aria-labelledby="proof-title"
+        className="container mx-auto scroll-mt-24 px-4 py-24 sm:px-6 sm:py-32 lg:px-8"
+      >
+        <div className="grid gap-14 lg:grid-cols-[0.8fr_1.2fr] lg:items-end lg:gap-24">
+          <div>
+            <div className="inline-flex items-center gap-2 border border-primary/40 bg-primary/10 px-3 py-1.5 font-mono text-[0.66rem] font-semibold uppercase tracking-[0.16em] text-foreground">
+              <CheckCircle2 className="h-3.5 w-3.5 text-primary" aria-hidden="true" />
+              Signed-live / testnet evidence
+            </div>
+            <h2
+              id="proof-title"
+              className="font-display mt-7 text-4xl font-semibold leading-tight tracking-[-0.04em] sm:text-5xl"
+            >
+              The corridor completed, not just compiled.
+            </h2>
+            <p className="mt-5 max-w-xl text-lg leading-relaxed text-muted-foreground">
+              A wallet-signed run burned USDC on Stellar Testnet, received
+              Circle&apos;s attestation, and minted USDC on Ethereum Sepolia.
+            </p>
+            <div className="mt-8 flex items-start gap-3 border-l-2 border-signal pl-4">
+              <Activity
+                className="mt-0.5 h-4 w-4 shrink-0 text-signal"
+                aria-hidden="true"
+              />
+              <p className="text-sm leading-relaxed text-muted-foreground">
+                Evidence scope is one-way and testnet only. This does not claim
+                mainnet availability or a signed-live reverse corridor.
+              </p>
+            </div>
+          </div>
+
+          <dl className="grid grid-cols-1 gap-px overflow-hidden border border-border bg-border sm:grid-cols-2">
+            <div className="bg-card p-7 sm:p-9">
+              <dt className="font-mono text-[0.66rem] uppercase tracking-[0.18em] text-muted-foreground">
+                Total saga
+              </dt>
+              <dd className="font-display mt-8 text-7xl font-semibold leading-none tracking-[-0.06em] text-foreground sm:text-8xl">
+                63<span className="ml-1 text-2xl text-primary">s</span>
+              </dd>
+              <p className="mt-5 text-sm text-muted-foreground">
+                Stellar Testnet → Sepolia completion
+              </p>
+            </div>
+            <div className="bg-card p-7 sm:p-9">
+              <dt className="font-mono text-[0.66rem] uppercase tracking-[0.18em] text-muted-foreground">
+                Burn → attestation
+              </dt>
+              <dd className="font-display mt-8 text-7xl font-semibold leading-none tracking-[-0.06em] text-foreground sm:text-8xl">
+                33<span className="ml-1 text-2xl text-signal">s</span>
+              </dd>
+              <p className="mt-5 text-sm text-muted-foreground">
+                Circle Iris attestation observed
+              </p>
+            </div>
+          </dl>
+        </div>
+      </section>
+
+      <section className="container mx-auto px-4 pb-12 sm:px-6 sm:pb-16 lg:px-8">
+        <div className="relative overflow-hidden border border-primary/40 bg-foreground px-6 py-12 text-background sm:px-10 sm:py-14 lg:px-14">
+          <div
+            className="absolute -right-20 -top-28 h-80 w-80 rounded-full border border-background/15"
+            aria-hidden="true"
+          />
+          <div
+            className="absolute -right-4 -top-10 h-44 w-44 rounded-full border border-background/15"
+            aria-hidden="true"
+          />
+          <div className="relative flex flex-col items-start justify-between gap-8 lg:flex-row lg:items-end">
+            <div>
+              <p className="font-mono text-[0.68rem] font-semibold uppercase tracking-[0.2em] text-primary">
+                Ready on Stellar
+              </p>
+              <h2 className="font-display mt-4 max-w-2xl text-3xl font-semibold leading-tight tracking-[-0.035em] sm:text-4xl">
+                Plot the route. Keep the signature.
+              </h2>
+            </div>
             <Button
               asChild
-              variant="outline"
               size="lg"
-              className="h-12 min-h-11 rounded-lg border-border/70 bg-background/40 px-7 text-base font-semibold backdrop-blur-sm"
+              className="h-12 min-h-11 shrink-0 rounded-lg bg-primary px-7 text-base text-primary-foreground hover:bg-primary/90"
             >
-              <Link href="/swap">Open swap deck</Link>
+              <Link href="/swap">
+                Open execution deck
+                <ArrowRight className="h-5 w-5" aria-hidden="true" />
+              </Link>
             </Button>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
   );
 }

--- a/frontend/hooks/useFeatureFlag.hydration.test.tsx
+++ b/frontend/hooks/useFeatureFlag.hydration.test.tsx
@@ -54,12 +54,12 @@ afterEach(() => {
 });
 
 describe('resolveFlagForInitialRender', () => {
-  it('ignores window overrides for hydration snapshot', () => {
+  it('uses the default-on hydration snapshot before a window false override', () => {
     (window as { __STELLAR_ROUTE_FLAGS__?: Record<string, boolean> }).__STELLAR_ROUTE_FLAGS__ = {
-      swap_ui_v2: true,
+      swap_ui_v2: false,
     };
-    expect(resolveFlagForInitialRender('swap_ui_v2')).toBe(false);
-    expect(resolveFlag('swap_ui_v2')).toBe(true);
+    expect(resolveFlagForInitialRender('swap_ui_v2')).toBe(true);
+    expect(resolveFlag('swap_ui_v2')).toBe(false);
   });
 
   it('reads env for initial snapshot', () => {
@@ -69,12 +69,12 @@ describe('resolveFlagForInitialRender', () => {
 });
 
 describe('useFeatureFlag hydration', () => {
-  it('window-only swap_ui_v2: initial off, no recoverable errors, then on after mount', async () => {
+  it('window-only false: initial on, no recoverable errors, then off after mount', async () => {
     const serverHtml = renderToString(<FlagProbe flag="swap_ui_v2" />);
-    expect(serverHtml).toContain('off');
+    expect(serverHtml).toContain('on');
 
     (window as { __STELLAR_ROUTE_FLAGS__?: Record<string, boolean> }).__STELLAR_ROUTE_FLAGS__ = {
-      swap_ui_v2: true,
+      swap_ui_v2: false,
     };
 
     const container = document.createElement('div');
@@ -106,17 +106,13 @@ describe('useFeatureFlag hydration', () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toContain('on');
+    expect(container.textContent).toContain('off');
   });
 
-  it('env=true and window=false: initial on, hydrates cleanly, then window override after mount', async () => {
-    process.env.NEXT_PUBLIC_FLAG_SWAP_UI_V2 = 'true';
+  it('env=false disables swap_ui_v2 for initial and hydrated renders', async () => {
+    process.env.NEXT_PUBLIC_FLAG_SWAP_UI_V2 = 'false';
     const serverHtml = renderToString(<FlagProbe flag="swap_ui_v2" />);
-    expect(serverHtml).toContain('on');
-
-    (window as { __STELLAR_ROUTE_FLAGS__?: Record<string, boolean> }).__STELLAR_ROUTE_FLAGS__ = {
-      swap_ui_v2: false,
-    };
+    expect(serverHtml).toContain('off');
 
     const container = document.createElement('div');
     container.innerHTML = serverHtml;
@@ -143,24 +139,24 @@ describe('useFeatureFlag hydration', () => {
 
   it('FLAGS_URL-only path stays loading until remote resolves', async () => {
     process.env.NEXT_PUBLIC_FLAGS_URL = 'https://flags.example.com/flags.json';
-    mockFetch({ swap_ui_v2: true });
+    mockFetch({ swap_ui_v2: false });
 
     const { result } = renderHook(() => useFeatureFlag('swap_ui_v2'));
     expect(result.current.loading).toBe(true);
-    expect(result.current.enabled).toBe(false);
+    expect(result.current.enabled).toBe(true);
 
     await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.enabled).toBe(true);
+    expect(result.current.enabled).toBe(false);
   });
 });
 
 describe('useFeatureFlags hydration', () => {
-  it('matches SSR snapshot and applies window override after mount', async () => {
+  it('matches default-on SSR snapshot and applies window false after mount', async () => {
     const serverHtml = renderToString(<BatchProbe flags={['swap_ui_v2']} />);
-    expect(serverHtml).toContain('legacy');
+    expect(serverHtml).toContain('v2');
 
     (window as { __STELLAR_ROUTE_FLAGS__?: Record<string, boolean> }).__STELLAR_ROUTE_FLAGS__ = {
-      swap_ui_v2: true,
+      swap_ui_v2: false,
     };
 
     const container = document.createElement('div');
@@ -183,6 +179,6 @@ describe('useFeatureFlags hydration', () => {
       await Promise.resolve();
     });
 
-    expect(container.textContent).toContain('v2');
+    expect(container.textContent).toContain('legacy');
   });
 });

--- a/frontend/hooks/useFeatureFlag.test.ts
+++ b/frontend/hooks/useFeatureFlag.test.ts
@@ -42,6 +42,23 @@ describe("resolveFlag / real_xdr security pin", () => {
   });
 });
 
+describe("resolveFlag / swap_ui_v2 default", () => {
+  it("defaults swap_ui_v2 on for initial and post-hydration resolution", () => {
+    expect(resolveFlagForInitialRender("swap_ui_v2")).toBe(true);
+    expect(resolveFlag("swap_ui_v2")).toBe(true);
+  });
+
+  it("honors explicit swap_ui_v2=false from env", () => {
+    process.env.NEXT_PUBLIC_FLAG_SWAP_UI_V2 = "false";
+    expect(resolveFlagForInitialRender("swap_ui_v2")).toBe(false);
+    expect(resolveFlag("swap_ui_v2")).toBe(false);
+  });
+
+  it("honors explicit swap_ui_v2=false from remote config", () => {
+    expect(resolveFlag("swap_ui_v2", { swap_ui_v2: false })).toBe(false);
+  });
+});
+
 describe("useFeatureFlag", () => {
   it("defaults to false when no env or remote config", async () => {
     const { result } = renderHook(() => useFeatureFlag("routes_beta"));
@@ -61,7 +78,7 @@ describe("useFeatureFlag", () => {
     mockFetch({ swap_ui_v2: true });
     const { result } = renderHook(() => useFeatureFlag("swap_ui_v2"));
     expect(result.current.loading).toBe(true);
-    expect(result.current.enabled).toBe(false);
+    expect(result.current.enabled).toBe(true);
     await waitFor(() => expect(result.current.loading).toBe(false));
     expect(result.current.enabled).toBe(true);
   });
@@ -117,8 +134,7 @@ describe("useFeatureFlag", () => {
     mockFetch({ routes_beta: true });
 
     const { result } = renderHook(() => useFeatureFlag("routes_beta"));
-    await waitFor(() => expect(result.current.loading).toBe(false));
-    expect(result.current.enabled).toBe(true);
+    await waitFor(() => expect(result.current.enabled).toBe(true));
   });
 
   it("window override beats env after mount when remote is absent", async () => {

--- a/frontend/hooks/useFeatureFlag.ts
+++ b/frontend/hooks/useFeatureFlag.ts
@@ -16,6 +16,10 @@ export type FlagMap = Partial<Record<FlagName, boolean>>;
 /** Security-critical: secure API swap path — not remotely killable. */
 export const SECURITY_PINNED_FLAGS: ReadonlySet<FlagName> = new Set(['real_xdr']);
 
+function defaultFlagValue(flag: FlagName): boolean {
+  return flag === 'swap_ui_v2';
+}
+
 // Cache layer
 let remoteFlags: FlagMap | null = null;
 let remoteFetchPromise: Promise<FlagMap> | null = null;
@@ -94,7 +98,7 @@ export function resolveFlagForInitialRender(flag: FlagName): boolean {
   }
   const env = readEnvFlag(flag);
   if (env !== undefined) return env;
-  return false;
+  return defaultFlagValue(flag);
 }
 
 function initialFlagLoading(flag: FlagName): boolean {
@@ -105,7 +109,7 @@ function initialFlagLoading(flag: FlagName): boolean {
 }
 
 /**
- * Full post-hydration resolution for ordinary flags: remote > window > env > false.
+ * Full post-hydration resolution for ordinary flags: remote > window > env > default.
  * `real_xdr` is security-pinned: env/default only (default on). Remote and window
  * cannot disable the secure API prepare/sign/submit path.
  */
@@ -120,7 +124,7 @@ export function resolveFlag(flag: FlagName, remote: FlagMap = {}): boolean {
   if (windowFlag !== undefined) return windowFlag;
   const env = readEnvFlag(flag);
   if (env !== undefined) return env;
-  return false;
+  return defaultFlagValue(flag);
 }
 
 export function useFeatureFlag(flag: FlagName): {

--- a/frontend/lib/cctp/client.test.ts
+++ b/frontend/lib/cctp/client.test.ts
@@ -7,6 +7,7 @@ import {
   redactSecretsForLogs,
   saveCctpSession,
 } from './session-vault';
+import { buildWalletRoleBindings } from './wallet-role-binding';
 import { CCTP_IDEMPOTENCY_HEADER, CCTP_TRANSFER_ACCESS_HEADER } from './types';
 
 describe('CctpApiClient', () => {
@@ -158,6 +159,15 @@ describe('session vault', () => {
         destChainId: 'stellar',
         amount: '1',
         recipient: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+        walletBindings:
+          buildWalletRoleBindings({
+            direction: 'evm_to_stellar',
+            sourceChainId: 'eip155:11155111',
+            destChainId: 'stellar:testnet',
+            sender: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0',
+            recipient: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+            mintSubmitter: 'GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF',
+          }) ?? undefined,
       },
     });
     saveCctpSession(record);


### PR DESCRIPTION
## Summary
- Carries the CI fixes that landed after #1147 was merged: Rust formatting/clippy, deterministic Postgres prepare-lock races, the v2 session-vault test fixture, and Cargo.lock in the API Docker build.
- Makes the cross-chain execution deck the default `/swap` experience while retaining explicit env/window/remote rollback controls.
- Reworks the landing page around Stellar liquidity routing, wallet-signed execution, and the proven Stellar Testnet → Sepolia Circle CCTP corridor, with honest TESTNET and production-gating labels.

## Test plan
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --all-features --exclude stellarroute-contracts -- -D warnings`
- [x] `./scripts/cctp-pg-test.sh`
- [x] `npm --prefix frontend run test -- lib/cctp/client.test.ts`
- [x] 28 focused feature-flag, hydration, and SwapPageClient tests
- [x] 9 HeroSection tests
- [x] Frontend lint and production build
- [x] Mobile overflow check
- [ ] GitHub CI green