### PR TITLE
fix(frontend): Freighter connect under ESM + ruint audit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1837,7 +1837,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2723,7 +2723,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4119,9 +4119,9 @@ dependencies = [
 
 [[package]]
 name = "ruint"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45caf26f647c19115bf9c453c70ffe4a4a3a6390dceebd942610584f99b8ddce"
+checksum = "f5e99bff0393163bb25029a6af25d3d8d202ba5b5438a74d1bd8789f5c822970"
 dependencies = [
  "alloy-rlp",
  "ark-ff 0.3.0",
@@ -4261,7 +4261,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5435,7 +5435,7 @@ dependencies = [
  "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6382,7 +6382,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -9,7 +9,7 @@
 # final stage has no Rust toolchain — only the release binary + CA certs +
 # OpenSSL + curl. Secrets (.env / keys) are never COPY'd.
 
-ARG RUST_VERSION=1.88
+ARG RUST_VERSION=1.90
 
 FROM rust:${RUST_VERSION}-bookworm AS builder
 WORKDIR /app

--- a/frontend/lib/wallet/freighter-api.test.ts
+++ b/frontend/lib/wallet/freighter-api.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveFreighterApi } from './freighter-api';
+
+function makeApi() {
+  return {
+    isConnected: async () => ({ isConnected: true }),
+    requestAccess: async () => ({ address: 'GTEST' }),
+    getAddress: async () => ({ address: 'GTEST' }),
+    getNetworkDetails: async () => ({ network: 'TESTNET' }),
+    signTransaction: async () => ({ signedTxXdr: 'AAAA' }),
+  };
+}
+
+describe('resolveFreighterApi', () => {
+  it('accepts direct named-export module shapes', () => {
+    const api = makeApi();
+    expect(resolveFreighterApi(api).requestAccess).toBe(api.requestAccess);
+  });
+
+  it('unwraps default export used by UMD/ESM interop', () => {
+    const api = makeApi();
+    const resolved = resolveFreighterApi({ default: api });
+    expect(resolved.requestAccess).toBe(api.requestAccess);
+  });
+
+  it('unwraps module.exports key produced by some bundlers', () => {
+    const api = makeApi();
+    const resolved = resolveFreighterApi({ 'module.exports': api });
+    expect(resolved.signTransaction).toBe(api.signTransaction);
+  });
+
+  it('throws a clear error when no callable API is present', () => {
+    expect(() => resolveFreighterApi({ requestAccess: undefined })).toThrow(
+      /Freighter API failed to load/,
+    );
+  });
+});

--- a/frontend/lib/wallet/freighter-api.ts
+++ b/frontend/lib/wallet/freighter-api.ts
@@ -1,0 +1,72 @@
+/**
+ * Resolve Freighter API methods across CJS/UMD/ESM interop shapes.
+ *
+ * `@stellar/freighter-api` ships a webpack UMD bundle. Under Next/Turbopack
+ * native ESM, named imports like `requestAccess` are often `undefined`, while
+ * the real functions live on `default` / `module.exports`. Calling those
+ * undefined named imports produces `(void 0) is not a function`.
+ */
+
+type FreighterApiError = { message?: string; code?: number };
+
+type FreighterFnResult<T> = T & { error?: FreighterApiError };
+
+export type FreighterApi = {
+  isConnected: () => Promise<FreighterFnResult<{ isConnected: boolean }>>;
+  requestAccess: () => Promise<FreighterFnResult<{ address: string }>>;
+  getAddress: () => Promise<FreighterFnResult<{ address: string }>>;
+  getNetworkDetails: () => Promise<
+    FreighterFnResult<{
+      network: string;
+      networkUrl?: string;
+      networkPassphrase?: string;
+      sorobanRpcUrl?: string;
+    }>
+  >;
+  signTransaction: (
+    xdr: string,
+    opts?: { networkPassphrase?: string; address?: string; network?: string },
+  ) => Promise<
+    FreighterFnResult<{ signedTxXdr: string; signerAddress?: string }>
+  >;
+};
+
+function isFreighterApi(value: unknown): value is FreighterApi {
+  if (!value || typeof value !== 'object') return false;
+  const candidate = value as Record<string, unknown>;
+  return (
+    typeof candidate.isConnected === 'function' &&
+    typeof candidate.requestAccess === 'function' &&
+    typeof candidate.getAddress === 'function' &&
+    typeof candidate.getNetworkDetails === 'function' &&
+    typeof candidate.signTransaction === 'function'
+  );
+}
+
+function unwrapCandidate(value: unknown): unknown {
+  if (!value || typeof value !== 'object') return value;
+  const record = value as Record<string, unknown>;
+  if (isFreighterApi(record)) return record;
+  if (isFreighterApi(record.default)) return record.default;
+  if (isFreighterApi(record.freighterApi)) return record.freighterApi;
+  if (isFreighterApi(record['module.exports'])) return record['module.exports'];
+  return value;
+}
+
+export function resolveFreighterApi(moduleNamespace: unknown): FreighterApi {
+  const candidates: unknown[] = [moduleNamespace, unwrapCandidate(moduleNamespace)];
+
+  if (typeof window !== 'undefined') {
+    const win = window as unknown as Record<string, unknown>;
+    candidates.push(win.freighterApi, unwrapCandidate(win.freighterApi));
+  }
+
+  for (const candidate of candidates) {
+    const resolved = unwrapCandidate(candidate);
+    if (isFreighterApi(resolved)) return resolved;
+  }
+
+  throw new Error(
+    'Freighter API failed to load in this browser bundle. Refresh the page, or install/enable the Freighter extension and try again.',
+  );
+}

--- a/frontend/lib/wallet/index.ts
+++ b/frontend/lib/wallet/index.ts
@@ -1,10 +1,4 @@
-import {
-  requestAccess,
-  getAddress,
-  getNetworkDetails,
-  isConnected,
-  signTransaction,
-} from '@stellar/freighter-api';
+import * as freighterModule from '@stellar/freighter-api';
 import {
   isConnected as isLobstrConnected,
   getPublicKey as getLobstrPublicKey,
@@ -19,6 +13,16 @@ import type {
   Capability,
   CapabilityStatus,
 } from './types';
+import { resolveFreighterApi, type FreighterApi } from './freighter-api';
+
+let freighterApiCache: FreighterApi | null = null;
+
+function freighterApi(): FreighterApi {
+  if (!freighterApiCache) {
+    freighterApiCache = resolveFreighterApi(freighterModule);
+  }
+  return freighterApiCache;
+}
 
 type AlbedoClient = {
   publicKey: () => Promise<{ pubkey?: string; publicKey?: string }>;
@@ -194,8 +198,9 @@ async function detectFreighterInstalled(): Promise<boolean> {
   if (isFreighterInjected()) return true;
 
   try {
+    // Freighter's isConnected() means "extension present" (not app authorization).
     const res = await withTimeout(
-      isConnected(),
+      freighterApi().isConnected(),
       FREIGHTER_DETECT_TIMEOUT_MS,
       { isConnected: false }
     );
@@ -261,18 +266,18 @@ export async function connectWallet(
   walletId: SupportedWallet
 ): Promise<WalletSession> {
   if (walletId === 'freighter') {
-    const access = await requestAccess();
+    const access = await freighterApi().requestAccess();
 
     if (access.error) {
       throw new Error(access.error.message ?? 'Freighter access denied');
     }
 
-    const addressRes = await getAddress();
+    const addressRes = await freighterApi().getAddress();
     if (addressRes.error) {
       throw new Error(addressRes.error.message ?? 'Failed to get address');
     }
 
-    const networkRes = await getNetworkDetails();
+    const networkRes = await freighterApi().getNetworkDetails();
     if (networkRes.error) {
       throw new Error(networkRes.error.message ?? 'Failed to get network');
     }
@@ -364,7 +369,7 @@ export async function checkWalletCapabilities(
 
   if (walletId === 'freighter') {
     try {
-      const accessRes = await requestAccess();
+      const accessRes = await freighterApi().requestAccess();
       statuses.push({
         capability: 'request_access',
         allowed: !accessRes.error,
@@ -383,7 +388,7 @@ export async function checkWalletCapabilities(
     }
 
     try {
-      const addressRes = await getAddress();
+      const addressRes = await freighterApi().getAddress();
       const hasAddress = !addressRes.error && !!addressRes.address;
       statuses.push({
         capability: 'view_address',
@@ -403,7 +408,7 @@ export async function checkWalletCapabilities(
     }
 
     try {
-      const networkRes = await getNetworkDetails();
+      const networkRes = await freighterApi().getNetworkDetails();
       const hasNetwork = !networkRes.error && !!networkRes.network;
       const networkMatch = hasNetwork && networkRes.network === network;
       statuses.push({
@@ -629,7 +634,7 @@ export async function signTransactionWithWallet(
   publicKey?: string
 ): Promise<string> {
   if (walletId === 'freighter') {
-    const res = await signTransaction(xdr, { networkPassphrase });
+    const res = await freighterApi().signTransaction(xdr, { networkPassphrase });
     if (res.error) {
       throw new Error(
         normalizeWalletSignError(
@@ -715,7 +720,7 @@ export async function checkAddressChange(
 
   try {
     if (walletId === 'freighter') {
-      const addressRes = await getAddress();
+      const addressRes = await freighterApi().getAddress();
       if (addressRes.error) return null;
       return addressRes.address !== currentAddress ? addressRes.address : null;
     }
@@ -736,12 +741,12 @@ export async function refreshWalletSession(
   walletId: SupportedWallet
 ): Promise<WalletSession> {
   if (walletId === 'freighter') {
-    const addressRes = await getAddress();
+    const addressRes = await freighterApi().getAddress();
     if (addressRes.error) {
       throw new Error(addressRes.error.message ?? 'Failed to get address');
     }
 
-    const networkRes = await getNetworkDetails();
+    const networkRes = await freighterApi().getNetworkDetails();
     if (networkRes.error) {
       throw new Error(networkRes.error.message ?? 'Failed to get network');
     }

--- a/frontend/tsconfig.json
+++ b/frontend/tsconfig.json
@@ -20,7 +20,6 @@
     ],
     "paths": {
       "@/*": ["./*"],
-      "@stellar/freighter-api": ["./node_modules/@stellar/freighter-api/build/@stellar/freighter-api/src/index.d.ts"],
       "@shared/*": ["./node_modules/@stellar/freighter-api/build/@shared/*"]
     }
   },


### PR DESCRIPTION
## Summary
- fix Freighter connect crashing with `(void 0) is not a function` by resolving the UMD/ESM interop shape of `@stellar/freighter-api`
- remove a `tsconfig` path override that pointed the package at a `.d.ts` file
- bump locked `ruint` to `1.20.0` (RUSTSEC-2026-0220) and raise the API Docker Rust toolchain to 1.90

## Test plan
- [x] `npm --prefix frontend run test -- lib/wallet/freighter-api.test.ts lib/wallet/index.test.ts lib/wallet/checkAddressChange.test.ts hooks/useWallet.test.ts components/providers/wallet-provider.test.tsx`
- [x] `cargo audit` (only allowed unmaintained warnings remain)
- [ ] Vercel preview: Connect Wallet → Freighter prompts for access instead of `(void 0) is not a function`
- [ ] Confirm Dependency Audit / cargo audit is green