### PR TITLE
fix(frontend): stop quote TTL race showing Error fetching quote

### DIFF
--- a/frontend/components/swap/SwapButton.tsx
+++ b/frontend/components/swap/SwapButton.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { AlertCircle, Wallet, ShieldOff } from "lucide-react";
+import { AlertCircle, Wallet, ShieldOff, RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Spinner } from "@/components/ui/spinner";
 import {
@@ -21,6 +21,7 @@ export type SwapButtonState =
   | "high_impact_warning"
   | "slippage_ack_required"
   | "refreshing_quote"
+  | "stale_quote"
   | "ready"
   | "executing"
   | "error"
@@ -30,6 +31,7 @@ interface SwapButtonProps {
   state: SwapButtonState;
   onSwap: () => void;
   onConnectWallet?: () => void;
+  onRefreshQuote?: () => void;
   isLoading?: boolean;
   className?: string;
 }
@@ -38,6 +40,7 @@ export function SwapButton({
   state,
   onSwap,
   onConnectWallet,
+  onRefreshQuote,
   isLoading = false,
   className,
 }: SwapButtonProps) {
@@ -119,6 +122,18 @@ export function SwapButton({
           variant: "outline" as const,
           icon: <Spinner className="mr-2" label={t("swap.cta.loadingQuote")} />,
           className: "border-primary/40 text-primary",
+        };
+      case "stale_quote":
+        return {
+          label: t("swap.card.refreshQuote"),
+          onClick: onRefreshQuote,
+          disabled: isLoading || !onRefreshQuote,
+          disabledReason: isLoading
+            ? "Fetching a fresh quote."
+            : "Quote expired — refresh to continue.",
+          variant: "default" as const,
+          icon: <RefreshCw className={cn("mr-2 h-5 w-5", isLoading && "animate-spin")} />,
+          className: "bg-primary hover:bg-primary/90 shadow-lg shadow-primary/20",
         };
       case "error":
         return {

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -44,6 +44,7 @@ import {
 import { useBatchQuote, usePairs, useRoutes } from '@/hooks/useApi';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import type { QuoteRequestItem } from '@/lib/api/client';
+import { StellarRouteApiError } from '@/lib/api/client';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
 import { useQuoteStreamStatus } from '@/hooks/useQuoteStreamStatus';
 import { useQuoteRefreshAnnouncements } from '@/hooks/useQuoteRefreshAnnouncements';
@@ -722,16 +723,23 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
     if (signBlocked) return 'permission_blocked';
     if (memoError) return 'error'; // Block swap if there is a memo validation error
     if (!fromAmount || parseFloat(fromAmount) === 0) return 'no_amount';
-    if (quote.error) return 'error';
-    if (requiresFreshQuote) return 'refreshing_quote';
+    if (requiresFreshQuote || quote.loading || quote.isRecovering) {
+      return 'refreshing_quote';
+    }
+    const refreshableQuoteError =
+      quote.error instanceof StellarRouteApiError &&
+      (quote.error.code === 'stale_market_data' ||
+        quote.error.code === 'quote_expired');
+    // Stale / refreshable expiry → clickable refresh, never "Error fetching quote".
+    if (quote.isStale || refreshableQuoteError) return 'stale_quote';
+    // Hard quote errors only when there is nothing usable on screen.
+    if (quote.error && !quote.data) return 'error';
     if (
       !balanceState.error &&
       parseFloat(fromAmount) > parseFloat(fromBalance)
     )
       return 'insufficient_balance';
     if (quote.priceImpact > 10) return 'high_impact_warning';
-    if (quote.loading) return 'refreshing_quote';
-    if (quote.isStale) return 'error';
     // One-hop classic preflight always applies — AMM/multi-hop never bypass gates.
     if (!classicPreflight.ok) return 'error';
     if (swapExecutionMode.mode === 'disabled') return 'error';
@@ -743,7 +751,9 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
     networkMismatch,
     capabilities,
     optimistic.submitLock,
+    quote.data,
     quote.error,
+    quote.isRecovering,
     quote.isStale,
     quote.loading,
     quote.priceImpact,
@@ -757,7 +767,10 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
   const displayButtonState = storyPresentation?.buttonState ?? buttonState;
   const displayQuoteLoading = storyPresentation?.quoteLoading ?? quote.loading;
   const displayQuoteStale = storyPresentation?.quoteStale ?? quote.isStale;
-  const displayQuoteError = storyPresentation?.quoteError ?? quote.error;
+  // Soft-fail: keep numbers, hide hard error copy while a quote is still shown.
+  const displayQuoteError =
+    storyPresentation?.quoteError ??
+    (quote.data ? null : quote.error);
   const displayQuotePriceImpact =
     storyPresentation?.quotePriceImpact ?? quote.priceImpact;
   const displayToAmount = storyPresentation?.toAmount ?? toAmount;
@@ -1522,6 +1535,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
               state={displayButtonState}
               onSwap={handleSwap}
               onConnectWallet={() => connect('freighter')} // Connection managed by WalletProvider
+              onRefreshQuote={() => quote.refresh({ force: true })}
               isLoading={displayQuoteLoading}
             />
           </div>

--- a/frontend/hooks/useQuote.ts
+++ b/frontend/hooks/useQuote.ts
@@ -89,8 +89,12 @@ export function useQuote({ fromToken, toToken, amount, type = 'sell' }: UseQuote
   // Prefer WS data when the socket is healthy, otherwise fall back to polling.
   const data = wsConnected && wsData ? wsData : pollingData;
 
-  // Only surface WS errors when polling has no data path of its own and WS is up.
-  const error = pollingError ?? (wsConnected && wsError ? wsError : null);
+  // Soft-fail background refresh: if we still have a displayable quote, do not
+  // surface a hard error (that raced into "Error fetching quote" over good numbers).
+  // First-load / no-data failures still propagate so the empty state can recover.
+  const error = data
+    ? null
+    : pollingError ?? (wsConnected && wsError ? wsError : null);
 
   const result = useMemo(() => {
     if (!data) {

--- a/frontend/hooks/useQuoteRefresh.ts
+++ b/frontend/hooks/useQuoteRefresh.ts
@@ -403,6 +403,30 @@ export function useQuoteRefresh(
     return () => clearInterval(id);
   }, [autoRefreshEnabled, autoRefreshIntervalMs, canRequest]);
 
+  // Refresh shortly before the client stale floor so a short API cache TTL
+  // cannot leave the CTA on "outdated" until the next 15–20s interval tick.
+  useEffect(() => {
+    if (!autoRefreshEnabled || !canRequest || lastQuotedAtMs == null) return;
+    if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+      return;
+    }
+
+    const refreshLeadMs = 750;
+    const dueAtMs = lastQuotedAtMs + Math.max(0, staleAfterMs - refreshLeadMs);
+    const delayMs = dueAtMs - Date.now();
+    // Already past the lead window — leave refresh to the interval / manual CTA.
+    if (delayMs <= 0) return;
+
+    const id = setTimeout(() => {
+      if (typeof document !== 'undefined' && document.visibilityState !== 'visible') {
+        return;
+      }
+      setTick((n) => n + 1);
+    }, delayMs);
+
+    return () => clearTimeout(id);
+  }, [autoRefreshEnabled, canRequest, lastQuotedAtMs, staleAfterMs]);
+
   const manualRefreshCoolingDown =
     manualCooldownUntil > 0 && nowMs < manualCooldownUntil;
 

--- a/frontend/lib/quote-stale.test.ts
+++ b/frontend/lib/quote-stale.test.ts
@@ -47,13 +47,35 @@ describe('isQuoteStale', () => {
     expect(isQuoteStale(last, Date.now(), 1000)).toBe(true);
   });
 
-  it('uses expiresAt when it is still ahead of the receive time', () => {
+  it('does not let a short cache expiresAt mark stale before the client window', () => {
     const last = Date.now();
     const expiresAt = last + 2_000;
     expect(isQuoteStale(last, last + 1_000, QUOTE_STALE_AFTER_MS, expiresAt)).toBe(
       false,
     );
+    // Cache TTL elapsed, but client floor has not — still fresh for CTA.
     expect(isQuoteStale(last, expiresAt, QUOTE_STALE_AFTER_MS, expiresAt)).toBe(
+      false,
+    );
+    expect(
+      isQuoteStale(
+        last,
+        last + QUOTE_STALE_AFTER_MS,
+        QUOTE_STALE_AFTER_MS,
+        expiresAt,
+      ),
+    ).toBe(true);
+  });
+
+  it('honors a longer server expiresAt beyond the client window', () => {
+    const last = Date.now();
+    const expiresAt = last + 30_000;
+    vi.advanceTimersByTime(QUOTE_STALE_AFTER_MS);
+    expect(isQuoteStale(last, Date.now(), QUOTE_STALE_AFTER_MS, expiresAt)).toBe(
+      false,
+    );
+    vi.advanceTimersByTime(30_000 - QUOTE_STALE_AFTER_MS);
+    expect(isQuoteStale(last, Date.now(), QUOTE_STALE_AFTER_MS, expiresAt)).toBe(
       true,
     );
   });

--- a/frontend/lib/quote-stale.ts
+++ b/frontend/lib/quote-stale.ts
@@ -1,9 +1,10 @@
 /**
  * Quote freshness / stale UI timing.
  *
- * Backend caches GET /api/v1/quote responses for **5 seconds**
- * (see docs/api/openapi.yaml). After that window, displayed numbers may
- * diverge from the next server response — show a stale indicator.
+ * API `expires_at` / `ttl_seconds` track the **server cache TTL** (often 2s via
+ * `QUOTE_CACHE_TTL_SECONDS`), not a trading safety window. UI stale detection
+ * therefore uses a client receive-time floor so a 2s cache expiry cannot brick
+ * the swap CTA between auto-refresh ticks.
  */
 export const QUOTE_STALE_AFTER_MS = 5500;
 
@@ -22,13 +23,16 @@ export const QUOTE_AUTO_REFRESH_INTERVAL_MS = 20_000;
 export const QUOTE_MANUAL_REFRESH_COOLDOWN_MS = 2000;
 
 /**
- * Returns true when a successful quote is older than `staleAfterMs` relative to `nowMs`.
- * If `expiresAtMs` is provided **and is still in the future relative to when we
- * received the quote**, it takes precedence over `staleAfterMs`.
+ * Returns true when a successful quote is older than the UI stale window.
  *
- * Cached API responses can arrive with an already-past `expires_at`; treating
- * those as immediately stale bricks the swap CTA ("Session restored" forever).
- * In that case fall back to the client receive-time window.
+ * Uses the **later** of:
+ * - client receive-time + `staleAfterMs`
+ * - server `expires_at` (when still ahead of receive time)
+ *
+ * So a short cache TTL (2s) cannot mark a quote stale before the client floor,
+ * while a longer server expiry can keep the quote fresh. Already-past
+ * `expires_at` values are ignored (cached responses) and fall back to the
+ * client window — otherwise the CTA stays bricked after session restore.
  */
 export function isQuoteStale(
   lastSuccessTimeMs: number | null,
@@ -38,13 +42,15 @@ export function isQuoteStale(
 ): boolean {
   if (lastSuccessTimeMs == null) return false;
 
+  const clientStaleAtMs = lastSuccessTimeMs + staleAfterMs;
+
   if (
     expiresAtMs != null &&
     Number.isFinite(expiresAtMs) &&
     expiresAtMs > lastSuccessTimeMs
   ) {
-    return nowMs >= expiresAtMs;
+    return nowMs >= Math.max(expiresAtMs, clientStaleAtMs);
   }
 
-  return nowMs - lastSuccessTimeMs >= staleAfterMs;
+  return nowMs >= clientStaleAtMs;
 }


### PR DESCRIPTION
## Summary
- Stop treating the API's 2s `expires_at` cache TTL as an immediate UI-stale / hard-error gate; keep a client stale floor so good XLM→USDy quotes stay actionable.
- Soft-fail background quote refresh when a quote is still on screen, and map stale/recovering states to refresh/loading CTAs instead of **Error fetching quote**.
- Refresh proactively just before the client stale window so the outdated banner does not stick until the next poll interval.

## Test plan
- [x] `npm --prefix frontend run test -- lib/quote-stale.test.ts hooks/useQuoteRefresh.test.ts components/swap/SwapButton.test.tsx`
- [ ] Hard-refresh production/staging swap UI with XLM→USDy
- [ ] Confirm quote numbers stay visible without flipping to **Error fetching quote** after ~2s
- [ ] Confirm stale path shows **Refresh quote** (not a hard error) if the quote ages past the client floor
- [ ] Confirm a transient refresh failure does not paint a red error over still-valid quote data