### PR TITLE
fix(deploy): make Caddy installer work non-interactively over SSH

### DIFF
--- a/.github/workflows/deploy-aws-ecr.yml
+++ b/.github/workflows/deploy-aws-ecr.yml
@@ -87,7 +87,11 @@ jobs:
             echo "Missing ECR repository variable for ${{ matrix.name }}"
             exit 1
           fi
-          docker build -f "${{ matrix.file }}" -t "${REPO}:${TAG}" -t "${REPO}:latest" .
-          docker push "${REPO}:${TAG}"
-          docker push "${REPO}:latest"
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            -f "${{ matrix.file }}" \
+            -t "${REPO}:${TAG}" \
+            -t "${REPO}:latest" \
+            --push \
+            .
           echo "Pushed ${REPO}:${TAG}"

--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -1,0 +1,163 @@
+name: Deploy EC2 Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: "Git ref to deploy (default: main)"
+        required: false
+        default: "main"
+  push:
+    branches: [main]
+    paths:
+      - "crates/**"
+      - "deploy/**"
+      - "Dockerfile.api"
+      - "Dockerfile.indexer"
+      - "docker-compose.yml"
+      - "Cargo.toml"
+      - "Cargo.lock"
+      - ".github/workflows/deploy-ec2-staging.yml"
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: deploy-ec2-staging
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    name: Deploy to staging EC2 via SSM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check configuration
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+          STAGING_INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
+        run: |
+          if [[ -z "${AWS_ROLE_ARN}" || -z "${STAGING_INSTANCE_ID}" ]]; then
+            echo "Missing required secrets AWS_ROLE_ARN and/or STAGING_INSTANCE_ID."
+            echo "SKIP=1" >> "${GITHUB_ENV}"
+          else
+            echo "SKIP=0" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Checkout
+        if: env.SKIP != '1'
+        uses: actions/checkout@v4
+
+      - name: Configure AWS credentials (OIDC)
+        if: env.SKIP != '1'
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Resolve deploy inputs
+        if: env.SKIP != '1'
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          INPUT_REF: ${{ github.event.inputs.git_ref }}
+          STAGING_API_BASE_URL: ${{ secrets.STAGING_API_BASE_URL }}
+          STAGING_EC2_HOST: ${{ secrets.STAGING_EC2_HOST }}
+        run: |
+          set -euo pipefail
+          DEPLOY_REF="${INPUT_REF}"
+          if [[ "${EVENT_NAME}" == "push" || -z "${DEPLOY_REF}" ]]; then
+            DEPLOY_REF="main"
+          fi
+
+          if [[ -n "${STAGING_API_BASE_URL}" ]]; then
+            DEPLOY_URL="${STAGING_API_BASE_URL}"
+          elif [[ -n "${STAGING_EC2_HOST}" ]]; then
+            DEPLOY_URL="https://${STAGING_EC2_HOST}.sslip.io"
+          else
+            echo "Set secrets.STAGING_API_BASE_URL or secrets.STAGING_EC2_HOST before running this workflow."
+            exit 1
+          fi
+
+          echo "DEPLOY_REF=${DEPLOY_REF}" >> "${GITHUB_ENV}"
+          echo "DEPLOY_URL=${DEPLOY_URL}" >> "${GITHUB_ENV}"
+
+      - name: Send SSM deploy command
+        if: env.SKIP != '1'
+        id: ssm
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          STAGING_INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
+          DEPLOY_REF: ${{ env.DEPLOY_REF }}
+          DEPLOY_URL: ${{ env.DEPLOY_URL }}
+        run: |
+          set -euo pipefail
+
+          cat > /tmp/ssm-commands.json <<EOF
+          {
+            "commands": [
+              "set -euo pipefail",
+              "cd /opt/stellarroute",
+              "git fetch --all --prune",
+              "git checkout ${DEPLOY_REF}",
+              "git pull --ff-only origin ${DEPLOY_REF}",
+              "bash deploy/aws/scripts/deploy-ec2-staging.sh",
+              "bash deploy/aws/scripts/ec2-postdeploy-smoke.sh ${DEPLOY_URL}"
+            ]
+          }
+          EOF
+
+          COMMAND_ID="$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${STAGING_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Deploy StellarRoute staging from ${GITHUB_REPOSITORY}@${GITHUB_SHA}" \
+            --parameters file:///tmp/ssm-commands.json \
+            --query 'Command.CommandId' \
+            --output text)"
+
+          echo "command_id=${COMMAND_ID}" >> "${GITHUB_OUTPUT}"
+          echo "Started SSM command: ${COMMAND_ID}"
+
+      - name: Wait and print SSM output
+        if: env.SKIP != '1'
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          STAGING_INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
+          COMMAND_ID: ${{ steps.ssm.outputs.command_id }}
+        run: |
+          set -euo pipefail
+          aws ssm wait command-executed \
+            --region "${AWS_REGION}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${STAGING_INSTANCE_ID}"
+
+          aws ssm get-command-invocation \
+            --region "${AWS_REGION}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${STAGING_INSTANCE_ID}" \
+            --query '{Status:Status,StatusDetails:StatusDetails,ResponseCode:ResponseCode,StandardOutputContent:StandardOutputContent,StandardErrorContent:StandardErrorContent}' \
+            --output json
+
+      - name: Fail if remote command failed
+        if: env.SKIP != '1'
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          STAGING_INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
+          COMMAND_ID: ${{ steps.ssm.outputs.command_id }}
+        run: |
+          set -euo pipefail
+          STATUS="$(aws ssm get-command-invocation \
+            --region "${AWS_REGION}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${STAGING_INSTANCE_ID}" \
+            --query 'Status' \
+            --output text)"
+
+          if [[ "${STATUS}" != "Success" ]]; then
+            echo "Remote deploy failed with status: ${STATUS}"
+            exit 1
+          fi
+
+      - name: Skipped
+        if: env.SKIP == '1'
+        run: echo "Deploy skipped because required secrets are not configured."

--- a/.github/workflows/docker-images.yml
+++ b/.github/workflows/docker-images.yml
@@ -76,6 +76,7 @@ jobs:
         with:
           context: .
           file: ${{ matrix.file }}
+          platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/deploy/aws/caddy/Caddyfile.example
+++ b/deploy/aws/caddy/Caddyfile.example
@@ -1,0 +1,8 @@
+{
+  email admin@example.com
+}
+
+api.example.com {
+  encode zstd gzip
+  reverse_proxy 127.0.0.1:8080
+}

--- a/deploy/aws/scripts/bootstrap-ec2.sh
+++ b/deploy/aws/scripts/bootstrap-ec2.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Install Docker Engine + Compose plugin on Ubuntu EC2 for single-host staging.
+# Run as root or via sudo on a fresh instance:
+#   sudo bash deploy/aws/scripts/bootstrap-ec2.sh
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Re-run with sudo: sudo bash $0" >&2
+  exit 1
+fi
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get update -y
+apt-get install -y ca-certificates curl gnupg git jq unzip
+
+install -m 0755 -d /etc/apt/keyrings
+if [[ ! -f /etc/apt/keyrings/docker.asc ]]; then
+  curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+  chmod a+r /etc/apt/keyrings/docker.asc
+fi
+
+ARCH="$(dpkg --print-architecture)"
+CODENAME="$(. /etc/os-release && echo "${VERSION_CODENAME}")"
+echo \
+  "deb [arch=${ARCH} signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu ${CODENAME} stable" \
+  >/etc/apt/sources.list.d/docker.list
+
+apt-get update -y
+apt-get install -y docker-ce docker-ce-cli containerd.io docker-buildx-plugin docker-compose-plugin
+
+systemctl enable --now docker
+
+TARGET_USER="${SUDO_USER:-${USER}}"
+if id "${TARGET_USER}" &>/dev/null; then
+  usermod -aG docker "${TARGET_USER}"
+  echo "Added ${TARGET_USER} to docker group (log out/in for group to apply)."
+fi
+
+# Small ARM and burstable shapes benefit from swap during the first Rust build.
+if [[ ! -f /swapfile ]]; then
+  echo "Creating 4G swapfile for Docker/Rust builds..."
+  fallocate -l 4G /swapfile || dd if=/dev/zero of=/swapfile bs=1M count=4096
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+  if ! grep -q '^/swapfile ' /etc/fstab; then
+    echo '/swapfile none swap sw 0 0' >>/etc/fstab
+  fi
+fi
+
+docker version
+docker compose version
+echo "Bootstrap complete. Next: clone repo, copy deploy/env.prod.example to .env.prod, deploy the compose stack, and install the systemd unit."

