### PR TITLE
fix(frontend): default swap UI to staging markets that quote

### DIFF
--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { ArrowUpDown, RefreshCw, Stethoscope } from 'lucide-react';
 import { AmountInput } from './AmountInput';
 import { TokenSelector } from './TokenSelector';
+import { SwapPresetTemplates } from './SwapPresetTemplates';
 import { PriceInfoPanel } from './PriceInfoPanel';
 import type { AlternativeRoute } from './RouteDisplay';
 import RouteDisplay from './RoutePanelAsync';
@@ -35,6 +36,11 @@ import {
   SESSION_RECOVERY_THRESHOLD_MS,
   type TradeFormSnapshot,
 } from '@/hooks/useTradeFormStorage';
+import {
+  counterpartsFor,
+  pairExists,
+  pickPreferredDemoPair,
+} from '@/lib/trading-pairs';
 import { useBatchQuote, usePairs, useRoutes } from '@/hooks/useApi';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import type { QuoteRequestItem } from '@/lib/api/client';
@@ -137,54 +143,51 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
 
   const { data: indexedPairs } = usePairs();
 
-  // Prefer an indexed native (XLM) pair; migrate off the old BTC/EXT default.
-  // Never force BTC/EXT just because it is the only indexed staging pair.
+  // Prefer an indexed demo market that currently quotes (EUR/USDy, BTC/EXT, …).
+  // Avoid legacy Circle-USDC defaults and unpaired token combinations.
   useEffect(() => {
     if (!indexedPairs?.length) return;
-    const assets = new Set(
-      indexedPairs.flatMap((pair) => [pair.base_asset, pair.counter_asset])
-    );
+
     const isLegacyDefaultPair =
-      fromToken === LEGACY_DEFAULT_FROM_TOKEN &&
+      (fromToken === LEGACY_DEFAULT_FROM_TOKEN &&
+        toToken === LEGACY_DEFAULT_TO_TOKEN) ||
       toToken === LEGACY_DEFAULT_TO_TOKEN;
-    const isLegacyIndexedPair = (pair: {
-      base_asset: string;
-      counter_asset: string;
-    }) =>
-      pair.base_asset === LEGACY_DEFAULT_FROM_TOKEN &&
-      pair.counter_asset === LEGACY_DEFAULT_TO_TOKEN;
 
-    if (assets.has(fromToken) && assets.has(toToken) && !isLegacyDefaultPair) {
+    if (pairExists(fromToken, toToken, indexedPairs) && !isLegacyDefaultPair) {
       return;
     }
 
-    const nativePair = indexedPairs.find(
-      (pair) =>
-        (pair.base_asset === 'native' || pair.counter_asset === 'native') &&
-        !isLegacyIndexedPair(pair)
-    );
-    if (nativePair) {
-      if (nativePair.base_asset === 'native') {
-        setTokenPair(nativePair.base_asset, nativePair.counter_asset);
-      } else {
-        setTokenPair('native', nativePair.base_asset);
-      }
-      return;
-    }
-
-    if (assets.has(DEFAULT_FROM_TOKEN) && assets.has(DEFAULT_TO_TOKEN)) {
+    if (pairExists(DEFAULT_FROM_TOKEN, DEFAULT_TO_TOKEN, indexedPairs)) {
       setTokenPair(DEFAULT_FROM_TOKEN, DEFAULT_TO_TOKEN);
       return;
     }
 
-    const firstNonLegacy = indexedPairs.find((pair) => !isLegacyIndexedPair(pair));
-    if (firstNonLegacy) {
-      setTokenPair(firstNonLegacy.base_asset, firstNonLegacy.counter_asset);
+    const preferred = pickPreferredDemoPair(indexedPairs);
+    if (preferred) {
+      setTokenPair(preferred.from, preferred.to);
       return;
     }
 
     setTokenPair(DEFAULT_FROM_TOKEN, DEFAULT_TO_TOKEN);
   }, [indexedPairs, fromToken, toToken, setTokenPair]);
+
+  // When pay asset changes, keep receive asset on a real indexed market.
+  const handleFromTokenSelect = useCallback(
+    (asset: string) => {
+      const counterparts = counterpartsFor(asset, indexedPairs);
+      if (counterparts.includes(toToken)) {
+        setFromToken(asset);
+        return;
+      }
+      const nextTo = counterparts[0];
+      if (nextTo) {
+        setTokenPair(asset, nextTo);
+        return;
+      }
+      setFromToken(asset);
+    },
+    [indexedPairs, setFromToken, setTokenPair, toToken]
+  );
 
   const [selectedRoute, setSelectedRoute] = useState<AlternativeRoute | null>(
     null
@@ -1223,6 +1226,16 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
             </div>
           </div>
 
+          {indexedPairs && indexedPairs.length > 0 && (
+            <SwapPresetTemplates
+              availablePairs={indexedPairs}
+              selectedBase={fromToken}
+              selectedQuote={toToken}
+              onSelect={(base, quote) => setTokenPair(base, quote)}
+              className={cn(isCompact ? 'mb-2' : 'mb-3')}
+            />
+          )}
+
           {/* Pay Section */}
           <div className={cn('space-y-2 group', isCompact && 'space-y-1')}>
             <div
@@ -1254,7 +1267,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
                 />
                 <TokenSelector
                   selectedAsset={fromToken}
-                  onSelect={setFromToken}
+                  onSelect={handleFromTokenSelect}
                   className="mt-6"
                 />
               </div>
@@ -1298,6 +1311,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
                 <TokenSelector
                   selectedAsset={toToken}
                   onSelect={setToToken}
+                  compatibleWith={fromToken}
                   className="mt-6"
                 />
               </div>

--- a/frontend/components/swap/SwapPresetTemplates.tsx
+++ b/frontend/components/swap/SwapPresetTemplates.tsx
@@ -1,16 +1,20 @@
 "use client";
 
-import React from "react";
+import React, { useMemo } from "react";
 import { History, Zap } from "lucide-react";
 import { cn } from "@/lib/utils";
 import { SwapPreset } from "@/lib/presets";
 import { useSwapPresetTemplates } from "@/hooks/useSwapPresetTemplates";
+import { pairExists } from "@/lib/trading-pairs";
+import type { TradingPair } from "@/types";
 
 export interface SwapPresetTemplatesProps {
   onSelect: (base: string, quote: string) => void;
   selectedBase?: string;
   selectedQuote?: string;
   className?: string;
+  /** When provided, only show presets that exist in the indexed market list. */
+  availablePairs?: TradingPair[];
 }
 
 export function SwapPresetTemplates({
@@ -18,15 +22,23 @@ export function SwapPresetTemplates({
   selectedBase,
   selectedQuote,
   className,
+  availablePairs,
 }: SwapPresetTemplatesProps) {
   const { templates, recentTemplates, addRecentTemplate } = useSwapPresetTemplates();
+
+  const visibleTemplates = useMemo(() => {
+    if (!availablePairs) return templates;
+    return templates.filter((preset) =>
+      pairExists(preset.baseAsset, preset.quoteAsset, availablePairs)
+    );
+  }, [availablePairs, templates]);
 
   const handleSelect = (preset: SwapPreset) => {
     onSelect(preset.baseAsset, preset.quoteAsset);
     addRecentTemplate(preset);
   };
 
-  if (templates.length === 0) return null;
+  if (visibleTemplates.length === 0) return null;
 
   return (
     <div className={cn("flex flex-col gap-3 pb-2", className)}>
@@ -46,7 +58,7 @@ export function SwapPresetTemplates({
       </div>
       
       <div className="flex flex-wrap gap-2.5">
-        {templates.map((preset, index) => {
+        {visibleTemplates.map((preset, index) => {
           const isSelected = 
             selectedBase === preset.baseAsset && 
             selectedQuote === preset.quoteAsset;

--- a/frontend/components/swap/TokenSelector.tsx
+++ b/frontend/components/swap/TokenSelector.tsx
@@ -5,6 +5,7 @@ import { Button } from '@/components/ui/button';
 import { ChevronDown } from 'lucide-react';
 import { TokenSearchModal, AssetOption } from '@/components/shared/TokenSearchModal';
 import { usePairs } from '@/hooks/useApi';
+import { counterpartsFor } from '@/lib/trading-pairs';
 import { cn } from '@/lib/utils';
 
 interface TokenSelectorProps {
@@ -14,6 +15,11 @@ interface TokenSelectorProps {
   disabled?: boolean;
   /** Optional override for loading state (useful for stories/tests) */
   isLoading?: boolean;
+  /**
+   * When set, only show assets that share an indexed market with this asset
+   * (used for the receive-side selector so users can't pick dead pairs).
+   */
+  compatibleWith?: string;
 }
 
 export function TokenSelector({
@@ -22,6 +28,7 @@ export function TokenSelector({
   className,
   disabled = false,
   isLoading: propLoading,
+  compatibleWith,
 }: TokenSelectorProps) {
   const [isModalOpen, setIsModalOpen] = useState(false);
   const { data: pairs, loading: hookLoading } = usePairs();
@@ -34,31 +41,32 @@ export function TokenSelector({
 
     const assetMap = new Map<string, AssetOption>();
 
+    const allow = compatibleWith
+      ? new Set(counterpartsFor(compatibleWith, pairs))
+      : null;
+
     pairs.forEach((pair) => {
-      if (!assetMap.has(pair.base_asset)) {
-        assetMap.set(pair.base_asset, {
-          code: pair.base === 'native' ? 'XLM' : pair.base,
-          asset: pair.base_asset,
-          issuer: pair.base_asset.includes(':')
-            ? pair.base_asset.split(':')[1]
+      const maybeAdd = (canonical: string, code: string) => {
+        if (allow && !allow.has(canonical)) return;
+        if (assetMap.has(canonical)) return;
+        assetMap.set(canonical, {
+          code: code === 'native' ? 'XLM' : code,
+          asset: canonical,
+          issuer: canonical.includes(':')
+            ? canonical.split(':')[1]
             : undefined,
-          displayName: pair.base === 'native' ? 'Stellar Lumens' : undefined,
+          displayName: code === 'native' ? 'Stellar Lumens' : undefined,
         });
-      }
-      if (!assetMap.has(pair.counter_asset)) {
-        assetMap.set(pair.counter_asset, {
-          code: pair.counter === 'native' ? 'XLM' : pair.counter,
-          asset: pair.counter_asset,
-          issuer: pair.counter_asset.includes(':')
-            ? pair.counter_asset.split(':')[1]
-            : undefined,
-          displayName: pair.counter === 'native' ? 'Stellar Lumens' : undefined,
-        });
-      }
+      };
+
+      maybeAdd(pair.base_asset, pair.base);
+      maybeAdd(pair.counter_asset, pair.counter);
     });
 
-    return Array.from(assetMap.values());
-  }, [pairs]);
+    return Array.from(assetMap.values()).sort((a, b) =>
+      a.code.localeCompare(b.code)
+    );
+  }, [pairs, compatibleWith]);
 
   const selectedAssetOption = useMemo(() => {
     return assets.find((a) => a.asset === selectedAsset);

--- a/frontend/hooks/useTradeFormStorage.test.ts
+++ b/frontend/hooks/useTradeFormStorage.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import {
+  DEFAULT_FROM_TOKEN,
   DEFAULT_TO_TOKEN,
   STORAGE_KEY,
   useTradeFormStorage,
@@ -22,7 +23,7 @@ describe("useTradeFormStorage", () => {
     expect(result.current.amount).toBe("");
     expect(result.current.slippage).toBe(0.5);
     expect(result.current.deadline).toBe(30);
-    expect(result.current.fromToken).toBe("native");
+    expect(result.current.fromToken).toBe(DEFAULT_FROM_TOKEN);
     expect(result.current.toToken).toBe(DEFAULT_TO_TOKEN);
     expect(result.current.side).toBe("sell");
     expect(result.current.pendingRecovery).toBeNull();

--- a/frontend/hooks/useTradeFormStorage.ts
+++ b/frontend/hooks/useTradeFormStorage.ts
@@ -2,21 +2,21 @@
 
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { QuoteType } from "@/types";
+import { STAGING_DEMO_ISSUER } from "@/lib/trading-pairs";
 
 export const STORAGE_KEY = "stellar-route-trade-form";
 export const DEFAULT_AMOUNT = "";
 export const DEFAULT_SLIPPAGE = 0.5;
 export const DEFAULT_DEADLINE = 30;
-/** Prefer native XLM so users with testnet funds land on a spendable asset. */
-export const DEFAULT_FROM_TOKEN = "native";
-/** Common testnet/mainnet USDC issuer; SwapCard falls back to indexed pairs if absent. */
-export const DEFAULT_TO_TOKEN =
-  "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
-/** Previous staging default — migrate away when a native pair is indexed. */
-export const LEGACY_DEFAULT_FROM_TOKEN =
-  "BTC:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS";
+
+/** Prefer a staged demo market that currently quotes successfully (not native/XLM). */
+export const DEFAULT_FROM_TOKEN = `EUR:${STAGING_DEMO_ISSUER}`;
+/** Staging USDy — Circle USDC is not on the staging orderbook. */
+export const DEFAULT_TO_TOKEN = `USDy:${STAGING_DEMO_ISSUER}`;
+/** Prior Circle-USDC defaults — migrate away when indexed pairs load. */
+export const LEGACY_DEFAULT_FROM_TOKEN = "native";
 export const LEGACY_DEFAULT_TO_TOKEN =
-  "EXT:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS";
+  "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN";
 export const DEFAULT_SIDE: QuoteType = "sell";
 export const SESSION_RECOVERY_THRESHOLD_MS = 60_000;
 

--- a/frontend/lib/presets.ts
+++ b/frontend/lib/presets.ts
@@ -1,3 +1,5 @@
+import { STAGING_DEMO_ISSUER } from "@/lib/trading-pairs";
+
 export interface SwapPreset {
   id: string;
   label: string;
@@ -5,29 +7,44 @@ export interface SwapPreset {
   quoteAsset: string;
 }
 
+const I = STAGING_DEMO_ISSUER;
+
+/** Quick-pair chips aligned with testnet staging orderbooks (GDMVY5 issuer). */
 export const DEFAULT_SWAP_PRESETS: SwapPreset[] = [
   {
-    id: "xlm-usdc",
-    label: "XLM / USDC",
-    baseAsset: "native",
-    quoteAsset: "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-  },
-  {
-    id: "xlm-aqua",
-    label: "XLM / AQUA",
-    baseAsset: "native",
-    quoteAsset: "AQUA:GBNZILSTVQZ4R7IKQDGHYGY2QXL5QOFJYQMXPKWRRM5PAV7Y4M67AQUA",
-  },
-  {
-    id: "usdc-xlm",
-    label: "USDC / XLM",
-    baseAsset: "USDC:GA5ZSEJYB37JRC5AVCIA5MOP4RHTM335X2KGX3IHOJAPP5RE34K4KZVN",
-    quoteAsset: "native",
+    id: "eur-usdy",
+    label: "EUR / USDy",
+    baseAsset: `EUR:${I}`,
+    quoteAsset: `USDy:${I}`,
   },
   {
     id: "btc-ext",
     label: "BTC / EXT",
-    baseAsset: "BTC:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS",
-    quoteAsset: "EXT:GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS",
+    baseAsset: `BTC:${I}`,
+    quoteAsset: `EXT:${I}`,
+  },
+  {
+    id: "btc-usdy",
+    label: "BTC / USDy",
+    baseAsset: `BTC:${I}`,
+    quoteAsset: `USDy:${I}`,
+  },
+  {
+    id: "ext-usdy",
+    label: "EXT / USDy",
+    baseAsset: `EXT:${I}`,
+    quoteAsset: `USDy:${I}`,
+  },
+  {
+    id: "eury-usd",
+    label: "EURy / USD",
+    baseAsset: `EURy:${I}`,
+    quoteAsset: `USD:${I}`,
+  },
+  {
+    id: "ars-eury",
+    label: "ARS / EURy",
+    baseAsset: `ARS:${I}`,
+    quoteAsset: `EURy:${I}`,
   },
 ];

--- a/frontend/lib/trading-pairs.test.ts
+++ b/frontend/lib/trading-pairs.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { TradingPair } from "@/types";
+import {
+  counterpartsFor,
+  pairExists,
+  pickPreferredDemoPair,
+  STAGING_DEMO_ISSUER,
+} from "@/lib/trading-pairs";
+
+const I = STAGING_DEMO_ISSUER;
+
+function pair(base: string, counter: string): TradingPair {
+  return {
+    base: base === "native" ? "XLM" : base.split(":")[0],
+    counter: counter === "native" ? "XLM" : counter.split(":")[0],
+    base_asset: base,
+    counter_asset: counter,
+    offer_count: 3,
+    last_updated: undefined,
+  };
+}
+
+describe("trading-pairs helpers", () => {
+  const pairs = [
+    pair(`EUR:${I}`, `USDy:${I}`),
+    pair(`BTC:${I}`, `EXT:${I}`),
+    pair("native", `USDy:${I}`),
+  ];
+
+  it("detects indexed markets in either direction", () => {
+    expect(pairExists(`EUR:${I}`, `USDy:${I}`, pairs)).toBe(true);
+    expect(pairExists(`USDy:${I}`, `EUR:${I}`, pairs)).toBe(true);
+    expect(pairExists("native", `BTC:${I}`, pairs)).toBe(false);
+  });
+
+  it("lists counterparts for an asset", () => {
+    expect(counterpartsFor(`USDy:${I}`, pairs).sort()).toEqual(
+      [`EUR:${I}`, "native"].sort()
+    );
+  });
+
+  it("prefers non-native demo pairs over native", () => {
+    expect(pickPreferredDemoPair(pairs)).toEqual({
+      from: `EUR:${I}`,
+      to: `USDy:${I}`,
+    });
+  });
+});

--- a/frontend/lib/trading-pairs.ts
+++ b/frontend/lib/trading-pairs.ts
@@ -1,0 +1,72 @@
+import type { TradingPair } from "@/types";
+
+/** Demo issuer used by the staged testnet orderbook fixtures. */
+export const STAGING_DEMO_ISSUER =
+  "GDMVY5CPSEY6IDQBEX7KMJSOVFNHMOMT5QY4MTOCSDFORV24AOFYDDGS";
+
+export function assetCode(asset: string): string {
+  if (asset === "native") return "XLM";
+  return asset.split(":")[0] || asset;
+}
+
+/** True when either offer direction is indexed for this asset pair. */
+export function pairExists(
+  a: string,
+  b: string,
+  pairs: TradingPair[] | undefined | null
+): boolean {
+  if (!pairs?.length || !a || !b || a === b) return false;
+  return pairs.some(
+    (pair) =>
+      (pair.base_asset === a && pair.counter_asset === b) ||
+      (pair.base_asset === b && pair.counter_asset === a)
+  );
+}
+
+/** Counter-assets that share an indexed market with `asset`. */
+export function counterpartsFor(
+  asset: string,
+  pairs: TradingPair[] | undefined | null
+): string[] {
+  if (!pairs?.length || !asset) return [];
+  const out = new Set<string>();
+  for (const pair of pairs) {
+    if (pair.base_asset === asset) out.add(pair.counter_asset);
+    if (pair.counter_asset === asset) out.add(pair.base_asset);
+  }
+  return Array.from(out);
+}
+
+const PREFERRED_DEMO_PAIRS: Array<[string, string]> = [
+  [`EUR:${STAGING_DEMO_ISSUER}`, `USDy:${STAGING_DEMO_ISSUER}`],
+  [`BTC:${STAGING_DEMO_ISSUER}`, `EXT:${STAGING_DEMO_ISSUER}`],
+  [`BTC:${STAGING_DEMO_ISSUER}`, `USDy:${STAGING_DEMO_ISSUER}`],
+  [`EXT:${STAGING_DEMO_ISSUER}`, `USDy:${STAGING_DEMO_ISSUER}`],
+  [`EURy:${STAGING_DEMO_ISSUER}`, `USD:${STAGING_DEMO_ISSUER}`],
+  [`ARS:${STAGING_DEMO_ISSUER}`, `EURy:${STAGING_DEMO_ISSUER}`],
+  [`ARS:${STAGING_DEMO_ISSUER}`, `USDy:${STAGING_DEMO_ISSUER}`],
+];
+
+/**
+ * Pick a demo pair that is actually indexed. Prefer non-native GDMVY5 markets
+ * because native (XLM) quote resolution is still flaky on staging.
+ */
+export function pickPreferredDemoPair(
+  pairs: TradingPair[] | undefined | null
+): { from: string; to: string } | null {
+  if (!pairs?.length) return null;
+
+  for (const [from, to] of PREFERRED_DEMO_PAIRS) {
+    if (pairExists(from, to, pairs)) return { from, to };
+  }
+
+  const nonNative = pairs.find(
+    (pair) => pair.base_asset !== "native" && pair.counter_asset !== "native"
+  );
+  if (nonNative) {
+    return { from: nonNative.base_asset, to: nonNative.counter_asset };
+  }
+
+  const any = pairs[0];
+  return { from: any.base_asset, to: any.counter_asset };
+}


### PR DESCRIPTION
## Summary
- Defaults and Quick Pairs now use staging GDMVY5 markets that currently return live quotes (EUR/USDy, BTC/EXT, BTC/USDy, EXT/USDy, EURy/USD, ARS/EURy).
- Receive-token selector only lists assets that share an indexed market with the pay asset.
- Stops auto-selecting native/XLM pairs (still `stale_market_data` on staging) and Circle USDC defaults that are not on the book.

## Test plan
- [x] `npm --prefix frontend run test -- lib/trading-pairs.test.ts hooks/useTradeFormStorage.test.ts components/swap/SwapPresetTemplates.test.tsx hooks/useSwapPresetTemplates.test.ts components/swap/SwapCard.test.tsx`
- [ ] After Vercel deploy: hard refresh, confirm Quick Pairs chips, EUR→USDy quote loads
- [ ] Confirm receive token list only shows counterparts for selected pay asset