### PR TITLE
fix: prevent bash expansion in SSM JSON parameters

### DIFF
--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -92,20 +92,27 @@ jobs:
         run: |
           set -euo pipefail
 
-          cat > /tmp/ssm-commands.json <<EOF
+          cat > /tmp/ssm-commands.json <<'EOF'
           {
             "commands": [
               "cd /opt/stellarroute",
               "git config --global --add safe.directory /opt/stellarroute",
               "git fetch --all --prune",
-              "git checkout ${DEPLOY_REF}",
-              "git pull --ff-only origin ${DEPLOY_REF}",
+              "git checkout main",
+              "git pull --ff-only origin main",
               "bash deploy/aws/scripts/deploy-ec2-staging.sh",
-              "for i in $(seq 1 60); do if curl -fsS http://127.0.0.1:8080/health >/dev/null && curl -fsS http://127.0.0.1:8080/health/deps >/dev/null; then echo 'API is healthy'; break; fi; echo 'Waiting for API health...'; sleep 5; done",
-              "bash deploy/aws/scripts/ec2-postdeploy-smoke.sh ${DEPLOY_URL}"
+              "for i in {1..60}; do if curl -fsS http://127.0.0.1:8080/health >/dev/null && curl -fsS http://127.0.0.1:8080/health/deps >/dev/null; then echo 'API is healthy'; break; fi; echo 'Waiting for API health...'; sleep 5; done"
             ]
           }
           EOF
+          
+          # Substitute variables into the JSON
+          sed -i "s|git checkout main|git checkout ${DEPLOY_REF}|" /tmp/ssm-commands.json
+          sed -i "s|git pull --ff-only origin main|git pull --ff-only origin ${DEPLOY_REF}|" /tmp/ssm-commands.json
+          
+          # Add the smoke test command with URL
+          jq --arg url "${DEPLOY_URL}" '.commands += ["bash deploy/aws/scripts/ec2-postdeploy-smoke.sh \($url)"]' /tmp/ssm-commands.json > /tmp/ssm-commands-final.json
+          mv /tmp/ssm-commands-final.json /tmp/ssm-commands.json
 
           COMMAND_ID="$(aws ssm send-command \
             --region "${AWS_REGION}" \


### PR DESCRIPTION
Fixes the JSON parsing error in the staging deploy pipeline that was causing:
```
Error parsing parameter '--parameters': Invalid JSON: Invalid control character at: line 9 column 16
```

## Problem
The `1
2
3
4
5
6
7
8
9
10
11
12
13
14
15
16
17
18
19
20
21
22
23
24
25
26
27
28
29
30
31
32
33
34
35
36
37
38
39
40
41
42
43
44
45
46
47
48
49
50
51
52
53
54
55
56
57
58
59
60` command was being expanded by bash during heredoc creation, producing a string like `1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60` with spaces, which created invalid JSON with control characters.

## Solution
- Use quoted heredoc (`<<'EOF'`) to prevent premature bash variable expansion
- Replace `$(seq 1 60)` with `{1..60}` brace expansion (evaluated on EC2, not during JSON creation)
- Safely inject `DEPLOY_REF` with `sed` after JSON creation
- Use `jq` for proper JSON escaping of `DEPLOY_URL`

This ensures clean JSON is always passed to AWS SSM's `--parameters` flag.