### PR TITLE
ci(deploy): fix EC2 git safe-directory and health readiness

### DIFF
--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -96,10 +96,12 @@ jobs:
           {
             "commands": [
               "cd /opt/stellarroute",
+              "git config --global --add safe.directory /opt/stellarroute",
               "git fetch --all --prune",
               "git checkout ${DEPLOY_REF}",
               "git pull --ff-only origin ${DEPLOY_REF}",
               "bash deploy/aws/scripts/deploy-ec2-staging.sh",
+              "for i in $(seq 1 60); do if curl -fsS http://127.0.0.1:8080/health >/dev/null && curl -fsS http://127.0.0.1:8080/health/deps >/dev/null; then echo 'API is healthy'; break; fi; echo 'Waiting for API health...'; sleep 5; done",
               "bash deploy/aws/scripts/ec2-postdeploy-smoke.sh ${DEPLOY_URL}"
             ]
           }


### PR DESCRIPTION
## Why
The deploy workflow on main still fails during SSM execution because:
- Git marks /opt/stellarroute as dubious ownership during remote pull\n- smoke can run before API is fully healthy\n\n## What changed\n- add  in SSM command sequence\n- add readiness wait loop for local /health and /health/deps before smoke\n\n## Result\nDeploy workflow becomes resilient on EC2 and avoids false failures from startup race conditions.\n