### PR TITLE
fix(ci): clean EC2 tree before checkout and fail if sync drifts

### DIFF
--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -95,24 +95,20 @@ jobs:
           # SSM RunShellScript often has no $HOME, so `git config --global` fails
           # with "fatal: $HOME not set" and the tree never updates (stale Docker cache).
           # Use per-command `git -c safe.directory=*` + HOME=/root instead.
-          # Host tree is often dirty/untracked from manual bootstrap; ff-only pull
-          # aborts and Docker rebuilds from a stale checkout. Hard-reset to origin
-          # while keeping .env.prod secrets.
+          # Host tree is often dirty/untracked from manual bootstrap. Clean/reset
+          # BEFORE checkout, keep .env.prod, and fail the SSM run if sync fails
+          # (AWS-RunShellScript continues past non-zero commands unless we exit).
+          # shellcheck disable=SC2016
+          SYNC_CMD="set -eu; cd /opt/stellarroute; export HOME=/root; git -c safe.directory=* fetch --all --prune; git -c safe.directory=* reset --hard HEAD; git -c safe.directory=* clean -fd -e .env.prod -e .env -e '.env.*'; git -c safe.directory=* checkout -B ${DEPLOY_REF} origin/${DEPLOY_REF}; git -c safe.directory=* log -1 --oneline; test \"\$(git -c safe.directory=* rev-parse HEAD)\" = \"\$(git -c safe.directory=* rev-parse origin/${DEPLOY_REF})\""
           jq -n \
-            --arg ref "${DEPLOY_REF}" \
+            --arg sync "${SYNC_CMD}" \
             --arg url "${DEPLOY_URL}" \
             '{
               commands: [
-                "cd /opt/stellarroute",
-                "export HOME=/root",
-                "git -c safe.directory=* fetch --all --prune",
-                ("git -c safe.directory=* checkout -B " + $ref + " origin/" + $ref),
-                "git -c safe.directory=* reset --hard HEAD",
-                "git -c safe.directory=* clean -fd -e .env.prod -e .env -e .env.*",
-                "git -c safe.directory=* log -1 --oneline",
-                "bash deploy/aws/scripts/deploy-ec2-staging.sh",
+                $sync,
+                "bash /opt/stellarroute/deploy/aws/scripts/deploy-ec2-staging.sh",
                 "for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30 31 32 33 34 35 36 37 38 39 40 41 42 43 44 45 46 47 48 49 50 51 52 53 54 55 56 57 58 59 60; do if curl -fsS http://127.0.0.1:8080/health >/dev/null && curl -fsS http://127.0.0.1:8080/health/deps >/dev/null; then echo API_is_healthy; break; fi; echo Waiting_for_API_health; sleep 5; done",
-                ("bash deploy/aws/scripts/ec2-postdeploy-smoke.sh " + $url)
+                ("bash /opt/stellarroute/deploy/aws/scripts/ec2-postdeploy-smoke.sh " + $url)
               ]
             }' > /tmp/ssm-commands.json
 


### PR DESCRIPTION
## Summary
- Previous hard-reset still ran `checkout` before `clean`, so sync aborted and Docker rebuilt `ecab927`.
- Reset + clean first (keep `.env.prod`), then checkout `origin/<ref>`, and `test` that HEAD matches origin so a failed sync fails the workflow.

## Test plan
- [ ] Deploy logs show current main SHA (not `ecab927`)
- [ ] Docker rebuilds crates (not fully CACHED) — may take several minutes
- [ ] native→USDy quote returns a price