### PR TITLE
fix(api): unblock browser wallet swap prepare/submit

### DIFF
--- a/crates/api/src/middleware/auth.rs
+++ b/crates/api/src/middleware/auth.rs
@@ -92,6 +92,17 @@ fn is_public_v2_metadata(method: &axum::http::Method, path: &str) -> bool {
 const CCTP_BRIDGE_PREFIX: &str = "/api/v2/bridge/cctp/";
 const CCTP_QUOTE_PATH: &str = "/api/v2/bridge/cctp/quote";
 
+/// Classic browser swap flow: prepare returns unsigned XDR; submit requires a
+/// wallet-signed envelope bound to `quote_id`. No integrator API key is used by
+/// the public frontend — authorization is the Stellar signature + sender lock.
+const CLASSIC_SWAP_PREPARE_PATH: &str = "/api/v1/swap/prepare";
+const CLASSIC_SWAP_SUBMIT_PATH: &str = "/api/v1/swap/submit";
+
+fn is_classic_swap_exempt(method: &axum::http::Method, path: &str) -> bool {
+    *method == axum::http::Method::POST
+        && (path == CLASSIC_SWAP_PREPARE_PATH || path == CLASSIC_SWAP_SUBMIT_PATH)
+}
+
 fn is_valid_uuid(segment: &str) -> bool {
     if segment.len() != 36 {
         return false;
@@ -244,6 +255,12 @@ where
         let config = self.config.clone();
 
         Box::pin(async move {
+            // CORS preflight must reach the CORS layer. Auth sits outside CORS in
+            // some deployments; never 401 OPTIONS or browsers report "Failed to fetch".
+            if req.method() == axum::http::Method::OPTIONS {
+                return inner.call(req).await;
+            }
+
             if is_always_exempt(req.uri().path()) {
                 return inner.call(req).await;
             }
@@ -253,6 +270,10 @@ where
             }
 
             if is_cctp_bridge_exempt(req.method(), req.uri().path()) {
+                return inner.call(req).await;
+            }
+
+            if is_classic_swap_exempt(req.method(), req.uri().path()) {
                 return inner.call(req).await;
             }
 
@@ -476,5 +497,27 @@ mod tests {
         assert!(!is_public_v2_metadata(&Method::POST, "/api/v2"));
         assert!(!is_public_v2_metadata(&Method::GET, "/api/v2/"));
         assert!(!is_public_v2_metadata(&Method::GET, "/api/v2/assets"));
+    }
+
+    #[test]
+    fn classic_swap_prepare_and_submit_are_auth_exempt() {
+        use axum::http::Method;
+        assert!(is_classic_swap_exempt(
+            &Method::POST,
+            "/api/v1/swap/prepare"
+        ));
+        assert!(is_classic_swap_exempt(
+            &Method::POST,
+            "/api/v1/swap/submit"
+        ));
+        assert!(!is_classic_swap_exempt(
+            &Method::GET,
+            "/api/v1/swap/prepare"
+        ));
+        assert!(!is_classic_swap_exempt(
+            &Method::POST,
+            "/api/v1/swap/prepare/extra"
+        ));
+        assert!(!is_classic_swap_exempt(&Method::POST, "/api/v1/quote"));
     }
 }

--- a/crates/api/src/server.rs
+++ b/crates/api/src/server.rs
@@ -285,16 +285,14 @@ impl Server {
             info!("✅ Response compression enabled");
         }
 
-        // Add CORS if enabled
+        // Rate limit closest to the router, then auth, then CORS outside auth so
+        // preflight/OPTIONS and auth error responses still get ACAO headers.
+        // (Last `.layer` is outermost: Trace → CORS → Auth → RateLimit → Router.)
+        app = app.layer(rate_limit);
+        app = app.layer(AuthLayer::default());
         if config.enable_cors {
             app = app.layer(build_cors_layer());
         }
-
-        // Add rate limiting (innermost — runs before CORS/compression in the response path)
-        app = app.layer(rate_limit);
-
-        // Add API key authentication
-        app = app.layer(AuthLayer::default());
 
         // Add request logging — each request gets a unique span with method, URI, status, and latency.
         app = app.layer(

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -43,6 +43,7 @@ import {
 } from '@/lib/trading-pairs';
 import { useBatchQuote, usePairs, useRoutes } from '@/hooks/useApi';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
+import { useStellarRouteClient } from '@/hooks/useStellarRouteClient';
 import type { QuoteRequestItem } from '@/lib/api/client';
 import { StellarRouteApiError } from '@/lib/api/client';
 import { useOnlineStatus } from '@/hooks/useOnlineStatus';
@@ -393,6 +394,10 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
     setTransactionPending,
   } = useWallet();
 
+  // Same network-aware origin as quotes — never fall back to the singleton's
+  // localhost default when only NEXT_PUBLIC_API_URL_TESTNET is set.
+  const apiClient = useStellarRouteClient();
+
   // Horizon lookup must follow the wallet's network (where funds live), not
   // only the app toggle — otherwise balances show Unavailable / zero.
   const balanceHorizonNetwork = walletNetwork ?? walletAppNetwork;
@@ -599,6 +604,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
     // No client-built XDR / direct-Horizon product path — fail closed when unavailable.
     if (swapExecutionMode.mode === 'api_prepare_submit') {
       const apiDeps = createApiSwapExecution({
+        client: apiClient,
         sender: walletAddress,
         slippageBps: Math.round(slippage * 100),
         network: walletAppNetwork,
@@ -623,6 +629,7 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
       getPreparedAmounts: () => null,
     };
   }, [
+    apiClient,
     walletReady,
     walletId,
     walletAddress,

--- a/frontend/lib/api/client.ts
+++ b/frontend/lib/api/client.ts
@@ -198,9 +198,14 @@ export class StellarRouteClient {
 
   constructor(baseUrlOrOptions?: string | StellarRouteClientOptions) {
     const proxyEnabled = process.env.NEXT_PUBLIC_API_PROXY === 'true';
+    // Static NEXT_PUBLIC_* access only — dynamic process.env[key] is not inlined
+    // on Vercel. Prefer shared URL, then testnet staging URL, never leave prod
+    // on localhost when only NEXT_PUBLIC_API_URL_TESTNET is configured.
     const defaultBaseUrl = proxyEnabled
       ? ''
-      : (process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost:8080');
+      : (process.env.NEXT_PUBLIC_API_URL?.trim() ||
+          process.env.NEXT_PUBLIC_API_URL_TESTNET?.trim() ||
+          'http://localhost:8080');
 
     let baseUrl = defaultBaseUrl;
     let retries = 2;


### PR DESCRIPTION
## Summary
- Staging `OPTIONS`/`POST /api/v1/swap/prepare` returned **401 API key required** with **no CORS ACAO**, so the browser reported `Failed to fetch` / "Network connection interrupted" before Freighter could sign.
- Exempt classic `POST /api/v1/swap/prepare` and `/submit` from the global API-key gate (wallet signature + sender lock remain the auth), pass OPTIONS through, and move CORS outside auth.
- Wire swap execution to `useStellarRouteClient()` / testnet API URL fallback so prepare does not silently target `localhost` when only `NEXT_PUBLIC_API_URL_TESTNET` is set.

## Test plan
- [x] `cargo test -p stellarroute-api middleware::auth --lib`
- [x] `npm --prefix frontend run test -- lib/swap/api-execution.test.ts`
- [ ] After EC2 deploy: `OPTIONS` + `POST` prepare from `Origin: https://www.stellarroute.app` return CORS headers (not bare 401)
- [ ] Production UI: Review Swap opens Freighter instead of Swap failed / Failed to fetch
- [ ] Complete a classic XLM→USDy testnet prepare → sign → submit