### PR TITLE
fix(deploy,api): unblock EC2 git pull so native XLM quotes can land

### DIFF
--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -92,27 +92,25 @@ jobs:
         run: |
           set -euo pipefail
 
-          cat > /tmp/ssm-commands.json <<'EOF'
-          {
-            "commands": [
-              "cd /opt/stellarroute",
-              "git config --global --add safe.directory /opt/stellarroute",
-              "git fetch --all --prune",
-              "git checkout main",
-              "git pull --ff-only origin main",
-              "bash deploy/aws/scripts/deploy-ec2-staging.sh",
-              "for i in {1..60}; do if curl -fsS http://127.0.0.1:8080/health >/dev/null && curl -fsS http://127.0.0.1:8080/health/deps >/dev/null; then echo 'API is healthy'; break; fi; echo 'Waiting for API health...'; sleep 5; done"
-            ]
-          }
-          EOF
-          
-          # Substitute variables into the JSON
-          sed -i "s|git checkout main|git checkout ${DEPLOY_REF}|" /tmp/ssm-commands.json
-          sed -i "s|git pull --ff-only origin main|git pull --ff-only origin ${DEPLOY_REF}|" /tmp/ssm-commands.json
-          
-          # Add the smoke test command with URL
-          jq --arg url "${DEPLOY_URL}" '.commands += ["bash deploy/aws/scripts/ec2-postdeploy-smoke.sh \($url)"]' /tmp/ssm-commands.json > /tmp/ssm-commands-final.json
-          mv /tmp/ssm-commands-final.json /tmp/ssm-commands.json
+          # SSM RunShellScript often has no $HOME, so `git config --global` fails
+          # with "fatal: $HOME not set" and the tree never updates (stale Docker cache).
+          # Use per-command `git -c safe.directory=*` + HOME=/root instead.
+          jq -n \
+            --arg ref "${DEPLOY_REF}" \
+            --arg url "${DEPLOY_URL}" \
+            '{
+              commands: [
+                "cd /opt/stellarroute",
+                "export HOME=/root",
+                "git -c safe.directory=* fetch --all --prune",
+                ("git -c safe.directory=* checkout " + $ref),
+                ("git -c safe.directory=* pull --ff-only origin " + $ref),
+                "git -c safe.directory=* log -1 --oneline",
+                "bash deploy/aws/scripts/deploy-ec2-staging.sh",
+                "for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60; do if curl -fsS http://127.0.0.1:8080/health >/dev/null && curl -fsS http://127.0.0.1:8080/health/deps >/dev/null; then echo API_is_healthy; break; fi; echo Waiting_for_API_health; sleep 5; done",
+                ("bash deploy/aws/scripts/ec2-postdeploy-smoke.sh " + $url)
+              ]
+            }' > /tmp/ssm-commands.json
 
           COMMAND_ID="$(aws ssm send-command \
             --region "${AWS_REGION}" \

--- a/crates/api/src/routes/orderbook.rs
+++ b/crates/api/src/routes/orderbook.rs
@@ -415,10 +415,17 @@ async fn find_asset_id(state: &AppState, asset: &AssetPath) -> Result<uuid::Uuid
     let asset_type = asset.to_asset_type();
 
     let row = if asset.asset_code == "native" {
+        // Prefer the native asset id that backs live SDEX offers (duplicate
+        // native rows historically broke quote/orderbook resolution).
         sqlx::query(
             r#"
-            select id from assets
-            where asset_type = $1
+            select a.id
+            from assets a
+            left join sdex_offers o
+              on o.selling_asset_id = a.id or o.buying_asset_id = a.id
+            where a.asset_type = $1
+            group by a.id, a.created_at
+            order by count(o.offer_id) desc, a.created_at asc
             limit 1
             "#,
         )

--- a/crates/api/src/routes/price_history.rs
+++ b/crates/api/src/routes/price_history.rs
@@ -164,8 +164,13 @@ async fn find_asset_id(state: &AppState, asset: &AssetPath) -> Result<uuid::Uuid
     let row = if asset.asset_code == "native" {
         sqlx::query(
             r#"
-            select id from assets
-            where asset_type = $1
+            select a.id
+            from assets a
+            left join sdex_offers o
+              on o.selling_asset_id = a.id or o.buying_asset_id = a.id
+            where a.asset_type = $1
+            group by a.id, a.created_at
+            order by count(o.offer_id) desc, a.created_at asc
             limit 1
             "#,
         )

--- a/crates/api/src/routes/ws/broadcaster.rs
+++ b/crates/api/src/routes/ws/broadcaster.rs
@@ -331,8 +331,13 @@ async fn find_asset_id(state: &AppState, asset: &AssetPath) -> Result<Uuid, ApiE
     let row = if asset.asset_code == "native" {
         sqlx::query(
             r#"
-            select id from assets
-            where asset_type = $1
+            select a.id
+            from assets a
+            left join sdex_offers o
+              on o.selling_asset_id = a.id or o.buying_asset_id = a.id
+            where a.asset_type = $1
+            group by a.id, a.created_at
+            order by count(o.offer_id) desc, a.created_at asc
             limit 1
             "#,
         )

--- a/deploy/aws/scripts/deploy-ec2-staging.sh
+++ b/deploy/aws/scripts/deploy-ec2-staging.sh
@@ -32,9 +32,14 @@ for key in "${required_vars[@]}"; do
 done
 
 cd "${ROOT}"
+GIT_SHA="$(git -c safe.directory=* rev-parse --short HEAD 2>/dev/null || echo unknown)"
+echo "Deploying git SHA ${GIT_SHA}"
+
 docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod config >/dev/null
 docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod up -d --build
 
 echo "Local health checks:"
-curl -sf http://127.0.0.1:${API_HOST_PORT:-8080}/health && echo " - /health OK"
-curl -sf http://127.0.0.1:${API_HOST_PORT:-8080}/health/deps && echo " - /health/deps OK"
+# API may still be booting; do not fail the whole deploy on a racing curl here.
+# Post-deploy smoke waits for readiness separately.
+curl -sf http://127.0.0.1:${API_HOST_PORT:-8080}/health && echo " - /health OK" || echo " - /health not ready yet"
+curl -sf http://127.0.0.1:${API_HOST_PORT:-8080}/health/deps && echo " - /health/deps OK" || echo " - /health/deps not ready yet"


### PR DESCRIPTION
## Summary
- **Root cause of broken XLM quotes:** EC2 SSM deploy never `git pull`s because `git config --global` fails with `$HOME not set`, so Docker keeps a cached pre-#1154/#1155 image. Horizon has XLM/USDy liquidity; staging DB/API does not.
- Fix SSM commands to `export HOME=/root` + `git -c safe.directory=* …` and print the deployed SHA.
- Align orderbook / price_history / WS `find_asset_id` for native with the quote path (prefer asset id with live offers).

## Test plan
- [x] `cargo test -p stellarroute-api --lib quote::`
- [ ] Merge → `Deploy EC2 Staging` succeeds and logs a recent `git log -1` SHA
- [ ] `curl …/quote/native/USDy:GDMVY5…?amount=10` returns a price (not `stale_market_data`)
- [ ] `curl …/orderbook/native/USDy:GDMVY5…` returns non-empty levels