--- a/deploy/aws/scripts/deploy-ec2-staging.sh
+++ b/deploy/aws/scripts/deploy-ec2-staging.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Deploy the single-host staging stack on EC2 using Docker Compose.
+# Run from the repo root on the EC2 instance:
+#   bash deploy/aws/scripts/deploy-ec2-staging.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ENV_FILE="${ROOT}/.env.prod"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}. Copy deploy/env.prod.example and fill required values first." >&2
+  exit 1
+fi
+
+required_vars=(
+  POSTGRES_USER
+  POSTGRES_PASSWORD
+  POSTGRES_DB
+  REDIS_PASSWORD
+  SOROBAN_RPC_URL
+  STELLAR_HORIZON_URL
+  ROUTER_CONTRACT_ADDRESS
+  CORS_ALLOWED_ORIGINS
+  ADMIN_AUTH_TOKEN
+)
+
+for key in "${required_vars[@]}"; do
+  if ! grep -Eq "^${key}=.+" "${ENV_FILE}"; then
+    echo "${key} is missing or empty in ${ENV_FILE}" >&2
+    exit 1
+  fi
+done
+
+cd "${ROOT}"
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod config >/dev/null
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod up -d --build
+
+echo "Local health checks:"
+curl -sf http://127.0.0.1:${API_HOST_PORT:-8080}/health && echo " - /health OK"
+curl -sf http://127.0.0.1:${API_HOST_PORT:-8080}/health/deps && echo " - /health/deps OK"

--- a/deploy/aws/scripts/ec2-health-check.sh
+++ b/deploy/aws/scripts/ec2-health-check.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Basic health check for the single-host EC2 staging deployment.
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+DISK_WARN_PERCENT="${DISK_WARN_PERCENT:-85}"
+LOCAL_PORT="${API_HOST_PORT:-8080}"
+
+cd "${ROOT}"
+
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod ps --status running >/dev/null
+systemctl is-active --quiet docker
+systemctl is-active --quiet caddy
+
+root_use="$(df -P / | awk 'NR==2 {gsub(/%/, "", $5); print $5}')"
+if (( root_use >= DISK_WARN_PERCENT )); then
+  echo "Disk usage critical: ${root_use}% used on /" >&2
+  exit 1
+fi
+
+curl -sf "http://127.0.0.1:${LOCAL_PORT}/health" >/dev/null
+curl -sf "http://127.0.0.1:${LOCAL_PORT}/health/deps" >/dev/null
+
+echo "EC2 health check OK: disk=${root_use}% caddy=active docker=active"

--- a/deploy/aws/scripts/ec2-postdeploy-smoke.sh
+++ b/deploy/aws/scripts/ec2-postdeploy-smoke.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# One-command smoke test for the EC2 staging deployment.
+# Run from the EC2 host after the stack and Caddy are up:
+#   bash deploy/aws/scripts/ec2-postdeploy-smoke.sh https://api-staging.example.com
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+PUBLIC_URL="${1:-${STAGING_API_BASE_URL:-}}"
+LOCAL_PORT="${API_HOST_PORT:-8080}"
+
+if [[ -z "${PUBLIC_URL}" ]]; then
+  echo "Usage: bash deploy/aws/scripts/ec2-postdeploy-smoke.sh <public-url>" >&2
+  echo "Example: bash deploy/aws/scripts/ec2-postdeploy-smoke.sh https://api-staging.example.com" >&2
+  exit 1
+fi
+
+PUBLIC_URL="${PUBLIC_URL%/}"
+HOSTNAME_ONLY="${PUBLIC_URL#https://}"
+HOSTNAME_ONLY="${HOSTNAME_ONLY#http://}"
+HOSTNAME_ONLY="${HOSTNAME_ONLY%%/*}"
+
+echo "EC2 staging smoke for ${PUBLIC_URL}"
+
+echo "[1/6] Docker Compose service status"
+cd "${ROOT}"
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod ps
+
+echo "[2/6] Local API health"
+curl -sf "http://127.0.0.1:${LOCAL_PORT}/health" >/dev/null
+curl -sf "http://127.0.0.1:${LOCAL_PORT}/health/deps" >/dev/null
+echo "Local health checks passed on 127.0.0.1:${LOCAL_PORT}"
+
+echo "[3/6] Caddy service state"
+sudo systemctl is-active --quiet caddy
+echo "Caddy is active"
+
+echo "[4/6] DNS resolution"
+getent hosts "${HOSTNAME_ONLY}" || host "${HOSTNAME_ONLY}" || nslookup "${HOSTNAME_ONLY}"
+
+echo "[5/6] Public HTTPS health"
+curl -sf "${PUBLIC_URL}/health" >/dev/null
+curl -sf "${PUBLIC_URL}/health/deps" >/dev/null
+echo "Public HTTPS health checks passed"
+
+echo "[6/6] Full API smoke"
+STAGING_API_BASE_URL="${PUBLIC_URL}" "${ROOT}/scripts/staging-smoke.sh"
+
+echo "EC2 post-deploy smoke passed."

--- a/deploy/aws/scripts/ec2-staging-start.sh
+++ b/deploy/aws/scripts/ec2-staging-start.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Start the staging EC2 instance and wait until it is running.
+#
+# Usage:
+#   bash deploy/aws/scripts/ec2-staging-start.sh
+#
+# Optional overrides:
+#   AWS_REGION=us-east-1 STAGING_INSTANCE_ID=i-xxxxxxxx bash deploy/aws/scripts/ec2-staging-start.sh
+#   AWS_REGION=us-east-1 STAGING_INSTANCE_NAME=stellarroute-staging-ec2 bash deploy/aws/scripts/ec2-staging-start.sh
+set -euo pipefail
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+STAGING_INSTANCE_ID="${STAGING_INSTANCE_ID:-}"
+STAGING_INSTANCE_NAME="${STAGING_INSTANCE_NAME:-stellarroute-staging-ec2}"
+
+resolve_instance_id() {
+  if [[ -n "${STAGING_INSTANCE_ID}" ]]; then
+    echo "${STAGING_INSTANCE_ID}"
+    return 0
+  fi
+
+  aws ec2 describe-instances \
+    --region "${AWS_REGION}" \
+    --filters \
+      "Name=tag:Name,Values=${STAGING_INSTANCE_NAME}" \
+      "Name=instance-state-name,Values=running,stopped,stopping,pending" \
+    --query 'Reservations[].Instances[].InstanceId' \
+    --output text
+}
+
+INSTANCE_ID="$(resolve_instance_id)"
+
+if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "None" ]]; then
+  echo "Could not find staging instance. Set STAGING_INSTANCE_ID or verify Name tag ${STAGING_INSTANCE_NAME}." >&2
+  exit 1
+fi
+
+CURRENT_STATE="$(aws ec2 describe-instances \
+  --region "${AWS_REGION}" \
+  --instance-ids "${INSTANCE_ID}" \
+  --query 'Reservations[0].Instances[0].State.Name' \
+  --output text)"
+
+if [[ "${CURRENT_STATE}" == "running" ]]; then
+  echo "Instance ${INSTANCE_ID} is already running."
+else
+  echo "Starting instance ${INSTANCE_ID} in ${AWS_REGION}..."
+  aws ec2 start-instances --region "${AWS_REGION}" --instance-ids "${INSTANCE_ID}" >/dev/null
+  aws ec2 wait instance-running --region "${AWS_REGION}" --instance-ids "${INSTANCE_ID}"
+fi
+
+PUBLIC_IP="$(aws ec2 describe-instances \
+  --region "${AWS_REGION}" \
+  --instance-ids "${INSTANCE_ID}" \
+  --query 'Reservations[0].Instances[0].PublicIpAddress' \
+  --output text)"
+
+PUBLIC_DNS="$(aws ec2 describe-instances \
+  --region "${AWS_REGION}" \
+  --instance-ids "${INSTANCE_ID}" \
+  --query 'Reservations[0].Instances[0].PublicDnsName' \
+  --output text)"
+
+echo "Staging instance is running."
+echo "  Instance ID: ${INSTANCE_ID}"
+echo "  Public IP:   ${PUBLIC_IP}"
+echo "  Public DNS:  ${PUBLIC_DNS}"
+echo ""
+echo "Next steps:"
+echo "  1. SSH: ssh -i <your-key> ubuntu@${PUBLIC_IP}"
+echo "  2. Check API: curl http://${PUBLIC_IP}:8080/health"

