### PR TITLE
fix(swap): resubmit same signed tx after Horizon dependency blip

### DIFF
--- a/crates/api/src/broadcast/mod.rs
+++ b/crates/api/src/broadcast/mod.rs
@@ -149,8 +149,10 @@ impl HorizonTransactionBroadcaster {
     }
 
     pub fn from_env() -> Self {
+        // Path payments can take longer than a simple /health probe under load;
+        // 10s was racing Horizon accept → false dependency_unavailable / stuck submitting.
         let client = Client::builder()
-            .timeout(Duration::from_secs(10))
+            .timeout(Duration::from_secs(30))
             .build()
             .unwrap_or_default();
 

--- a/frontend/components/swap/TransactionConfirmationModal.tsx
+++ b/frontend/components/swap/TransactionConfirmationModal.tsx
@@ -24,6 +24,9 @@ import type { TradeParams } from '@/hooks/useTransactionLifecycle';
 import { PostSwapSuccessScreen } from './PostSwapSuccessScreen';
 import { useSwapI18n } from '@/lib/swap-i18n';
 import { getTraderErrorCopy } from '@/lib/api/trader-error-copy';
+import { isLifecycleError } from '@/lib/swap/lifecycle-error';
+import { conflictStatusFromDetails } from '@/lib/swap/api-execution';
+import { StellarRouteApiError } from '@/lib/api/client';
 
 export interface TransactionConfirmationModalProps {
   isOpen: boolean;
@@ -145,6 +148,10 @@ export function TransactionConfirmationModal({
     status === 'failed' && (error || errorMessage)
       ? getTraderErrorCopy(error ?? { message: errorMessage! })
       : null;
+  const isPendingReconcile =
+    (isLifecycleError(error) && error.status === 'pending_reconcile') ||
+    (error instanceof StellarRouteApiError &&
+      conflictStatusFromDetails(error.details) === 'pending_reconcile');
   const droppedCopy =
     status === 'dropped'
       ? getTraderErrorCopy(new Error('Transaction timed out'))
@@ -323,10 +330,12 @@ export function TransactionConfirmationModal({
             <>
               <Button
                 ref={primaryActionRef}
-                onClick={onTryAgain}
+                onClick={isPendingReconcile ? onResubmit : onTryAgain}
                 className="flex-1 min-h-[48px] h-12 rounded-xl font-bold"
               >
-                {t('swap.confirm.cta.tryAgain')}
+                {isPendingReconcile
+                  ? t('swap.confirm.cta.resubmit')
+                  : t('swap.confirm.cta.tryAgain')}
               </Button>
               <Button
                 variant="outline"

--- a/frontend/hooks/useTransactionLifecycle.ts
+++ b/frontend/hooks/useTransactionLifecycle.ts
@@ -168,6 +168,8 @@ export function useTransactionLifecycle(
   );
   // Ref to allow cancel() to abort an in-progress signing
   const cancelledRef = useRef(false);
+  /** Preserved after Freighter signs so pending_reconcile can retry submit only. */
+  const lastSignedXdrRef = useRef<string | null>(null);
 
   const { addTransaction, updateTransactionStatus } = useTransactionHistory(
     tradeParams?.walletAddress ?? null
@@ -183,6 +185,7 @@ export function useTransactionLifecycle(
   const initiateSwap = useCallback(
     async (params: TradeParams) => {
       cancelledRef.current = false;
+      lastSignedXdrRef.current = null;
       setTradeParams(params);
       setTxHash(undefined);
       clearError();
@@ -285,8 +288,10 @@ export function useTransactionLifecycle(
       let signedXdr: string;
       try {
         signedXdr = await signTransaction(xdrToSign);
+        lastSignedXdrRef.current = signedXdr;
       } catch (err: unknown) {
         if (cancelledRef.current) return;
+        lastSignedXdrRef.current = null;
         const rawMsg =
           err instanceof Error ? err.message : "Signature failed";
         const userFacingMsg = isRejectionError(rawMsg)
@@ -317,7 +322,7 @@ export function useTransactionLifecycle(
 
       if (cancelledRef.current) return;
 
-      // Step 2: Submit
+      // Step 3: Submit
       setStatus("submitted");
       emitSwapFunnelEvent("swap_submitted", funnelPayloadFromTrade(params));
       updateTransactionStatus(tempId, "submitted");
@@ -415,18 +420,79 @@ export function useTransactionLifecycle(
   }, [status, clearDeadlineTimer, clearError]);
 
   const resubmit = useCallback(async () => {
+    // After Horizon broadcast ambiguity the quote stays `submitting` server-side.
+    // Retry the same signed envelope — never prepare/sign again.
+    if (
+      status === "failed" &&
+      error?.status === "pending_reconcile" &&
+      tradeParams &&
+      lastSignedXdrRef.current
+    ) {
+      cancelledRef.current = false;
+      clearError();
+      clearDeadlineTimer();
+      const tempId = txIdRef.current ?? `pending_${Date.now()}`;
+      txIdRef.current = tempId;
+      setStatus("submitted");
+      updateTransactionStatus(tempId, "submitted");
+      deadlineTimerRef.current = setTimeout(() => {
+        setStatus((current) => {
+          if (current === "submitted") {
+            updateTransactionStatus(tempId, "dropped");
+            return "dropped";
+          }
+          return current;
+        });
+      }, deadlineMs);
+      try {
+        const result = await submitTransaction(lastSignedXdrRef.current);
+        clearDeadlineTimer();
+        if (cancelledRef.current) return;
+        setTxHash(result.hash);
+        setStatus("confirmed");
+        updateTransactionStatus(tempId, "confirmed", { hash: result.hash });
+      } catch (err: unknown) {
+        clearDeadlineTimer();
+        if (cancelledRef.current) return;
+        const msg = failWith(err);
+        setStatus("failed");
+        updateTransactionStatus(tempId, "failed", { errorMessage: msg });
+      }
+      return;
+    }
+
     if (status === "dropped" && tradeParams) {
       await initiateSwap(tradeParams);
     }
-  }, [status, tradeParams, initiateSwap]);
+  }, [
+    status,
+    error?.status,
+    tradeParams,
+    initiateSwap,
+    submitTransaction,
+    clearError,
+    clearDeadlineTimer,
+    updateTransactionStatus,
+    deadlineMs,
+    failWith,
+  ]);
 
   const tryAgain = useCallback(() => {
+    // Prefer reconcile retry when we still hold the signed envelope.
+    if (
+      status === "failed" &&
+      error?.status === "pending_reconcile" &&
+      lastSignedXdrRef.current
+    ) {
+      void resubmit();
+      return;
+    }
     clearDeadlineTimer();
     setStatus("review");
     clearError();
     setTxHash(undefined);
     // tradeParams is preserved so the modal can pre-populate
-  }, [clearDeadlineTimer, clearError]);
+  }, [status, error?.status, resubmit, clearDeadlineTimer, clearError]);
 
   const dismiss = useCallback(() => {
     clearDeadlineTimer();
@@ -434,6 +500,7 @@ export function useTransactionLifecycle(
     clearError();
     setTxHash(undefined);
     setTradeParams(undefined);
+    lastSignedXdrRef.current = null;
   }, [clearDeadlineTimer, clearError]);
 
   return {

--- a/frontend/lib/api/trader-error-copy.ts
+++ b/frontend/lib/api/trader-error-copy.ts
@@ -134,9 +134,11 @@ const API_ERROR_COPY: Record<ApiErrorCode, TraderErrorCopy> = {
   },
   dependency_unavailable: {
     headline: 'Network dependency unavailable',
-    explanation: 'Horizon or another upstream dependency is temporarily unreachable.',
-    recoveryAction: 'Wait briefly and reconcile before preparing a new swap.',
-    ctaLabel: 'Retry shortly',
+    explanation:
+      'Horizon did not confirm the broadcast yet. Your signed swap may still be pending on-chain.',
+    recoveryAction:
+      'Tap Retry submit to send the same signed transaction again. Do not prepare a new swap.',
+    ctaLabel: 'Retry submit',
   },
   unsupported_execution_mode: {
     headline: 'AMM and Soroban swaps are not supported yet',
@@ -514,6 +516,20 @@ export function getTraderErrorCopy(error: unknown): TraderErrorCopy {
       lifecycleStatusFromApiError(error),
     );
     if (conflictCopy) return conflictCopy;
+
+    if (
+      error.code === 'not_executable' &&
+      /op_no_trust/i.test(error.message)
+    ) {
+      return {
+        headline: 'Missing asset trustline',
+        explanation:
+          'Your wallet has not trusted the destination asset yet, so Horizon rejected the swap.',
+        recoveryAction:
+          'In Freighter → Manage assets, add USDy (issuer …FYDDGS), then refresh and swap again.',
+        ctaLabel: 'Add trustline',
+      };
+    }
 
     const byCode = copyFromApiCode(error.code);
     if (byCode) return byCode;

--- a/frontend/lib/swap/api-execution.ts
+++ b/frontend/lib/swap/api-execution.ts
@@ -257,7 +257,14 @@ export function userCopyForSwapExecutionError(err: unknown): string {
     return 'Confirmation timed out. Your submission may still reconcile on-chain — check wallet activity before preparing again.';
   }
   if (code === 'dependency_unavailable' || conflictStatus === 'pending_reconcile') {
-    return 'Network dependency is unavailable. Your prior submit may still be pending — wait and reconcile before trying again.';
+    return 'Horizon did not confirm the broadcast yet. Use Retry submit (same signed transaction) — do not prepare a new swap.';
+  }
+  if (
+    code === 'not_executable' &&
+    err instanceof StellarRouteApiError &&
+    /op_no_trust/i.test(err.message)
+  ) {
+    return 'Your wallet needs a USDy trustline before this swap can settle. Add USDy in Freighter (Manage assets), then refresh and try again.';
   }
   if (code === 'duplicate_quote' || conflictStatus === 'active_prepare_exists') {
     if (conflictStatus === 'active_prepare_exists') {
@@ -283,7 +290,7 @@ export interface ApiSwapExecutionOptions {
   slippageBps: number;
   network: WalletNetwork | null;
   signTransaction: (xdr: string) => Promise<string>;
-  /** Max ambiguous submit retries after the first attempt (default: 2). */
+  /** Max ambiguous submit retries after the first attempt (default: 4). */
   ambiguousSubmitRetries?: number;
   confirmOnHorizon?: boolean;
   confirmTimeoutMs?: number;
@@ -473,7 +480,7 @@ export function createApiSwapExecution(
         signed_xdr: envelope,
       };
 
-      const maxAmbiguous = options.ambiguousSubmitRetries ?? 2;
+      const maxAmbiguous = options.ambiguousSubmitRetries ?? 4;
       let submitted: SwapSubmitResponse | undefined;
       let lastErr: unknown;
 


### PR DESCRIPTION
## Summary
- After Freighter signs, Horizon broadcast timeouts return `dependency_unavailable` and leave the quote in `submitting`. **Try Again** previously only closed the modal, so users re-prepared into a stuck sender lock.
- Increase Horizon broadcast timeout (10s → 30s), raise ambiguous submit retries, and wire failed/`pending_reconcile` to **Resubmit** the same `quote_id` + signed XDR.
- Clearer copy for missing USDy trustline (`op_no_trust`).

## Test plan
- [x] `npm --prefix frontend run test -- lib/swap/api-execution.test.ts lib/api/trader-error-copy.test.ts`
- [x] Staging prepare→sign→submit succeeds with friendbot + USDy trustline (manual)
- [ ] UI: after a dependency_unavailable failure, primary CTA is Resubmit and retries without a new Freighter prompt
- [ ] UI without USDy trustline shows trustline guidance instead of a generic route error