### PR TITLE
fix(ci): run EC2 SSM deploy without bash-only pipefail

### DIFF
--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -95,7 +95,6 @@ jobs:
           cat > /tmp/ssm-commands.json <<EOF
           {
             "commands": [
-              "set -euo pipefail",
               "cd /opt/stellarroute",
               "git fetch --all --prune",
               "git checkout ${DEPLOY_REF}",


### PR DESCRIPTION
## Summary
- Remove `set -euo pipefail` from the SSM remote command list; AWS-RunShellScript runs `/bin/sh` (dash), which fails immediately on `pipefail`.
- Deploy/smoke scripts still run under `bash` with their own strict mode.

## Test plan
- [ ] Merge and confirm `Deploy EC2 Staging` workflow succeeds on next push
- [ ] Verify `curl` native→USDy quote on staging after indexer migration applies