--- a/deploy/aws/scripts/ec2-staging-stop.sh
+++ b/deploy/aws/scripts/ec2-staging-stop.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Stop the staging EC2 instance and wait until it is stopped.
+#
+# Usage:
+#   bash deploy/aws/scripts/ec2-staging-stop.sh
+#
+# Optional overrides:
+#   AWS_REGION=us-east-1 STAGING_INSTANCE_ID=i-xxxxxxxx bash deploy/aws/scripts/ec2-staging-stop.sh
+#   AWS_REGION=us-east-1 STAGING_INSTANCE_NAME=stellarroute-staging-ec2 bash deploy/aws/scripts/ec2-staging-stop.sh
+set -euo pipefail
+
+AWS_REGION="${AWS_REGION:-us-east-1}"
+STAGING_INSTANCE_ID="${STAGING_INSTANCE_ID:-}"
+STAGING_INSTANCE_NAME="${STAGING_INSTANCE_NAME:-stellarroute-staging-ec2}"
+
+resolve_instance_id() {
+  if [[ -n "${STAGING_INSTANCE_ID}" ]]; then
+    echo "${STAGING_INSTANCE_ID}"
+    return 0
+  fi
+
+  aws ec2 describe-instances \
+    --region "${AWS_REGION}" \
+    --filters \
+      "Name=tag:Name,Values=${STAGING_INSTANCE_NAME}" \
+      "Name=instance-state-name,Values=running,stopped,stopping,pending" \
+    --query 'Reservations[].Instances[].InstanceId' \
+    --output text
+}
+
+INSTANCE_ID="$(resolve_instance_id)"
+
+if [[ -z "${INSTANCE_ID}" || "${INSTANCE_ID}" == "None" ]]; then
+  echo "Could not find staging instance. Set STAGING_INSTANCE_ID or verify Name tag ${STAGING_INSTANCE_NAME}." >&2
+  exit 1
+fi
+
+CURRENT_STATE="$(aws ec2 describe-instances \
+  --region "${AWS_REGION}" \
+  --instance-ids "${INSTANCE_ID}" \
+  --query 'Reservations[0].Instances[0].State.Name' \
+  --output text)"
+
+if [[ "${CURRENT_STATE}" == "stopped" ]]; then
+  echo "Instance ${INSTANCE_ID} is already stopped."
+  exit 0
+fi
+
+echo "Stopping instance ${INSTANCE_ID} in ${AWS_REGION}..."
+aws ec2 stop-instances --region "${AWS_REGION}" --instance-ids "${INSTANCE_ID}" >/dev/null
+aws ec2 wait instance-stopped --region "${AWS_REGION}" --instance-ids "${INSTANCE_ID}"
+
+echo "Staging instance stopped."
+echo "  Instance ID: ${INSTANCE_ID}"

--- a/deploy/aws/scripts/install-caddy.sh
+++ b/deploy/aws/scripts/install-caddy.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Install Caddy on Ubuntu and configure HTTPS reverse proxy for the staging API.
+# Example:
+#   sudo bash deploy/aws/scripts/install-caddy.sh api.example.com ops@example.com
+set -euo pipefail
+
+if [[ "${EUID}" -ne 0 ]]; then
+  echo "Re-run with sudo: sudo bash $0 <domain> [email]" >&2
+  exit 1
+fi
+
+DOMAIN="${1:-}"
+EMAIL="${2:-}"
+
+if [[ -z "${DOMAIN}" ]]; then
+  echo "Usage: sudo bash $0 <domain> [email]" >&2
+  exit 1
+fi
+
+apt-get update -y
+apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl gnupg
+
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
+chmod o+r /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+chmod o+r /etc/apt/sources.list.d/caddy-stable.list
+
+apt-get update -y
+apt-get install -y caddy
+
+if [[ -n "${EMAIL}" ]]; then
+  cat >/etc/caddy/Caddyfile <<EOF
+{
+  email ${EMAIL}
+}
+
+${DOMAIN} {
+  encode zstd gzip
+  reverse_proxy 127.0.0.1:8080
+}
+EOF
+else
+  cat >/etc/caddy/Caddyfile <<EOF
+${DOMAIN} {
+  encode zstd gzip
+  reverse_proxy 127.0.0.1:8080
+}
+EOF
+fi
+
+caddy fmt --overwrite /etc/caddy/Caddyfile
+systemctl enable --now caddy
+systemctl reload caddy
+systemctl status caddy --no-pager
+
+echo "Caddy configured for https://${DOMAIN} -> http://127.0.0.1:8080"
+echo "Ensure DNS for ${DOMAIN} points to this instance and ports 80/443 are open."

--- a/deploy/aws/scripts/install-caddy.sh
+++ b/deploy/aws/scripts/install-caddy.sh
@@ -21,7 +21,7 @@ apt-get update -y
 apt-get install -y debian-keyring debian-archive-keyring apt-transport-https curl gnupg
 
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
-  | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+  | gpg --batch --yes --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
 curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
   | tee /etc/apt/sources.list.d/caddy-stable.list >/dev/null
 chmod o+r /usr/share/keyrings/caddy-stable-archive-keyring.gpg

--- a/deploy/aws/scripts/postgres-backup.sh
+++ b/deploy/aws/scripts/postgres-backup.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Create a compressed Postgres backup from the EC2 single-host staging stack.
+# Example:
+#   sudo bash deploy/aws/scripts/postgres-backup.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ENV_FILE="${ROOT}/.env.prod"
+BACKUP_DIR="${BACKUP_DIR:-/var/backups/stellarroute-postgres}"
+CONTAINER_NAME="${POSTGRES_CONTAINER_NAME:-stellarroute-postgres}"
+RETENTION_DAYS="${RETENTION_DAYS:-7}"
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}." >&2
+  exit 1
+fi
+
+set -a
+source "${ENV_FILE}"
+set +a
+
+: "${POSTGRES_USER:?POSTGRES_USER is required in .env.prod}"
+: "${POSTGRES_DB:?POSTGRES_DB is required in .env.prod}"
+
+mkdir -p "${BACKUP_DIR}"
+timestamp="$(date -u +%Y%m%dT%H%M%SZ)"
+outfile="${BACKUP_DIR}/${POSTGRES_DB}-${timestamp}.sql.gz"
+
+docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"
+
+docker exec -e PGPASSWORD="${POSTGRES_PASSWORD:-}" "${CONTAINER_NAME}" \
+  pg_dump -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+  | gzip -9 >"${outfile}"
+
+find "${BACKUP_DIR}" -type f -name '*.sql.gz' -mtime +"${RETENTION_DAYS}" -delete
+
+echo "Backup created: ${outfile}"

