### PR TITLE
fix(frontend): unblock testnet Freighter + unlock Stellar→Sepolia CCTP

### DIFF
--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -30,6 +30,8 @@ import {
   DEFAULT_FROM_TOKEN,
   DEFAULT_SLIPPAGE,
   DEFAULT_TO_TOKEN,
+  LEGACY_DEFAULT_FROM_TOKEN,
+  LEGACY_DEFAULT_TO_TOKEN,
   SESSION_RECOVERY_THRESHOLD_MS,
   type TradeFormSnapshot,
 } from '@/hooks/useTradeFormStorage';
@@ -135,14 +137,33 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
 
   const { data: indexedPairs } = usePairs();
 
-  // Staging often only has BTC/EXT liquidity. Reset stale localStorage pairs
-  // (e.g. XLM→USDC) that cannot quote against the indexed market set.
+  // Prefer an indexed native (XLM) pair; migrate off the old BTC/EXT default.
+  // Fall back to defaults, then the first indexed pair when liquidity is sparse.
   useEffect(() => {
     if (!indexedPairs?.length) return;
     const assets = new Set(
       indexedPairs.flatMap((pair) => [pair.base_asset, pair.counter_asset])
     );
-    if (assets.has(fromToken) && assets.has(toToken)) return;
+    const isLegacyDefaultPair =
+      fromToken === LEGACY_DEFAULT_FROM_TOKEN &&
+      toToken === LEGACY_DEFAULT_TO_TOKEN;
+
+    if (assets.has(fromToken) && assets.has(toToken) && !isLegacyDefaultPair) {
+      return;
+    }
+
+    const nativePair = indexedPairs.find(
+      (pair) =>
+        pair.base_asset === 'native' || pair.counter_asset === 'native'
+    );
+    if (nativePair) {
+      if (nativePair.base_asset === 'native') {
+        setTokenPair(nativePair.base_asset, nativePair.counter_asset);
+      } else {
+        setTokenPair('native', nativePair.base_asset);
+      }
+      return;
+    }
 
     if (assets.has(DEFAULT_FROM_TOKEN) && assets.has(DEFAULT_TO_TOKEN)) {
       setTokenPair(DEFAULT_FROM_TOKEN, DEFAULT_TO_TOKEN);

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -138,7 +138,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
   const { data: indexedPairs } = usePairs();
 
   // Prefer an indexed native (XLM) pair; migrate off the old BTC/EXT default.
-  // Fall back to defaults, then the first indexed pair when liquidity is sparse.
+  // Never force BTC/EXT just because it is the only indexed staging pair.
   useEffect(() => {
     if (!indexedPairs?.length) return;
     const assets = new Set(
@@ -147,6 +147,12 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
     const isLegacyDefaultPair =
       fromToken === LEGACY_DEFAULT_FROM_TOKEN &&
       toToken === LEGACY_DEFAULT_TO_TOKEN;
+    const isLegacyIndexedPair = (pair: {
+      base_asset: string;
+      counter_asset: string;
+    }) =>
+      pair.base_asset === LEGACY_DEFAULT_FROM_TOKEN &&
+      pair.counter_asset === LEGACY_DEFAULT_TO_TOKEN;
 
     if (assets.has(fromToken) && assets.has(toToken) && !isLegacyDefaultPair) {
       return;
@@ -154,7 +160,8 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
 
     const nativePair = indexedPairs.find(
       (pair) =>
-        pair.base_asset === 'native' || pair.counter_asset === 'native'
+        (pair.base_asset === 'native' || pair.counter_asset === 'native') &&
+        !isLegacyIndexedPair(pair)
     );
     if (nativePair) {
       if (nativePair.base_asset === 'native') {
@@ -170,8 +177,13 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
       return;
     }
 
-    const first = indexedPairs[0];
-    setTokenPair(first.base_asset, first.counter_asset);
+    const firstNonLegacy = indexedPairs.find((pair) => !isLegacyIndexedPair(pair));
+    if (firstNonLegacy) {
+      setTokenPair(firstNonLegacy.base_asset, firstNonLegacy.counter_asset);
+      return;
+    }
+
+    setTokenPair(DEFAULT_FROM_TOKEN, DEFAULT_TO_TOKEN);
   }, [indexedPairs, fromToken, toToken, setTokenPair]);
 
   const [selectedRoute, setSelectedRoute] = useState<AlternativeRoute | null>(

--- a/frontend/components/swap/cross-chain/CrossChainRoutePanel.test.tsx
+++ b/frontend/components/swap/cross-chain/CrossChainRoutePanel.test.tsx
@@ -30,4 +30,22 @@ describe('CrossChainRoutePanel', () => {
     );
     expect(screen.getByTestId('cctp-route-rail')).toBeInTheDocument();
   });
+
+  it('describes same-chain Stellar routes without CCTP unavailable copy', () => {
+    render(
+      <CrossChainRoutePanel
+        sourceChainId="stellar"
+        destChainId="stellar"
+        protocol="stellar-native"
+        executable
+        bridgeUnavailable
+      />
+    );
+    expect(
+      screen.getByText(/Same-chain Stellar swap/i)
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByText(/CCTP corridor is listed but not executable/i)
+    ).not.toBeInTheDocument();
+  });
 });

--- a/frontend/components/swap/cross-chain/CrossChainRoutePanel.tsx
+++ b/frontend/components/swap/cross-chain/CrossChainRoutePanel.tsx
@@ -73,11 +73,13 @@ export function CrossChainRoutePanel({
         </p>
         <h2 className="brand-wordmark text-lg text-foreground">{pairLabel}</h2>
         <p className="text-sm text-muted-foreground">
-          {executable
-            ? 'Circle CCTP — server-prepared payloads, wallet sign, hash-only submit.'
-            : bridgeUnavailable
-              ? 'CCTP corridor is listed but not executable on this API yet.'
-              : 'Protocol preview — quotes and execution are not available for this corridor yet.'}
+          {protocol === 'stellar-native'
+            ? 'Same-chain Stellar swap — SDEX and Soroban venues via the existing swap path.'
+            : executable
+              ? 'Circle CCTP — server-prepared payloads, wallet sign, hash-only submit.'
+              : bridgeUnavailable
+                ? 'CCTP corridor is listed but not executable on this API yet.'
+                : 'Protocol preview — quotes and execution are not available for this corridor yet.'}
         </p>
       </div>
 

--- a/frontend/components/swap/cross-chain/CrossChainRoutePanel.tsx
+++ b/frontend/components/swap/cross-chain/CrossChainRoutePanel.tsx
@@ -85,19 +85,31 @@ export function CrossChainRoutePanel({
 
       <div className="flex items-center justify-center gap-3 py-2">
         <HubNode
-          label={sourceChainId === 'stellar' ? 'Stellar hub' : 'Source'}
-          active={sourceChainId === 'stellar'}
+          label={sourceChainId === 'stellar' ? 'Stellar' : 'Source'}
+          active
         />
         <ArrowRight className="h-5 w-5 text-primary shrink-0" aria-hidden />
         <HubNode
-          label="Stellar hub"
-          active={destChainId === 'stellar' || sourceChainId === 'stellar'}
+          label={
+            protocol === 'stellar-native'
+              ? 'SDEX / Soroban'
+              : protocol === 'cctp-preview'
+                ? 'CCTP'
+                : 'Route'
+          }
+          active
           emphasized
         />
         <ArrowRight className="h-5 w-5 text-primary shrink-0" aria-hidden />
         <HubNode
-          label={destChainId === 'stellar' ? 'Stellar hub' : 'Destination'}
-          active={destChainId === 'stellar'}
+          label={
+            destChainId === 'stellar'
+              ? 'Stellar'
+              : destChainId === 'ethereum-sepolia'
+                ? 'ETH Sepolia'
+                : 'Destination'
+          }
+          active
         />
       </div>
 

--- a/frontend/components/swap/cross-chain/CrossChainSwapDeck.test.tsx
+++ b/frontend/components/swap/cross-chain/CrossChainSwapDeck.test.tsx
@@ -116,7 +116,15 @@ describe('CrossChainSwapDeck', () => {
       screen.getByTestId('chain-option-destination-ethereum-sepolia')
     ).toBeChecked();
     expect(screen.queryByTestId('swap-card')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('unsupported-corridor-alert')).not.toBeInTheDocument();
     expect(screen.getByTestId('cctp-route-rail')).toBeInTheDocument();
+    expect(screen.getByTestId('corridor-status-badge')).toHaveTextContent(
+      /executable corridor/i
+    );
+    // Settlement still waits on API readiness in this mock.
+    expect(
+      screen.getByText(/CCTP corridor is listed but not executable on this API yet/i)
+    ).toBeInTheDocument();
   });
 
   it('shows unsupported alert for catalogued coming-soon corridor', () => {

--- a/frontend/components/swap/cross-chain/CrossChainSwapDeck.tsx
+++ b/frontend/components/swap/cross-chain/CrossChainSwapDeck.tsx
@@ -297,10 +297,17 @@ export function CrossChainSwapDeck({
             sourceChainId={state.sourceChainId}
             destChainId={state.destChainId}
             protocol={state.corridor?.protocol ?? null}
-            executable={state.executable && readiness.cctpGloballyReady}
+            executable={
+              state.isStellarNativeExecutable ||
+              (state.executable && readiness.cctpGloballyReady)
+            }
             uncatalogued={state.isUncatalogued}
             quote={saga.quote}
-            bridgeUnavailable={readiness.loaded && !readiness.cctpGloballyReady}
+            bridgeUnavailable={
+              !state.isStellarNativeExecutable &&
+              readiness.loaded &&
+              !readiness.cctpGloballyReady
+            }
             sagaStatus={saga.transferStatus?.status}
           />
           <RouteDisclosurePanel />

--- a/frontend/hooks/useCorridorCatalog.ts
+++ b/frontend/hooks/useCorridorCatalog.ts
@@ -1,4 +1,4 @@
-import { useMemo } from 'react';
+import { useMemo, useSyncExternalStore } from 'react';
 import type { CorridorDefinition, CorridorId } from '@/lib/cross-chain/types';
 import {
   CORRIDOR_CATALOG,
@@ -6,8 +6,19 @@ import {
   isCorridorExecutable,
   resolveCorridorAvailability,
 } from '@/lib/cross-chain/corridors';
+import {
+  getReadinessSnapshot,
+  subscribeReadiness,
+} from '@/lib/cctp/readiness';
 
 export function useCorridorCatalog() {
+  // Recompute when /api/v2 readiness updates CCTP route registration.
+  const readiness = useSyncExternalStore(
+    subscribeReadiness,
+    getReadinessSnapshot,
+    getReadinessSnapshot
+  );
+
   const corridors = useMemo(
     () =>
       CORRIDOR_CATALOG.map((corridor) => ({
@@ -15,7 +26,7 @@ export function useCorridorCatalog() {
         availability: resolveCorridorAvailability(corridor),
         executable: isCorridorExecutable(corridor),
       })),
-    []
+    [readiness.fetchedAt, readiness.corridors]
   );
 
   const executableCorridors = useMemo(

--- a/frontend/hooks/useCrossChainSwapState.test.ts
+++ b/frontend/hooks/useCrossChainSwapState.test.ts
@@ -51,6 +51,16 @@ describe('useCrossChainSwapState', () => {
     expect(result.current.executable).toBe(false);
   });
 
+  it('marks default Stellar → Sepolia as catalog-executable', () => {
+    const { result } = renderHook(() => useCrossChainSwapState());
+
+    expect(result.current.sourceChainId).toBe('stellar');
+    expect(result.current.destChainId).toBe('ethereum-sepolia');
+    expect(result.current.corridorId).toBe('stellar-to-evm');
+    expect(result.current.executable).toBe(true);
+    expect(result.current.isStellarNativeExecutable).toBe(false);
+  });
+
   it('does not allow review for catalogued coming-soon corridors', () => {
     const { result } = renderHook(() =>
       useCrossChainSwapState({

--- a/frontend/hooks/useCrossChainSwapState.ts
+++ b/frontend/hooks/useCrossChainSwapState.ts
@@ -51,6 +51,7 @@ export function useCrossChainSwapState(options?: {
     ? 'unsupported'
     : resolveCorridorAvailability(corridor!);
 
+  // Catalog/backend-route executable. CCTP settlement still gates on /api/v2 readiness.
   const executable = !isUncatalogued && isCorridorExecutable(corridor!);
   const isStellarNativePair =
     sourceChainId === 'stellar' && destChainId === 'stellar';

--- a/frontend/hooks/useTradeFormStorage.test.ts
+++ b/frontend/hooks/useTradeFormStorage.test.ts
@@ -22,9 +22,7 @@ describe("useTradeFormStorage", () => {
     expect(result.current.amount).toBe("");
     expect(result.current.slippage).toBe(0.5);
     expect(result.current.deadline).toBe(30);
-    expect(result.current.fromToken).toBe(
-      "BTC:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS"
-    );
+    expect(result.current.fromToken).toBe("native");
     expect(result.current.toToken).toBe(DEFAULT_TO_TOKEN);
     expect(result.current.side).toBe("sell");
     expect(result.current.pendingRecovery).toBeNull();

--- a/frontend/hooks/useTradeFormStorage.ts
+++ b/frontend/hooks/useTradeFormStorage.ts
@@ -7,10 +7,15 @@ export const STORAGE_KEY = "stellar-route-trade-form";
 export const DEFAULT_AMOUNT = "";
 export const DEFAULT_SLIPPAGE = 0.5;
 export const DEFAULT_DEADLINE = 30;
-/** Staging default pair present in Wave 0 indexed SDEX offers (quotes successfully). */
-export const DEFAULT_FROM_TOKEN =
-  "BTC:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS";
+/** Prefer native XLM so users with testnet funds land on a spendable asset. */
+export const DEFAULT_FROM_TOKEN = "native";
+/** Common testnet/mainnet USDC issuer; SwapCard falls back to indexed pairs if absent. */
 export const DEFAULT_TO_TOKEN =
+  "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
+/** Previous staging default — migrate away when a native pair is indexed. */
+export const LEGACY_DEFAULT_FROM_TOKEN =
+  "BTC:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS";
+export const LEGACY_DEFAULT_TO_TOKEN =
   "EXT:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS";
 export const DEFAULT_SIDE: QuoteType = "sell";
 export const SESSION_RECOVERY_THRESHOLD_MS = 60_000;

--- a/frontend/lib/cross-chain/corridors.test.ts
+++ b/frontend/lib/cross-chain/corridors.test.ts
@@ -13,10 +13,11 @@ describe('corridor catalog', () => {
     expect(catalogMatchesBackendRoutes()).toBe(true);
   });
 
-  it('only marks stellar-native as executable', () => {
-    const executable = CORRIDOR_CATALOG.filter((c) => isCorridorExecutable(c));
-    expect(executable).toHaveLength(1);
-    expect(executable[0].id).toBe('stellar-native');
+  it('marks stellar-native and stellar→Sepolia CCTP as executable', () => {
+    const executable = CORRIDOR_CATALOG.filter((c) => isCorridorExecutable(c)).map(
+      (c) => c.id
+    );
+    expect(executable).toEqual(['stellar-native', 'stellar-to-evm']);
   });
 
   it('reflects backend route registration per corridor leg', () => {

--- a/frontend/lib/cross-chain/corridors.ts
+++ b/frontend/lib/cross-chain/corridors.ts
@@ -80,11 +80,11 @@ export const CORRIDOR_CATALOG: CorridorDefinition[] = [
   {
     id: 'stellar-to-evm',
     label: 'Stellar → ETH Sepolia',
-    description: 'CCTP corridor preview — burn on Stellar, mint on Ethereum.',
+    description: 'CCTP testnet corridor — burn USDC on Stellar, mint on Sepolia.',
     sourceChainId: 'stellar',
     destChainId: 'ethereum-sepolia',
     protocol: 'cctp-preview',
-    catalogAvailability: 'coming_soon',
+    catalogAvailability: 'executable',
   },
   {
     id: 'solana-to-stellar',

--- a/frontend/lib/presets.ts
+++ b/frontend/lib/presets.ts
@@ -7,12 +7,6 @@ export interface SwapPreset {
 
 export const DEFAULT_SWAP_PRESETS: SwapPreset[] = [
   {
-    id: "btc-ext",
-    label: "BTC / EXT",
-    baseAsset: "BTC:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS",
-    quoteAsset: "EXT:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS",
-  },
-  {
     id: "xlm-usdc",
     label: "XLM / USDC",
     baseAsset: "native",
@@ -29,5 +23,11 @@ export const DEFAULT_SWAP_PRESETS: SwapPreset[] = [
     label: "USDC / XLM",
     baseAsset: "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
     quoteAsset: "native",
+  },
+  {
+    id: "btc-ext",
+    label: "BTC / EXT",
+    baseAsset: "BTC:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS",
+    quoteAsset: "EXT:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS",
   },
 ];

--- a/frontend/lib/wallet/adapters/execution-support.test.ts
+++ b/frontend/lib/wallet/adapters/execution-support.test.ts
@@ -61,6 +61,7 @@ describe('execution support', () => {
   });
 
   it('reports no backend route for non-stellar pairs even when signing is available', () => {
+    expect(hasBackendRoute('stellar', 'evm')).toBe(true);
     expect(hasBackendRoute('evm', 'stellar')).toBe(false);
     expect(hasBackendRoute('bitcoin', 'stellar')).toBe(false);
     expect(hasBackendRoute('tron', 'bitcoin')).toBe(false);

--- a/frontend/lib/wallet/adapters/execution-support.ts
+++ b/frontend/lib/wallet/adapters/execution-support.ts
@@ -1,16 +1,19 @@
 /**
  * Execution support for multi-chain wallet sessions.
  *
- * StellarRoute's live swap path is Stellar-native today. EVM/Solana/
- * Bitcoin/TRON adapters may sign chain-native payloads, but MUST surface
- * `unsupported` / `degraded` when no backend cross-chain route exists.
+ * Live paths: Stellar-native swaps, plus testnet Stellar→EVM CCTP when the
+ * API reports bridge readiness. Other adapters may sign chain-native
+ * payloads, but MUST surface `unsupported` / `degraded` when no backend
+ * cross-chain route exists.
  */
 
 import type { ChainFamily, ExecutionSupport } from './types';
 
 const CROSS_CHAIN_BACKEND_ROUTES: ReadonlySet<string> = new Set([
-  // Intentionally empty until backend exposes non-Stellar (or bridge) routes.
+  // Proven testnet CCTP direction (Stellar USDC burn → Sepolia mint).
+  // Settlement still requires API readiness (`CCTP_ENABLED` + /api/v2).
   // Format: `${source}->${destination}`
+  'stellar->evm',
 ]);
 
 let cctpExecutableRoutes: ReadonlySet<string> = new Set();

--- a/frontend/lib/wallet/index.test.ts
+++ b/frontend/lib/wallet/index.test.ts
@@ -286,6 +286,41 @@ describe('signTransactionWithWallet - xBull', () => {
   });
 });
 
+describe('checkWalletCapabilities - Freighter', () => {
+  // vitest.setup calls vi.restoreAllMocks() after each test, which strips the
+  // shared Freighter mock implementations. Re-seed them for this suite.
+  beforeEach(() => {
+    vi.mocked(freighter.requestAccess).mockResolvedValue({
+      address: MOCK_PUBLIC_KEY,
+    });
+    vi.mocked(freighter.getAddress).mockResolvedValue({
+      address: MOCK_PUBLIC_KEY,
+    });
+    vi.mocked(freighter.getNetworkDetails).mockResolvedValue({
+      network: 'TESTNET',
+      networkUrl: 'https://horizon-testnet.stellar.org',
+      networkPassphrase: TEST_PASSPHRASE,
+    });
+  });
+
+  it('treats Freighter TESTNET as matching app testnet', async () => {
+    const caps = await checkWalletCapabilities('freighter', 'testnet');
+    const netCap = caps.statuses.find((s) => s.capability === 'view_network');
+    const signCap = caps.statuses.find(
+      (s) => s.capability === 'sign_transaction'
+    );
+
+    expect(netCap?.allowed).toBe(true);
+    expect(signCap?.allowed).toBe(true);
+    expect(signCap?.reason).toBeUndefined();
+  });
+
+  it('normalizes Freighter TESTNET onto the session network', async () => {
+    const session = await connectWallet('freighter');
+    expect(session.network).toBe('testnet');
+  });
+});
+
 describe('checkWalletCapabilities - xBull', () => {
   afterEach(() => {
     delete (window as unknown as Record<string, unknown>).xbull;

--- a/frontend/lib/wallet/index.ts
+++ b/frontend/lib/wallet/index.ts
@@ -14,6 +14,7 @@ import type {
   CapabilityStatus,
 } from './types';
 import { resolveFreighterApi, type FreighterApi } from './freighter-api';
+import { normalizeAppNetwork } from '@/lib/network-policy';
 
 let freighterApiCache: FreighterApi | null = null;
 
@@ -22,6 +23,11 @@ function freighterApi(): FreighterApi {
     freighterApiCache = resolveFreighterApi(freighterModule);
   }
   return freighterApiCache;
+}
+
+/** Freighter reports `TESTNET` / `PUBLIC`; app policy uses lowercase `testnet` / `mainnet`. */
+function normalizeFreighterNetwork(network: string): string {
+  return normalizeAppNetwork(network) ?? network.trim().toLowerCase();
 }
 
 type AlbedoClient = {
@@ -285,7 +291,7 @@ export async function connectWallet(
     return {
       walletId,
       address: addressRes.address,
-      network: networkRes.network,
+      network: normalizeFreighterNetwork(networkRes.network),
       isConnected: true,
     };
   }
@@ -410,7 +416,14 @@ export async function checkWalletCapabilities(
     try {
       const networkRes = await freighterApi().getNetworkDetails();
       const hasNetwork = !networkRes.error && !!networkRes.network;
-      const networkMatch = hasNetwork && networkRes.network === network;
+      const walletNetwork = hasNetwork
+        ? normalizeAppNetwork(networkRes.network)
+        : null;
+      const expectedNetwork = normalizeAppNetwork(network);
+      const networkMatch =
+        walletNetwork !== null &&
+        expectedNetwork !== null &&
+        walletNetwork === expectedNetwork;
       statuses.push({
         capability: 'view_network',
         allowed: networkMatch,
@@ -754,7 +767,7 @@ export async function refreshWalletSession(
     return {
       walletId,
       address: addressRes.address,
-      network: networkRes.network,
+      network: normalizeFreighterNetwork(networkRes.network),
       isConnected: true,
     };
   }


### PR DESCRIPTION
## Summary
- Fix Freighter `TESTNET` vs app `testnet` false “Wallet permissions required” block (missed when #1150 merged early).
- Stop forcing the legacy BTC/EXT default; prefer native XLM pairs on Stellar-native swaps.
- Mark proven testnet **Stellar → ETH Sepolia** CCTP as catalog-executable (settlement still gates on `/api/v2` readiness / `CCTP_ENABLED`).
- Clarify same-chain vs CCTP route-rail copy/labels so the UI stops looking like a dead end.

## Test plan
- [ ] Hard-refresh Vercel preview after deploy; reconnect Freighter on testnet — permissions banner should clear when wallet is on TESTNET.
- [ ] Stellar native: default pay asset is XLM (not BTC); swap card usable with testnet funds.
- [ ] Stellar → ETH Sepolia tab shows **Executable** (not Coming soon); if API CCTP is off, route panel explains API not ready instead of catalog coming-soon.
- [ ] With `CCTP_ENABLED` API: quote / burn / attest / mint flow reachable with Stellar + Sepolia wallets.
- [ ] `npm --prefix frontend run test -- lib/wallet/index.test.ts hooks/useCrossChainSwapState.test.ts components/swap/cross-chain/CrossChainSwapDeck.test.tsx`