### PR TITLE
fix(indexer,api): restore XLM quote liquidity on AWS staging

### DIFF
--- a/crates/api/migrations/20260804_assets_native_singleton.sql
+++ b/crates/api/migrations/20260804_assets_native_singleton.sql
@@ -1,0 +1,153 @@
+-- Consolidate duplicate native (XLM) asset rows. NULL code/issuer bypasses the
+-- composite unique constraint, so historical indexer runs created thousands of
+-- native ids and broke quote resolution.
+
+WITH keeper AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+    ORDER BY created_at ASC
+    LIMIT 1
+),
+dupes AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+      AND id <> (SELECT id FROM keeper)
+)
+UPDATE sdex_offers o
+SET selling_asset_id = (SELECT id FROM keeper)
+WHERE selling_asset_id IN (SELECT id FROM dupes);
+
+WITH keeper AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+    ORDER BY created_at ASC
+    LIMIT 1
+),
+dupes AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+      AND id <> (SELECT id FROM keeper)
+)
+UPDATE sdex_offers o
+SET buying_asset_id = (SELECT id FROM keeper)
+WHERE buying_asset_id IN (SELECT id FROM dupes);
+
+WITH keeper AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+    ORDER BY created_at ASC
+    LIMIT 1
+),
+dupes AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+      AND id <> (SELECT id FROM keeper)
+)
+UPDATE normalized_liquidity nl
+SET selling_asset_id = (SELECT id FROM keeper)
+WHERE selling_asset_id IN (SELECT id FROM dupes);
+
+WITH keeper AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+    ORDER BY created_at ASC
+    LIMIT 1
+),
+dupes AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+      AND id <> (SELECT id FROM keeper)
+)
+UPDATE normalized_liquidity nl
+SET buying_asset_id = (SELECT id FROM keeper)
+WHERE buying_asset_id IN (SELECT id FROM dupes);
+
+WITH keeper AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+    ORDER BY created_at ASC
+    LIMIT 1
+),
+dupes AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+      AND id <> (SELECT id FROM keeper)
+)
+UPDATE amm_pool_reserves r
+SET selling_asset_id = (SELECT id FROM keeper)
+WHERE selling_asset_id IN (SELECT id FROM dupes);
+
+WITH keeper AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+    ORDER BY created_at ASC
+    LIMIT 1
+),
+dupes AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+      AND id <> (SELECT id FROM keeper)
+)
+UPDATE amm_pool_reserves r
+SET buying_asset_id = (SELECT id FROM keeper)
+WHERE buying_asset_id IN (SELECT id FROM dupes);
+
+WITH keeper AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+    ORDER BY created_at ASC
+    LIMIT 1
+),
+dupes AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+      AND id <> (SELECT id FROM keeper)
+)
+UPDATE trading_pairs tp
+SET base_asset_id = (SELECT id FROM keeper)
+WHERE base_asset_id IN (SELECT id FROM dupes);
+
+WITH keeper AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+    ORDER BY created_at ASC
+    LIMIT 1
+),
+dupes AS (
+    SELECT id
+    FROM assets
+    WHERE asset_type = 'native'
+      AND id <> (SELECT id FROM keeper)
+)
+UPDATE trading_pairs tp
+SET counter_asset_id = (SELECT id FROM keeper)
+WHERE counter_asset_id IN (SELECT id FROM dupes);
+
+DELETE FROM assets
+WHERE asset_type = 'native'
+  AND id <> (
+      SELECT id
+      FROM assets
+      WHERE asset_type = 'native'
+      ORDER BY created_at ASC
+      LIMIT 1
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS assets_native_singleton
+    ON assets (asset_type)
+    WHERE asset_type = 'native';

--- a/crates/api/src/routes/quote.rs
+++ b/crates/api/src/routes/quote.rs
@@ -1557,10 +1557,18 @@ async fn find_asset_id(state: &AppState, asset: &AssetPath) -> Result<uuid::Uuid
     let asset_type = asset.to_asset_type();
 
     let row = if asset.asset_code == "native" {
+        // Native rows were historically inserted with NULL code/issuer, so the
+        // unique constraint does not dedupe them. Prefer the asset id that
+        // actually backs live SDEX offers.
         sqlx::query(
             r#"
-            select id from assets
-            where asset_type = $1
+            select a.id
+            from assets a
+            left join sdex_offers o
+              on o.selling_asset_id = a.id or o.buying_asset_id = a.id
+            where a.asset_type = $1
+            group by a.id, a.created_at
+            order by count(o.offer_id) desc, a.created_at asc
             limit 1
             "#,
         )

--- a/crates/indexer/src/config/mod.rs
+++ b/crates/indexer/src/config/mod.rs
@@ -203,7 +203,7 @@ fn default_partition_id() -> usize {
 
 // New defaults for partitioning and hot‑pair detection
 fn default_partition_count() -> usize {
-    4
+    1
 }
 fn default_hot_pair_allowlist() -> String {
     String::new()

--- a/crates/indexer/src/sdex.rs
+++ b/crates/indexer/src/sdex.rs
@@ -6,7 +6,7 @@ use tracing::{debug, error, info, warn};
 use crate::db::Database;
 use crate::error::{IndexerError, Result};
 use crate::horizon::HorizonClient;
-use crate::models::{asset::Asset, horizon::HorizonOffer, offer::Offer};
+use crate::models::{asset::Asset, offer::Offer};
 use crate::telemetry::TraceContext;
 
 /// Indexing mode
@@ -257,57 +257,83 @@ impl SdexIndexer {
     async fn index_offers(&self) -> Result<usize> {
         debug!("Fetching offers from Horizon");
 
-        let horizon_offers: Vec<HorizonOffer> = self.horizon.get_offers(None, None, None).await?;
-        debug!("Fetched {} offers from Horizon", horizon_offers.len());
-
         let pool = self.db.pool();
         let mut indexed = 0;
+        let page_limit = 200u32;
+        let mut cursor: Option<String> = None;
 
-        for horizon_offer in horizon_offers {
-            // Convert Horizon offer to our Offer model
-            let offer = match Offer::try_from(horizon_offer) {
-                Ok(o) => o,
-                Err(e) => {
-                    warn!("Failed to parse offer: {}", e);
-                    continue;
-                }
-            };
-
-            // Determine market pair identifier for partitioning
-            let pair_key = pair_key(&offer.selling, &offer.buying);
-            if !self.partition_manager.should_process(&pair_key) {
-                debug!(
-                    "Skipping pair {} on partition {}",
-                    pair_key, self.partition_manager.partition_id
-                );
-                continue;
+        // Horizon returns offers in pages; polling only the first page misses most
+        // of testnet/mainnet liquidity (including native/XLM sell offers).
+        for _ in 0..100 {
+            let horizon_offers = self
+                .horizon
+                .get_offers(Some(page_limit), cursor.as_deref(), None)
+                .await?;
+            let batch_len = horizon_offers.len();
+            if batch_len == 0 {
+                break;
             }
 
-            // Extract and upsert assets
-            let selling_asset_id = match self.upsert_asset(pool, &offer.selling).await {
-                Ok(id) => id,
-                Err(e) => {
-                    warn!("Failed to upsert selling asset: {}", e);
-                    continue;
-                }
-            };
-            let buying_asset_id = match self.upsert_asset(pool, &offer.buying).await {
-                Ok(id) => id,
-                Err(e) => {
-                    warn!("Failed to upsert buying asset: {}", e);
-                    continue;
-                }
-            };
+            debug!("Fetched {} offers from Horizon", batch_len);
+            let next_cursor = horizon_offers
+                .last()
+                .and_then(|offer| offer.paging_token.clone());
 
-            // Upsert offer
-            match self
-                .upsert_offer(pool, &offer, selling_asset_id, buying_asset_id)
-                .await
-            {
-                Ok(_) => indexed += 1,
-                Err(e) => {
-                    warn!("Failed to upsert offer {}: {}", offer.id, e);
+            for horizon_offer in horizon_offers {
+                // Convert Horizon offer to our Offer model
+                let offer = match Offer::try_from(horizon_offer) {
+                    Ok(o) => o,
+                    Err(e) => {
+                        warn!("Failed to parse offer: {}", e);
+                        continue;
+                    }
+                };
+
+                // Determine market pair identifier for partitioning
+                let pair_key = pair_key(&offer.selling, &offer.buying);
+                if !self.partition_manager.should_process(&pair_key) {
+                    debug!(
+                        "Skipping pair {} on partition {}",
+                        pair_key, self.partition_manager.partition_id
+                    );
+                    continue;
                 }
+
+                // Extract and upsert assets
+                let selling_asset_id = match self.upsert_asset(pool, &offer.selling).await {
+                    Ok(id) => id,
+                    Err(e) => {
+                        warn!("Failed to upsert selling asset: {}", e);
+                        continue;
+                    }
+                };
+                let buying_asset_id = match self.upsert_asset(pool, &offer.buying).await {
+                    Ok(id) => id,
+                    Err(e) => {
+                        warn!("Failed to upsert buying asset: {}", e);
+                        continue;
+                    }
+                };
+
+                // Upsert offer
+                match self
+                    .upsert_offer(pool, &offer, selling_asset_id, buying_asset_id)
+                    .await
+                {
+                    Ok(_) => indexed += 1,
+                    Err(e) => {
+                        warn!("Failed to upsert offer {}: {}", offer.id, e);
+                    }
+                }
+            }
+
+            if batch_len < page_limit as usize {
+                break;
+            }
+
+            cursor = next_cursor;
+            if cursor.is_none() {
+                break;
             }
         }
 
@@ -318,6 +344,23 @@ impl SdexIndexer {
     #[tracing::instrument(skip(self, pool, asset), fields(asset_type = %asset.key().0))]
     async fn upsert_asset(&self, pool: &PgPool, asset: &Asset) -> Result<uuid::Uuid> {
         let (asset_type, asset_code, asset_issuer) = asset.key();
+
+        if asset_type == "native" {
+            if let Some(id) = sqlx::query_scalar::<_, uuid::Uuid>(
+                r#"
+                select id from assets
+                where asset_type = 'native'
+                order by created_at asc
+                limit 1
+                "#,
+            )
+            .fetch_optional(pool)
+            .await
+            .map_err(IndexerError::DatabaseQuery)?
+            {
+                return Ok(id);
+            }
+        }
 
         sqlx::query_scalar(
             r#"


### PR DESCRIPTION
## Summary
Staging quotes for **XLM → USDy** fail with `stale_market_data` / `no_route` even though `/health` is green. Root causes:

1. **SDEX indexer only ingested the first Horizon page** (~43 offers), missing native sell-side liquidity
2. **Duplicate `native` asset rows** (NULL code/issuer bypasses unique constraint) broke XLM asset resolution in quotes
3. **Default partition count of 4** dropped 75% of pairs on single-instance deploys

This PR fixes ingestion + resolution and adds a one-time DB migration.

## Changes
- **Indexer (`sdex.rs`)**: paginate Horizon offers (200/page, up to 20k/cycle); reuse canonical native asset id on upsert
- **Indexer config**: default `INDEXER_PARTITION_COUNT` → `1` for single-node staging/prod
- **API (`quote.rs`)**: `find_asset_id(native)` prefers the asset id with live SDEX offers
- **Migration `20260804_assets_native_singleton.sql`**: consolidate duplicate native rows + partial unique index

## DevOps redeploy (EC2)
After merge, on `34.224.110.144.sslip.io` / `13.218.179.53.sslip.io`:

1. Pull/build new `stellarroute-api` + `stellarroute-indexer` images from `main`
2. Run API migrations (applies native singleton consolidation):
   ```bash
   docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml exec api \
     # or run migration job per your deploy script
   ```
3. Restart **indexer** then **api** (indexer must backfill offers before quotes improve)
4. Smoke:
   ```bash
   bash deploy/aws/scripts/ec2-postdeploy-smoke.sh https://34.224.110.144.sslip.io
   curl -sS "https://34.224.110.144.sslip.io/api/v1/quote/native/USDy:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS?amount=10&quote_type=sell"
   ```
   Expect HTTP 200 with `data.amount`, not `stale_market_data`.

## Test plan
- [x] `cargo clippy -p stellarroute-indexer -p stellarroute-api -- -D warnings`
- [x] `cargo test -p stellarroute-indexer --lib` (169 passed)
- [x] `cargo test -p stellarroute-api quote::tests --lib` (24 passed)
- [ ] Post-deploy: `www.stellarroute.app` XLM → USDy shows **Review Swap** (not stale_market_data)