--- a/deploy/aws/scripts/postgres-restore.sh
+++ b/deploy/aws/scripts/postgres-restore.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# Restore a compressed Postgres backup into the EC2 single-host staging stack.
+# Example:
+#   sudo bash deploy/aws/scripts/postgres-restore.sh /var/backups/stellarroute-postgres/stellarroute-20260803T120000Z.sql.gz --yes
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+ENV_FILE="${ROOT}/.env.prod"
+CONTAINER_NAME="${POSTGRES_CONTAINER_NAME:-stellarroute-postgres}"
+
+BACKUP_FILE="${1:-}"
+CONFIRM="${2:-}"
+
+if [[ -z "${BACKUP_FILE}" || "${CONFIRM}" != "--yes" ]]; then
+  echo "Usage: sudo bash deploy/aws/scripts/postgres-restore.sh <backup.sql.gz> --yes" >&2
+  exit 1
+fi
+
+if [[ ! -f "${BACKUP_FILE}" ]]; then
+  echo "Backup file not found: ${BACKUP_FILE}" >&2
+  exit 1
+fi
+
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}." >&2
+  exit 1
+fi
+
+set -a
+source "${ENV_FILE}"
+set +a
+
+: "${POSTGRES_USER:?POSTGRES_USER is required in .env.prod}"
+: "${POSTGRES_DB:?POSTGRES_DB is required in .env.prod}"
+
+docker ps --format '{{.Names}}' | grep -qx "${CONTAINER_NAME}"
+
+echo "Stopping API and indexer to avoid writes during restore..."
+cd "${ROOT}"
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod stop api indexer
+
+restore_exit=0
+if ! docker exec -e PGPASSWORD="${POSTGRES_PASSWORD:-}" "${CONTAINER_NAME}" \
+  psql -U "${POSTGRES_USER}" -d postgres -v ON_ERROR_STOP=1 \
+  -c "SELECT pg_terminate_backend(pid) FROM pg_stat_activity WHERE datname = '${POSTGRES_DB}' AND pid <> pg_backend_pid();" \
+  -c "DROP DATABASE IF EXISTS \"${POSTGRES_DB}\";" \
+  -c "CREATE DATABASE \"${POSTGRES_DB}\";"; then
+  restore_exit=1
+fi
+
+if [[ "${restore_exit}" -eq 0 ]]; then
+  if ! gzip -dc "${BACKUP_FILE}" | docker exec -i -e PGPASSWORD="${POSTGRES_PASSWORD:-}" "${CONTAINER_NAME}" \
+    psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1; then
+    restore_exit=1
+  fi
+fi
+
+echo "Restarting API and indexer..."
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod up -d api indexer
+
+if [[ "${restore_exit}" -ne 0 ]]; then
+  echo "Restore failed." >&2
+  exit 1
+fi
+
+echo "Restore completed from ${BACKUP_FILE}"

--- a/deploy/aws/scripts/push-images.sh
+++ b/deploy/aws/scripts/push-images.sh
@@ -7,6 +7,7 @@ ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
 TF_DIR="${ROOT}/deploy/aws/terraform"
 IMAGE_TAG="${IMAGE_TAG:-$(git -C "${ROOT}" rev-parse --short HEAD)}"
 PUSH_LATEST="${PUSH_LATEST:-1}"
+DOCKER_PLATFORMS="${DOCKER_PLATFORMS:-linux/amd64}"
 
 AWS_REGION="${AWS_REGION:-}"
 if [[ -z "${AWS_REGION}" && -f "${TF_DIR}/terraform.tfvars" ]]; then
@@ -23,24 +24,30 @@ echo "==> Logging into ECR ${ACCOUNT_ID} (${AWS_REGION})"
 aws ecr get-login-password --region "${AWS_REGION}" \
   | docker login --username AWS --password-stdin "${ACCOUNT_ID}.dkr.ecr.${AWS_REGION}.amazonaws.com"
 
+docker buildx inspect >/dev/null 2>&1 || docker buildx create --use
+
 echo "==> Building API → ${API_REPO}:${IMAGE_TAG}"
-docker build -f "${ROOT}/Dockerfile.api" -t "${API_REPO}:${IMAGE_TAG}" "${ROOT}"
-docker push "${API_REPO}:${IMAGE_TAG}"
+docker buildx build \
+  --platform "${DOCKER_PLATFORMS}" \
+  -f "${ROOT}/Dockerfile.api" \
+  -t "${API_REPO}:${IMAGE_TAG}" \
+  $( [[ "${PUSH_LATEST}" == "1" ]] && printf '%s ' -t "${API_REPO}:latest" ) \
+  --push \
+  "${ROOT}"
 
 echo "==> Building indexer → ${INDEXER_REPO}:${IMAGE_TAG}"
-docker build -f "${ROOT}/Dockerfile.indexer" -t "${INDEXER_REPO}:${IMAGE_TAG}" "${ROOT}"
-docker push "${INDEXER_REPO}:${IMAGE_TAG}"
-
-if [[ "${PUSH_LATEST}" == "1" ]]; then
-  docker tag "${API_REPO}:${IMAGE_TAG}" "${API_REPO}:latest"
-  docker tag "${INDEXER_REPO}:${IMAGE_TAG}" "${INDEXER_REPO}:latest"
-  docker push "${API_REPO}:latest"
-  docker push "${INDEXER_REPO}:latest"
-fi
+docker buildx build \
+  --platform "${DOCKER_PLATFORMS}" \
+  -f "${ROOT}/Dockerfile.indexer" \
+  -t "${INDEXER_REPO}:${IMAGE_TAG}" \
+  $( [[ "${PUSH_LATEST}" == "1" ]] && printf '%s ' -t "${INDEXER_REPO}:latest" ) \
+  --push \
+  "${ROOT}"
 
 echo "==> Done"
 echo "    API:     ${API_REPO}:${IMAGE_TAG}"
 echo "    Indexer: ${INDEXER_REPO}:${IMAGE_TAG}"
+echo "    Platforms: ${DOCKER_PLATFORMS}"
 echo
 CLUSTER="$(terraform output -raw ecs_cluster_name)"
 API_SVC="$(terraform output -raw api_service_name)"

--- a/deploy/aws/systemd/stellarroute-healthcheck.service
+++ b/deploy/aws/systemd/stellarroute-healthcheck.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=StellarRoute EC2 health check
+After=docker.service caddy.service stellarroute-staging.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/stellarroute
+ExecStart=/bin/bash /opt/stellarroute/deploy/aws/scripts/ec2-health-check.sh

--- a/deploy/aws/systemd/stellarroute-healthcheck.timer
+++ b/deploy/aws/systemd/stellarroute-healthcheck.timer
@@ -1,0 +1,11 @@
+[Unit]
+Description=Run StellarRoute EC2 health check every 5 minutes
+
+[Timer]
+OnBootSec=3m
+OnUnitActiveSec=5m
+Persistent=true
+Unit=stellarroute-healthcheck.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/aws/systemd/stellarroute-postgres-backup.service
+++ b/deploy/aws/systemd/stellarroute-postgres-backup.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=StellarRoute Postgres backup
+After=docker.service stellarroute-staging.service
+Requires=docker.service
+
+[Service]
+Type=oneshot
+WorkingDirectory=/opt/stellarroute
+ExecStart=/bin/bash /opt/stellarroute/deploy/aws/scripts/postgres-backup.sh

