### PR TITLE
fix(ci): hard-reset EC2 checkout so staging gets main

### DIFF
--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -95,6 +95,9 @@ jobs:
           # SSM RunShellScript often has no $HOME, so `git config --global` fails
           # with "fatal: $HOME not set" and the tree never updates (stale Docker cache).
           # Use per-command `git -c safe.directory=*` + HOME=/root instead.
+          # Host tree is often dirty/untracked from manual bootstrap; ff-only pull
+          # aborts and Docker rebuilds from a stale checkout. Hard-reset to origin
+          # while keeping .env.prod secrets.
           jq -n \
             --arg ref "${DEPLOY_REF}" \
             --arg url "${DEPLOY_URL}" \
@@ -103,8 +106,9 @@ jobs:
                 "cd /opt/stellarroute",
                 "export HOME=/root",
                 "git -c safe.directory=* fetch --all --prune",
-                ("git -c safe.directory=* checkout " + $ref),
-                ("git -c safe.directory=* pull --ff-only origin " + $ref),
+                ("git -c safe.directory=* checkout -B " + $ref + " origin/" + $ref),
+                "git -c safe.directory=* reset --hard HEAD",
+                "git -c safe.directory=* clean -fd -e .env.prod -e .env -e .env.*",
                 "git -c safe.directory=* log -1 --oneline",
                 "bash deploy/aws/scripts/deploy-ec2-staging.sh",
                 "for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60; do if curl -fsS http://127.0.0.1:8080/health >/dev/null && curl -fsS http://127.0.0.1:8080/health/deps >/dev/null; then echo API_is_healthy; break; fi; echo Waiting_for_API_health; sleep 5; done",


### PR DESCRIPTION
## Summary
- Last deploy finally could talk to git, but `git pull --ff-only` aborted on dirty/untracked files under `/opt/stellarroute`, so Docker still used a pre-#1154 image and XLM quotes stayed broken.
- Switch SSM sync to `checkout -B origin/<ref>` + `clean -fd` (keeps `.env.prod`).

## Test plan
- [ ] Deploy logs show `git log -1` at current main SHA
- [ ] Docker rebuilds api/indexer (not fully CACHED crates)
- [ ] `curl` native→USDy quote returns a price