--- a/deploy/aws/systemd/stellarroute-postgres-backup.timer
+++ b/deploy/aws/systemd/stellarroute-postgres-backup.timer
@@ -1,0 +1,10 @@
+[Unit]
+Description=Run StellarRoute Postgres backup daily
+
+[Timer]
+OnCalendar=*-*-* 03:15:00
+Persistent=true
+Unit=stellarroute-postgres-backup.service
+
+[Install]
+WantedBy=timers.target

--- a/deploy/aws/systemd/stellarroute-staging.service
+++ b/deploy/aws/systemd/stellarroute-staging.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=StellarRoute staging stack (Docker Compose)
+Requires=docker.service
+After=docker.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+WorkingDirectory=/opt/stellarroute
+ExecStart=/usr/bin/docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod up -d
+ExecStop=/usr/bin/docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod down
+TimeoutStartSec=0
+
+[Install]
+WantedBy=multi-user.target

--- a/deploy/aws/terraform/data.tf
+++ b/deploy/aws/terraform/data.tf
@@ -33,11 +33,13 @@ resource "aws_db_instance" "main" {
 }
 
 resource "aws_elasticache_subnet_group" "main" {
+  count      = var.enable_redis ? 1 : 0
   name       = "${local.name}-redis"
   subnet_ids = aws_subnet.private[*].id
 }
 
 resource "aws_elasticache_replication_group" "main" {
+  count                      = var.enable_redis ? 1 : 0
   replication_group_id       = "${local.name}-redis"
   description                = "StellarRoute quote cache / rate limits"
   engine                     = "redis"
@@ -46,7 +48,7 @@ resource "aws_elasticache_replication_group" "main" {
   num_cache_clusters         = 1
   port                       = 6379
   parameter_group_name       = "default.redis7"
-  subnet_group_name          = aws_elasticache_subnet_group.main.name
+  subnet_group_name          = aws_elasticache_subnet_group.main[0].name
   security_group_ids         = [aws_security_group.redis.id]
   at_rest_encryption_enabled = true
   # Transit encryption + AUTH require a TLS-capable redis client (rediss://).
@@ -69,9 +71,9 @@ locals {
     var.db_name,
   )
 
-  redis_url = format(
+  redis_url = var.enable_redis ? format(
     "redis://%s:%d",
-    aws_elasticache_replication_group.main.primary_endpoint_address,
-    aws_elasticache_replication_group.main.port,
-  )
+    aws_elasticache_replication_group.main[0].primary_endpoint_address,
+    aws_elasticache_replication_group.main[0].port,
+  ) : ""
 }

--- a/deploy/aws/terraform/ecs.tf
+++ b/deploy/aws/terraform/ecs.tf
@@ -9,6 +9,18 @@ resource "aws_ecs_cluster" "main" {
   tags = { Name = local.name }
 }
 
+# FARGATE_SPOT is opt-in per service via indexer_use_fargate_spot; always
+# registering both providers here keeps the cluster ready without cost impact.
+resource "aws_ecs_cluster_capacity_providers" "main" {
+  cluster_name       = aws_ecs_cluster.main.name
+  capacity_providers = ["FARGATE", "FARGATE_SPOT"]
+
+  default_capacity_provider_strategy {
+    capacity_provider = "FARGATE"
+    weight            = 1
+  }
+}
+
 locals {
   secret_arn = aws_secretsmanager_secret.app.arn
 
@@ -56,6 +68,11 @@ resource "aws_ecs_task_definition" "api" {
   execution_role_arn       = aws_iam_role.ecs_execution.arn
   task_role_arn            = aws_iam_role.ecs_task.arn
 
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = var.cpu_architecture
+  }
+
   container_definitions = jsonencode([
     {
       name      = "api"
@@ -99,6 +116,11 @@ resource "aws_ecs_task_definition" "indexer" {
   execution_role_arn       = aws_iam_role.ecs_execution.arn
   task_role_arn            = aws_iam_role.ecs_task.arn
 
+  runtime_platform {
+    operating_system_family = "LINUX"
+    cpu_architecture        = var.cpu_architecture
+  }
+
   container_definitions = jsonencode([
     {
       name      = "indexer"
@@ -128,9 +150,9 @@ resource "aws_ecs_service" "api" {
   launch_type     = "FARGATE"
 
   network_configuration {
-    subnets          = aws_subnet.private[*].id
+    subnets          = var.ecs_use_public_subnets ? aws_subnet.public[*].id : aws_subnet.private[*].id
     security_groups  = [aws_security_group.ecs.id]
-    assign_public_ip = false
+    assign_public_ip = var.ecs_use_public_subnets
   }
 
   load_balancer {
@@ -155,12 +177,20 @@ resource "aws_ecs_service" "indexer" {
   cluster         = aws_ecs_cluster.main.id
   task_definition = aws_ecs_task_definition.indexer.arn
   desired_count   = var.indexer_desired_count
-  launch_type     = "FARGATE"
+  launch_type     = var.indexer_use_fargate_spot ? null : "FARGATE"
+
+  dynamic "capacity_provider_strategy" {
+    for_each = var.indexer_use_fargate_spot ? [1] : []
+    content {
+      capacity_provider = "FARGATE_SPOT"
+      weight            = 100
+    }
+  }
 
   network_configuration {
-    subnets          = aws_subnet.private[*].id
+    subnets          = var.ecs_use_public_subnets ? aws_subnet.public[*].id : aws_subnet.private[*].id
     security_groups  = [aws_security_group.ecs.id]
-    assign_public_ip = false
+    assign_public_ip = var.ecs_use_public_subnets
   }
 
   deployment_minimum_healthy_percent = 0
@@ -168,6 +198,7 @@ resource "aws_ecs_service" "indexer" {
 
   depends_on = [
     aws_secretsmanager_secret_version.app,
+    aws_ecs_cluster_capacity_providers.main,
   ]
 
   tags = { Name = "${local.name}-indexer" }

--- a/deploy/aws/terraform/outputs.tf
+++ b/deploy/aws/terraform/outputs.tf
@@ -60,7 +60,7 @@ output "rds_endpoint" {
 }
 
 output "redis_endpoint" {
-  value = aws_elasticache_replication_group.main.primary_endpoint_address
+  value = var.enable_redis ? aws_elasticache_replication_group.main[0].primary_endpoint_address : null
 }
 
 output "cloudwatch_api_log_group" {

--- a/deploy/aws/terraform/terraform.staging.lowcost.tfvars
+++ b/deploy/aws/terraform/terraform.staging.lowcost.tfvars
@@ -1,0 +1,38 @@
+aws_region   = "us-east-1"
+project_name = "stellarroute"
+environment  = "staging"
+
+# Must match region AZs
+availability_zones = ["us-east-1a", "us-east-1b"]
+
+# Fill this once ACM is issued in us-east-1 for api.<your-domain>
+certificate_arn = ""
+
+# Pin these to a git SHA after the first image push.
+api_image_tag     = "latest"
+indexer_image_tag = "latest"
+
+# Lowest-cost always-on staging profile.
+api_cpu           = 256
+api_memory        = 512
+api_desired_count = 1
+
+indexer_cpu           = 256
+indexer_memory        = 512
+indexer_desired_count = 1
+
+db_instance_class       = "db.t4g.micro"
+db_allocated_storage    = 20
+rds_deletion_protection = false
+
+redis_node_type = "cache.t4g.micro"
+
+# Run ECS tasks in public subnets to avoid NAT Gateway fixed cost.
+ecs_use_public_subnets   = true
+enable_nat_gateway       = false
+single_nat_gateway       = true
+enable_redis             = false
+indexer_use_fargate_spot = true
+
+# Switch to ARM64 only after publishing multi-arch images and verifying startup.
+cpu_architecture = "X86_64"

--- a/deploy/aws/terraform/terraform.tfvars.example
+++ b/deploy/aws/terraform/terraform.tfvars.example
@@ -28,3 +28,14 @@ redis_node_type = "cache.t4g.micro"
 
 enable_nat_gateway = true
 single_nat_gateway = true
+
+# ── Lowest-cost staging profile (see docs/deployment/aws.md#cost-sketch) ─────
+# Uncomment to cut the ~$32+/mo NAT Gateway and ~$12+/mo ElastiCache node:
+# ecs_use_public_subnets  = true   # tasks get public IPs; SGs still block all inbound except ALB->API
+# enable_nat_gateway      = false  # only safe once ecs_use_public_subnets = true
+# enable_redis            = false  # REDIS_URL is optional at the app layer
+# indexer_use_fargate_spot = true  # ~70% cheaper; indexer is a single restart-safe worker
+# api_cpu    = 256
+# api_memory = 512
+# indexer_cpu    = 256
+# indexer_memory = 512

--- a/deploy/aws/terraform/variables.tf
+++ b/deploy/aws/terraform/variables.tf
@@ -110,7 +110,7 @@ variable "redis_node_type" {
 
 variable "enable_nat_gateway" {
   type        = bool
-  description = "Required for Fargate tasks in private subnets to reach Horizon/Soroban/ECR."
+  description = "Required for Fargate tasks in private subnets to reach Horizon/Soroban/ECR. Set to false (and set ecs_use_public_subnets=true) to eliminate the ~$32+/mo NAT Gateway cost entirely for staging."
   default     = true
 }
 
@@ -118,4 +118,32 @@ variable "single_nat_gateway" {
   type        = bool
   description = "One NAT for all private subnets (cheaper staging)."
   default     = true
+}
+
+variable "ecs_use_public_subnets" {
+  type        = bool
+  description = "Run ECS tasks directly in public subnets with public IPs instead of NAT-routed private subnets. Security groups still block all inbound traffic except ALB->API, so this is safe for staging and removes the need for a NAT Gateway. Pair with enable_nat_gateway=false for the lowest-cost setup."
+  default     = false
+}
+
+variable "indexer_use_fargate_spot" {
+  type        = bool
+  description = "Run the indexer task on Fargate Spot (~70% cheaper than on-demand). Safe for the indexer because it is a single, restart-safe worker; not recommended for the user-facing API service."
+  default     = false
+}
+
+variable "enable_redis" {
+  type        = bool
+  description = "Provision ElastiCache Redis. REDIS_URL is optional at the application layer (quote caching/rate limiting degrade gracefully without it) — set to false to skip ElastiCache entirely and save its node + data-transfer cost for early staging."
+  default     = true
+}
+
+variable "cpu_architecture" {
+  type        = string
+  description = "Fargate CPU architecture. ARM64 (Graviton) is ~20% cheaper per vCPU/GB-hour than X86_64, but requires multi-arch Docker images (docker buildx --platform linux/amd64,linux/arm64). Verify Dockerfile.api/Dockerfile.indexer build cleanly for arm64 before switching."
+  default     = "X86_64"
+  validation {
+    condition     = contains(["X86_64", "ARM64"], var.cpu_architecture)
+    error_message = "cpu_architecture must be X86_64 or ARM64."
+  }
 }

--- a/docs/deployment/aws-ec2-staging.md
+++ b/docs/deployment/aws-ec2-staging.md
@@ -24,6 +24,7 @@ Related files:
 - `deploy/aws/scripts/ec2-postdeploy-smoke.sh`
 - `deploy/aws/scripts/ec2-health-check.sh`
 - `deploy/aws/scripts/install-caddy.sh`
+- `.github/workflows/deploy-ec2-staging.yml`
 - `deploy/aws/scripts/postgres-backup.sh`
 - `deploy/aws/scripts/postgres-restore.sh`
 - `deploy/aws/systemd/stellarroute-healthcheck.timer`
@@ -356,3 +357,51 @@ Move to ECS/RDS later if any of these become true:
 - you want managed Postgres durability and easier restores
 - you need cleaner service isolation
 - one VM becomes an operational bottleneck
+
+## 11. Auto-update EC2 from GitHub (main branch)
+
+This repo now includes:
+
+- `.github/workflows/deploy-ec2-staging.yml`
+
+What it does:
+
+- triggers on pushes to `main` (for backend/deploy path changes)
+- can also run manually from Actions via `workflow_dispatch`
+- uses AWS Systems Manager (SSM) Run Command to execute deploy steps on EC2
+- runs:
+  - `git fetch` + `git checkout` + `git pull --ff-only`
+  - `bash deploy/aws/scripts/deploy-ec2-staging.sh`
+  - `bash deploy/aws/scripts/ec2-postdeploy-smoke.sh <staging-url>`
+
+Why SSM instead of SSH from Actions:
+
+- no inbound port `22` required for GitHub runners
+- avoids dynamic GitHub runner IP allowlist maintenance
+
+Required GitHub repository secrets:
+
+- `AWS_ROLE_ARN` (IAM role assumed by OIDC)
+- `STAGING_INSTANCE_ID` (for example, `i-073051e6b1dccd329`)
+- optional `AWS_REGION` (defaults to `us-east-1`)
+- one of:
+  - `STAGING_API_BASE_URL` (recommended, for example `https://34.224.110.144.sslip.io`)
+  - or `STAGING_EC2_HOST` (workflow will derive `https://<host>.sslip.io`)
+
+IAM role policy must allow at least:
+
+- `ssm:SendCommand`
+- `ssm:GetCommandInvocation`
+- `ssm:ListCommandInvocations`
+- `ec2:DescribeInstances`
+
+The EC2 instance must be managed by SSM:
+
+- SSM Agent installed/running (Ubuntu AMIs usually include this)
+- instance IAM role/profile allowing SSM agent registration (for example `AmazonSSMManagedInstanceCore`)
+
+Manual run:
+
+1. Open GitHub Actions.
+2. Run workflow `Deploy EC2 Staging`.
+3. (Optional) set `git_ref`.

--- a/docs/deployment/aws-ec2-staging.md
+++ b/docs/deployment/aws-ec2-staging.md
@@ -1,0 +1,358 @@
+# AWS EC2 Staging Deployment
+
+For one staging deployment, this is the best AWS path for StellarRoute.
+
+Why this path wins:
+
+- Lowest fixed monthly cost on AWS
+- Simpler than ECS + ALB + RDS + ElastiCache
+- Reuses the repo's existing Docker Compose production overlay
+- Good enough for one low-traffic staging environment
+
+This is not the most production-shaped AWS setup. It is the most efficient one
+for a single staging environment.
+
+Related files:
+
+- `deploy/docker-compose.prod.yml`
+- `deploy/env.prod.example`
+- `deploy/aws/caddy/Caddyfile.example`
+- `deploy/aws/scripts/bootstrap-ec2.sh`
+- `deploy/aws/scripts/deploy-ec2-staging.sh`
+- `deploy/aws/scripts/ec2-staging-start.sh`
+- `deploy/aws/scripts/ec2-staging-stop.sh`
+- `deploy/aws/scripts/ec2-postdeploy-smoke.sh`
+- `deploy/aws/scripts/ec2-health-check.sh`
+- `deploy/aws/scripts/install-caddy.sh`
+- `deploy/aws/scripts/postgres-backup.sh`
+- `deploy/aws/scripts/postgres-restore.sh`
+- `deploy/aws/systemd/stellarroute-healthcheck.timer`
+- `deploy/aws/systemd/stellarroute-postgres-backup.timer`
+- `deploy/aws/systemd/stellarroute-staging.service`
+- `docs/deployment/vercel-frontend.md`
+- `docs/deployment/aws-staging-cost-estimate.md`
+
+## Recommended instance
+
+Start with one of these Graviton instances in `us-east-1`:
+
+- `t4g.small` for the cheapest start
+- `t4g.medium` if you want more headroom for builds, indexer bursts, and Docker memory pressure
+
+Suggested storage:
+
+- 30-50 GB gp3 EBS
+
+Suggested OS:
+
+- Ubuntu 24.04 LTS
+
+## Security group
+
+Allow inbound:
+
+- `22/tcp` from your IP only
+- `80/tcp` from `0.0.0.0/0` only if using HTTP-to-HTTPS redirect on-box
+- `443/tcp` from `0.0.0.0/0` if terminating TLS on the instance
+
+Do not allow inbound:
+
+- `5432/tcp`
+- `6379/tcp`
+
+Outbound can remain open.
+
+## Cost shape
+
+The EC2 single-host path is cheaper than the ECS path because it avoids:
+
+- ALB fixed monthly cost
+- NAT Gateway fixed monthly cost
+- RDS fixed monthly cost
+- ElastiCache fixed monthly cost
+
+Directional monthly range for one always-on staging VM:
+
+- `t4g.small` + 30-50 GB gp3: roughly `$18-$35/month`
+- `t4g.medium` + 30-50 GB gp3: roughly `$28-$50/month`
+
+These estimates exclude unusual bandwidth spikes and optional extras such as
+Route 53, CloudWatch retention beyond basics, or external monitoring vendors.
+
+## 1. Create the instance
+
+In EC2:
+
+1. Launch one Ubuntu 24.04 LTS ARM instance.
+2. Instance type: `t4g.small` or `t4g.medium`.
+3. Root volume: gp3, 30-50 GB.
+4. Attach the security group described above.
+5. Attach your SSH key.
+6. Create a DNS record such as `api-staging.<your-domain>` pointing at the instance public IP before enabling Caddy.
+
+## 2. Bootstrap the host
+
+SSH into the instance and run:
+
+```bash
+sudo bash deploy/aws/scripts/bootstrap-ec2.sh
+```
+
+If the repo is not on the box yet:
+
+```bash
+sudo mkdir -p /opt
+sudo chown "$USER":"$USER" /opt
+git clone https://github.com/StellarRoute/StellarRoute.git /opt/stellarroute
+cd /opt/stellarroute
+sudo bash deploy/aws/scripts/bootstrap-ec2.sh
+```
+
+Log out and back in so the `docker` group applies.
+
+## 3. Fill environment variables
+
+From the repo root on the instance:
+
+```bash
+cd /opt/stellarroute
+cp deploy/env.prod.example .env.prod
+```
+
+Fill at least:
+
+- `POSTGRES_USER`
+- `POSTGRES_PASSWORD`
+- `POSTGRES_DB`
+- `REDIS_PASSWORD`
+- `SOROBAN_RPC_URL`
+- `STELLAR_HORIZON_URL`
+- `ROUTER_CONTRACT_ADDRESS`
+- `CORS_ALLOWED_ORIGINS`
+- `ADMIN_AUTH_TOKEN`
+
+Keep:
+
+- `STELLARROUTE_ENV=production`
+- `ENABLE_ADMIN_ROUTES=false`
+- `API_HOST_PORT=8080`
+
+## 4. Deploy the stack
+
+Run:
+
+```bash
+cd /opt/stellarroute
+bash deploy/aws/scripts/deploy-ec2-staging.sh
+```
+
+This validates `.env.prod`, renders the merged Compose config, builds the
+images, and starts the API, indexer, Postgres, and Redis.
+
+## 5. Install the systemd unit
+
+This makes the stack come back after a reboot.
+
+```bash
+cd /opt/stellarroute
+sudo cp deploy/aws/systemd/stellarroute-staging.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now stellarroute-staging.service
+sudo systemctl status stellarroute-staging.service
+```
+
+The unit assumes the repo lives at `/opt/stellarroute`.
+
+## 5b. Enable backups and basic monitoring
+
+For the single-host setup, use local compressed Postgres dumps plus lightweight
+systemd timers.
+
+Install the timers:
+
+```bash
+cd /opt/stellarroute
+sudo cp deploy/aws/systemd/stellarroute-postgres-backup.service /etc/systemd/system/
+sudo cp deploy/aws/systemd/stellarroute-postgres-backup.timer /etc/systemd/system/
+sudo cp deploy/aws/systemd/stellarroute-healthcheck.service /etc/systemd/system/
+sudo cp deploy/aws/systemd/stellarroute-healthcheck.timer /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now stellarroute-postgres-backup.timer
+sudo systemctl enable --now stellarroute-healthcheck.timer
+systemctl list-timers --all | grep stellarroute
+```
+
+What they do:
+
+- `stellarroute-postgres-backup.timer` runs daily and writes compressed dumps to `/var/backups/stellarroute-postgres`
+- `stellarroute-healthcheck.timer` runs every 5 minutes and checks Docker, Caddy, disk pressure, and local API health
+
+Run them manually if needed:
+
+```bash
+sudo bash deploy/aws/scripts/postgres-backup.sh
+bash deploy/aws/scripts/ec2-health-check.sh
+```
+
+## 6. Expose the API with Caddy
+
+This is the default recommendation for EC2 staging. It is simpler than managing
+Nginx yourself and gives you automatic HTTPS.
+
+Requirements:
+
+- your DNS record already points to the EC2 public IP
+- ports `80` and `443` are open in the instance security group
+
+Run on the instance:
+
+```bash
+cd /opt/stellarroute
+sudo bash deploy/aws/scripts/install-caddy.sh api-staging.<your-domain> ops@<your-domain>
+```
+
+This installs the official Caddy Ubuntu package, writes `/etc/caddy/Caddyfile`,
+formats it, and starts the `caddy` systemd service.
+
+The generated proxy is equivalent to:
+
+```caddyfile
+api-staging.<your-domain> {
+  encode zstd gzip
+  reverse_proxy 127.0.0.1:8080
+}
+```
+
+Template reference:
+
+- `deploy/aws/caddy/Caddyfile.example`
+
+### Alternate public path: Cloudflare Tunnel
+
+If you do not want the instance directly reachable on `80/443`, use the tunnel
+approach from:
+
+- `docs/deployment/oracle-always-free.md`
+
+Point the tunnel to `http://127.0.0.1:8080`.
+
+## 7. Wire the frontend
+
+In Vercel production:
+
+- `NEXT_PUBLIC_API_URL=https://api.<your-domain>`
+- `NEXT_PUBLIC_API_URL_TESTNET=https://api.<your-domain>`
+- `NEXT_PUBLIC_STELLAR_NETWORK=testnet`
+
+Then confirm `CORS_ALLOWED_ORIGINS` in `.env.prod` includes:
+
+- `https://www.stellarroute.app`
+- `https://stellarroute.app`
+- your Vercel project hostname
+
+See:
+
+- `docs/deployment/vercel-frontend.md`
+
+## 8. Verify
+
+On the instance:
+
+```bash
+curl -sf http://127.0.0.1:8080/health && echo OK
+curl -sf http://127.0.0.1:8080/health/deps && echo OK
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod ps
+```
+
+From your laptop after the public hostname is live:
+
+```bash
+curl -sf https://api-staging.<your-domain>/health && echo OK
+curl -sf https://api-staging.<your-domain>/health/deps && echo OK
+STAGING_API_BASE_URL=https://api-staging.<your-domain> ./scripts/staging-smoke.sh
+```
+
+Or from the EC2 host, run the single-command smoke wrapper:
+
+```bash
+cd /opt/stellarroute
+bash deploy/aws/scripts/ec2-postdeploy-smoke.sh https://api-staging.<your-domain>
+```
+
+## 9. Restore from a local Postgres backup
+
+Backups are written by default to:
+
+- `/var/backups/stellarroute-postgres`
+
+Create one on demand:
+
+```bash
+cd /opt/stellarroute
+sudo bash deploy/aws/scripts/postgres-backup.sh
+```
+
+Restore one backup:
+
+```bash
+cd /opt/stellarroute
+sudo bash deploy/aws/scripts/postgres-restore.sh /var/backups/stellarroute-postgres/<backup-file>.sql.gz --yes
+```
+
+Restore behavior:
+
+- stops API and indexer first to avoid write traffic
+- drops and recreates the application database
+- imports the selected dump
+- restarts API and indexer
+
+This is intentionally destructive to the current database contents, so use it
+only for staging recovery or refresh workflows.
+
+## 10. Start and stop staging to reduce cost
+
+If you do not need 24/7 uptime, stop the EC2 instance when idle.
+
+From your local machine:
+
+```bash
+cd /path/to/StellarRoute
+bash deploy/aws/scripts/ec2-staging-start.sh
+```
+
+```bash
+cd /path/to/StellarRoute
+bash deploy/aws/scripts/ec2-staging-stop.sh
+```
+
+Defaults in these scripts:
+
+- `AWS_REGION=us-east-1`
+- `STAGING_INSTANCE_NAME=stellarroute-staging-ec2`
+
+Override if needed:
+
+```bash
+AWS_REGION=us-east-1 STAGING_INSTANCE_ID=i-xxxxxxxxxxxxxxxxx bash deploy/aws/scripts/ec2-staging-start.sh
+AWS_REGION=us-east-1 STAGING_INSTANCE_ID=i-xxxxxxxxxxxxxxxxx bash deploy/aws/scripts/ec2-staging-stop.sh
+```
+
+## Best practices for this shape
+
+- Keep Postgres and Redis unexposed to the public internet.
+- Keep SSH limited to your IP.
+- Keep the API bound to `127.0.0.1:8080` behind Caddy or Cloudflare Tunnel.
+- Snapshot the EBS volume or back up Postgres daily.
+- Check `journalctl -u stellarroute-healthcheck.service -n 100` if the host starts failing health checks.
+- Keep `ENABLE_ADMIN_ROUTES=false`.
+- Do not use `latest` forever if you move beyond staging; pin deploys to a git SHA.
+- If the instance is too tight during builds, move from `t4g.small` to `t4g.medium` before over-engineering the platform.
+
+## When to leave EC2 and move to ECS
+
+Move to ECS/RDS later if any of these become true:
+
+- staging must closely mirror production
+- you want managed Postgres durability and easier restores
+- you need cleaner service isolation
+- one VM becomes an operational bottleneck

--- a/docs/deployment/aws-staging-cost-estimate.md
+++ b/docs/deployment/aws-staging-cost-estimate.md
@@ -1,0 +1,124 @@
+# AWS Staging Cost Estimate
+
+This estimate is for one always-on staging deployment of StellarRoute on AWS.
+
+For this repo, if you only need one staging environment, a single EC2 instance
+is usually the best AWS choice. The ECS numbers below are still useful if you
+want a more production-shaped staging stack.
+
+Scope:
+
+- Frontend remains on Vercel.
+- Backend runs in AWS.
+- One API task.
+- One indexer task.
+- One PostgreSQL instance.
+- No Redis for the cheapest staging profile.
+- No NAT Gateway for the cheapest staging profile.
+
+These numbers are directional, not a bill guarantee. They vary by region, data
+transfer, storage growth, log volume, and request rate. The main purpose is to
+show the cost shape and the biggest levers.
+
+## Pricing assumptions checked against AWS docs
+
+- ECS on Fargate supports mixing Fargate and Fargate Spot with capacity
+  providers, and Spot tasks can be interrupted with a two-minute notice.
+- RDS PostgreSQL supports the `db.t4g` burstable Graviton family, which is the
+  right low-cost default for a small staging database.
+- NAT Gateway is a fixed hourly charge plus per-GB processing, so it is often a
+  disproportionate cost for small always-on environments.
+- ElastiCache is billed per node, so even the smallest dedicated Redis node is
+  a meaningful fixed monthly cost.
+
+## Recommended staging profile
+
+Use this profile for the first AWS staging deployment:
+
+- ECS API: Fargate, `256` CPU, `512` MiB, `desired_count = 1`
+- ECS indexer: Fargate Spot, `256` CPU, `512` MiB, `desired_count = 1`
+- RDS PostgreSQL: `db.t4g.micro`, 20 GB gp3
+- Redis: disabled
+- NAT Gateway: disabled
+- ECS tasks: public subnets with strict security groups
+- ALB: enabled for the API
+
+## Monthly estimate
+
+### Best single-staging option on AWS: one EC2 instance
+
+| Component | Configuration | Estimated monthly |
+| --- | --- | ---: |
+| EC2 compute | `t4g.small` to `t4g.medium` | $12-$30 |
+| EBS storage | 30-50 GB gp3 | $3-$8 |
+| Data transfer and logs | modest staging traffic | $2-$10 |
+| Total | single-host staging | **$17-$48** |
+
+This path uses the VM deployment flow in `docs/deployment/aws-ec2-staging.md`
+and avoids the fixed monthly cost of ALB, NAT Gateway, RDS, and ElastiCache.
+
+### Cheapest sensible staging on AWS
+
+| Component | Configuration | Estimated monthly |
+| --- | --- | ---: |
+| ALB | 1 public ALB for API | $18-$30 |
+| ECS API | Fargate 0.25 vCPU / 0.5 GB | $9-$14 |
+| ECS indexer | Fargate Spot 0.25 vCPU / 0.5 GB | $3-$6 |
+| RDS PostgreSQL | `db.t4g.micro` + 20 GB gp3 | $16-$28 |
+| CloudWatch logs | low traffic / basic retention | $2-$8 |
+| Data transfer | modest staging traffic | $2-$10 |
+| Total | recommended starting point | **$50-$96** |
+
+### Safer staging with private ECS networking
+
+This is the same stack, but ECS tasks stay in private subnets and use one NAT
+Gateway for outbound access.
+
+| Component | Configuration | Estimated monthly |
+| --- | --- | ---: |
+| Cheapest sensible staging total | from above | $50-$96 |
+| NAT Gateway | 1 gateway + light processing | $32-$45 |
+| Total | private ECS subnets | **$82-$141** |
+
+### Managed-cache staging
+
+This is the safer staging profile plus a small ElastiCache Redis node.
+
+| Component | Configuration | Estimated monthly |
+| --- | --- | ---: |
+| Safer staging total | from above | $82-$141 |
+| ElastiCache Redis | `cache.t4g.micro` | $12-$20 |
+| Total | with managed Redis | **$94-$161** |
+
+## Main cost drivers
+
+For this repo, the largest cost levers are usually:
+
+1. NAT Gateway
+2. ALB fixed cost
+3. RDS fixed cost
+4. Whether Redis is enabled
+
+Fargate CPU and memory matter, but for a small staging environment they are not
+usually the biggest surprise line item.
+
+## Recommendation
+
+For one AWS staging deployment, start with the cheapest sensible profile:
+
+- No NAT Gateway
+- No Redis
+- API on standard Fargate
+- Indexer on Fargate Spot
+- `db.t4g.micro` PostgreSQL
+
+Then add NAT and Redis only when traffic, reliability, or security posture
+needs justify the extra fixed monthly cost.
+
+## Repo files tied to this estimate
+
+- `deploy/aws/terraform/terraform.staging.lowcost.tfvars`
+- `deploy/aws/terraform/variables.tf`
+- `deploy/aws/terraform/ecs.tf`
+- `deploy/aws/terraform/data.tf`
+- `docs/deployment/aws.md`


### PR DESCRIPTION
## Summary
- make install-caddy script non-interactive by adding batch flags to gpg dearmor
- fixes SSH-driven provisioning runs that failed with gpg tty prompt
- validated on staging by re-running Caddy config and smoke checks on the Elastic IP endpoint

## Validation
- HTTPS health: /health and /health/deps return 200 on the stable sslip URL
- ec2-postdeploy-smoke script passed end-to-end on staging
