### PR TITLE
fix(swap): stop submit Resubmit loop on permanent 409/422 failures

### DIFF
--- a/crates/api/src/routes/swap.rs
+++ b/crates/api/src/routes/swap.rs
@@ -398,9 +398,22 @@ async fn submit_swap_inner(
         });
     }
 
-    // Submitting remains reconcilable past prepare TTL — never TTL-fail it.
+    // Submitting remains reconcilable past prepare TTL — never TTL-fail it
+    // unless the on-chain timebounds window has already closed.
     if quote.submission_status == SubmissionStatus::Submitting {
-        let Some(stored_hash) = quote.tx_hash.clone() else {
+        let Some(stored_hash) = quote.tx_hash.clone().filter(|h| !h.is_empty()) else {
+            if quote_timebounds_expired(&quote) {
+                let _ = state
+                    .swap_quote_store
+                    .mark_failed(body.quote_id.trim())
+                    .await;
+                return Err(ApiError::Conflict {
+                    message: "Quote submission window expired; request a fresh prepare".into(),
+                    quote_id: body.quote_id.clone(),
+                    tx_hash: String::new(),
+                    status: "permanently_failed".into(),
+                });
+            }
             return Err(ApiError::Conflict {
                 message: "Quote is submitting without a bound transaction hash; request operator reconciliation or a fresh prepare".into(),
                 quote_id: body.quote_id.clone(),
@@ -471,13 +484,39 @@ async fn submit_swap_inner(
                 status: "already_submitted".to_string(),
             });
         }
-        ClaimSubmitOutcome::InProgress => {
-            return Err(ApiError::Conflict {
-                message: "Quote submission is already in progress".to_string(),
-                quote_id: body.quote_id.clone(),
-                tx_hash: String::new(),
-                status: "in_progress".to_string(),
-            });
+        ClaimSubmitOutcome::InProgress(current) => {
+            // Race: another request already claimed. Reconcile/rebroadcast with
+            // the bound hash instead of hard-409ing the client into a retry loop.
+            let Some(stored_hash) = current.tx_hash.clone().filter(|h| !h.is_empty()) else {
+                if quote_timebounds_expired(&current) {
+                    let _ = state
+                        .swap_quote_store
+                        .mark_failed(body.quote_id.trim())
+                        .await;
+                    return Err(ApiError::Conflict {
+                        message: "Quote submission window expired; request a fresh prepare".into(),
+                        quote_id: body.quote_id.clone(),
+                        tx_hash: String::new(),
+                        status: "permanently_failed".into(),
+                    });
+                }
+                return Err(ApiError::Conflict {
+                    message: "Quote is submitting without a bound transaction hash; request operator reconciliation or a fresh prepare".into(),
+                    quote_id: body.quote_id.clone(),
+                    tx_hash: String::new(),
+                    status: "submitting_without_hash".into(),
+                });
+            };
+            return reconcile_or_rebroadcast(
+                state,
+                body,
+                &current,
+                &stored_hash,
+                request_id,
+                trace_id,
+                started,
+            )
+            .await;
         }
         ClaimSubmitOutcome::PermanentlyFailed => {
             return Err(ApiError::Conflict {
@@ -597,6 +636,32 @@ async fn reconcile_or_rebroadcast(
             Ok((resp, status, quote.sender_account_hash.clone()))
         }
         Ok(None) => {
+            // Horizon has no tx. If timebounds already closed, rebroadcast can
+            // never succeed — release the sender lock instead of looping 409s.
+            if quote_timebounds_expired(quote) {
+                let _ = state
+                    .swap_quote_store
+                    .mark_failed(body.quote_id.trim())
+                    .await;
+                state.swap_submit_audit_writer.emit_swap_submit(
+                    &body.quote_id,
+                    Some(stored_hash),
+                    &quote.sender_account_hash,
+                    request_id,
+                    trace_id,
+                    started.elapsed().as_millis() as u64,
+                    SwapSubmitOutcome::Failed,
+                    "timebounds_expired",
+                    serde_json::json!({ "event": "reconciliation_timebounds_expired" }),
+                );
+                return Err(ApiError::Conflict {
+                    message: "Transaction timebounds expired before confirmation; request a fresh prepare"
+                        .into(),
+                    quote_id: body.quote_id.clone(),
+                    tx_hash: stored_hash.to_string(),
+                    status: "permanently_failed".into(),
+                });
+            }
             state.swap_submit_audit_writer.emit_swap_submit(
                 &body.quote_id,
                 Some(stored_hash),
@@ -864,6 +929,14 @@ fn map_envelope_error(err: EnvelopeValidationError) -> ApiError {
     }
 }
 
+/// True when the prepared envelope's max time is in the past (unix seconds).
+fn quote_timebounds_expired(quote: &PreparedSwapQuote) -> bool {
+    match quote.timebounds_max {
+        Some(max) if max > 0 => Utc::now().timestamp() > max,
+        _ => false,
+    }
+}
+
 fn submit_error_class(err: &ApiError) -> &'static str {
     match err {
         ApiError::QuoteExpired { .. } => "quote_expired",
@@ -891,9 +964,41 @@ fn validate_stellar_account(sender: &str) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use chrono::Duration;
 
     #[test]
     fn validate_stellar_account_rejects_short_keys() {
         assert!(validate_stellar_account("GSHORT").is_err());
+    }
+
+    #[test]
+    fn quote_timebounds_expired_requires_positive_max() {
+        let mut quote = PreparedSwapQuote {
+            quote_id: "q".into(),
+            sender_account: "G".into(),
+            sender_account_hash: "h".into(),
+            unsigned_xdr_hash: "u".into(),
+            expires_at: Utc::now() + Duration::minutes(1),
+            estimated_output: "1".into(),
+            min_output: "1".into(),
+            amount_in: "1".into(),
+            execution_mode: "classic_path_payment".into(),
+            network_passphrase: "p".into(),
+            route_digest: "r".into(),
+            price_digest: "pd".into(),
+            source_sequence: None,
+            timebounds_max: None,
+            base_fee: None,
+            valid_until_ledger: None,
+            submission_status: SubmissionStatus::Submitting,
+            tx_hash: Some("abc".into()),
+        };
+        assert!(!quote_timebounds_expired(&quote));
+        quote.timebounds_max = Some(0);
+        assert!(!quote_timebounds_expired(&quote));
+        quote.timebounds_max = Some(Utc::now().timestamp() - 5);
+        assert!(quote_timebounds_expired(&quote));
+        quote.timebounds_max = Some(Utc::now().timestamp() + 60);
+        assert!(!quote_timebounds_expired(&quote));
     }
 }

--- a/crates/api/src/swap/store.rs
+++ b/crates/api/src/swap/store.rs
@@ -76,7 +76,9 @@ pub enum SwapStoreError {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ClaimSubmitOutcome {
     Claimed(Box<PreparedSwapQuote>),
-    InProgress,
+    /// Another request already moved the quote to `submitting` (or a retry
+    /// raced claim). Carry the bound quote so the caller can reconcile.
+    InProgress(Box<PreparedSwapQuote>),
     AlreadySubmitted { tx_hash: String },
     PermanentlyFailed,
 }
@@ -245,7 +247,7 @@ impl SwapQuoteStore for PgSwapQuoteStore {
             }
             SubmissionStatus::Submitting => {
                 tx.commit().await?;
-                return Ok(ClaimSubmitOutcome::InProgress);
+                return Ok(ClaimSubmitOutcome::InProgress(Box::new(row.into_quote())));
             }
             SubmissionStatus::Failed => {
                 tx.commit().await?;
@@ -383,6 +385,14 @@ impl InMemorySwapQuoteStore {
             q.expires_at = expires_at;
         }
     }
+
+    /// Test helper: overwrite `timebounds_max` without changing submission status.
+    pub fn set_timebounds_max_for_tests(&self, quote_id: &str, timebounds_max: Option<i64>) {
+        let mut guard = self.quotes.lock().unwrap();
+        if let Some(q) = guard.get_mut(quote_id) {
+            q.timebounds_max = timebounds_max;
+        }
+    }
 }
 
 #[async_trait]
@@ -429,7 +439,9 @@ impl SwapQuoteStore for InMemorySwapQuoteStore {
             SubmissionStatus::Submitted => Ok(ClaimSubmitOutcome::AlreadySubmitted {
                 tx_hash: quote.tx_hash.clone().unwrap_or_default(),
             }),
-            SubmissionStatus::Submitting => Ok(ClaimSubmitOutcome::InProgress),
+            SubmissionStatus::Submitting => {
+                Ok(ClaimSubmitOutcome::InProgress(Box::new(quote.clone())))
+            }
             SubmissionStatus::Failed => Ok(ClaimSubmitOutcome::PermanentlyFailed),
             SubmissionStatus::Prepared => {
                 quote.submission_status = SubmissionStatus::Submitting;

--- a/crates/api/tests/swap_submit_integration.rs
+++ b/crates/api/tests/swap_submit_integration.rs
@@ -485,6 +485,41 @@ async fn submit_swap_broadcast_failure_marks_failed() {
 }
 
 #[tokio::test]
+async fn submit_submitting_past_timebounds_absent_horizon_marks_failed() {
+    let store = Arc::new(InMemorySwapQuoteStore::default());
+    let (quote, signed, _, _) = build_prepared_pair("q-tb", false);
+    store.insert_prepared(&quote).await.unwrap();
+
+    let broadcaster =
+        Arc::new(MockTransactionBroadcaster::fail(BroadcastError::Timeout).with_lookup(None));
+    let router = make_submit_router(store.clone(), broadcaster).await;
+    let (status, _) = post_submit(
+        &router,
+        json!({ "quote_id": "q-tb", "signed_xdr": signed.clone() }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE);
+
+    // Close the Stellar timebounds window while Horizon still has no tx.
+    store.set_timebounds_max_for_tests("q-tb", Some(Utc::now().timestamp() - 10));
+
+    let broadcaster2 =
+        Arc::new(MockTransactionBroadcaster::succeed("").with_lookup(None));
+    let router2 = make_submit_router(store.clone(), broadcaster2.clone()).await;
+    let (status2, json2) = post_submit(
+        &router2,
+        json!({ "quote_id": "q-tb", "signed_xdr": signed }),
+    )
+    .await;
+    assert_eq!(status2, StatusCode::CONFLICT, "{json2}");
+    assert_eq!(json2["data"]["details"]["status"], "permanently_failed");
+    assert_eq!(broadcaster2.call_count(), 0);
+
+    let after = store.get("q-tb").await.unwrap().unwrap();
+    assert_eq!(after.submission_status, SubmissionStatus::Failed);
+}
+
+#[tokio::test]
 async fn submit_timeout_keeps_submitting_then_allows_reconcile_retry() {
     let store = Arc::new(InMemorySwapQuoteStore::default());
     let (quote, signed, _, _) = build_prepared_pair("q-retry", false);

--- a/frontend/hooks/useTransactionLifecycle.ts
+++ b/frontend/hooks/useTransactionLifecycle.ts
@@ -487,6 +487,8 @@ export function useTransactionLifecycle(
       void resubmit();
       return;
     }
+    // Permanent failures must start a fresh prepare/sign — drop the old envelope.
+    lastSignedXdrRef.current = null;
     clearDeadlineTimer();
     setStatus("review");
     clearError();

--- a/frontend/lib/api/trader-error-copy.ts
+++ b/frontend/lib/api/trader-error-copy.ts
@@ -463,6 +463,16 @@ function copyForConflictStatus(
       ctaLabel: 'Check activity',
     };
   }
+  if (status === 'permanently_failed') {
+    return {
+      headline: 'This quote can no longer be submitted',
+      explanation:
+        'The prepared swap failed permanently (missing trustline, expired timebounds, or a prior reject).',
+      recoveryAction:
+        'Add any missing asset trustlines in Freighter, refresh for a new quote, then swap again.',
+      ctaLabel: 'Refresh quote',
+    };
+  }
   if (status === 'pending_reconcile') {
     return API_ERROR_COPY.dependency_unavailable;
   }

--- a/frontend/lib/swap/api-execution.test.ts
+++ b/frontend/lib/swap/api-execution.test.ts
@@ -336,6 +336,41 @@ describe('createApiSwapExecution', () => {
     });
   });
 
+  it('does not rewrite permanent submit failures as pending_reconcile', async () => {
+    const client = {
+      prepareSwap: vi.fn().mockResolvedValue(
+        preparedFixture({ quote_id: 'q-trust', expected_output: '9.9' }),
+      ),
+      submitSwap: vi.fn().mockRejectedValue(
+        new StellarRouteApiError(
+          422,
+          'not_executable',
+          'op_no_trust',
+          { status: 'broadcast_failed' },
+        ),
+      ),
+    } as unknown as StellarRouteClient;
+
+    const deps = createApiSwapExecution({
+      client,
+      sender: tradeParams.walletAddress,
+      slippageBps: 50,
+      network: 'testnet',
+      signTransaction: async () => 'opaque_signed_xdr',
+      ambiguousSubmitRetries: 3,
+      confirmOnHorizon: false,
+    });
+
+    await deps.buildXdr(tradeParams);
+    await deps.signTransaction('opaque_unsigned_xdr');
+    await expect(deps.submitTransaction('opaque_signed_xdr')).rejects.toMatchObject({
+      code: 'not_executable',
+      status: 422,
+      details: expect.not.objectContaining({ status: 'pending_reconcile' }),
+    });
+    expect(client.submitSwap).toHaveBeenCalledTimes(1);
+  });
+
   it('confirmation timeout fails closed', async () => {
     const client = {
       prepareSwap: vi.fn().mockResolvedValue(

--- a/frontend/lib/swap/api-execution.ts
+++ b/frontend/lib/swap/api-execution.ts
@@ -270,6 +270,9 @@ export function userCopyForSwapExecutionError(err: unknown): string {
     if (conflictStatus === 'active_prepare_exists') {
       return 'An active prepare already exists for this wallet. Finish or wait for it to expire before preparing again.';
     }
+    if (conflictStatus === 'permanently_failed') {
+      return 'This quote can no longer be submitted. Add any missing trustlines, refresh for a new quote, then try again.';
+    }
     if (conflictStatus === 'already_submitted' || conflictStatus === 'in_progress') {
       return 'This swap was already submitted. Check wallet activity before trying again.';
     }
@@ -500,7 +503,13 @@ export function createApiSwapExecution(
       }
 
       if (!submitted) {
-        if (lastErr instanceof StellarRouteApiError) {
+        // Only ambiguous Horizon outcomes become pending_reconcile + Resubmit.
+        // Permanent failures (422 op_no_trust, 409 permanently_failed, etc.)
+        // must keep their original status so the UI does not retry forever.
+        if (
+          lastErr instanceof StellarRouteApiError &&
+          isAmbiguousSubmitError(lastErr)
+        ) {
           throw new StellarRouteApiError(
             lastErr.status,
             lastErr.code,
@@ -514,9 +523,11 @@ export function createApiSwapExecution(
             },
           );
         }
+        pendingSignedXdr = null;
+        pendingQuoteId = null;
         throw lastErr instanceof Error
           ? lastErr
-          : new Error('Submit pending — reconcile before preparing again');
+          : new Error('Swap submit failed. Refresh the quote and try again.');
       }
 
       lastSubmit = submitted;


### PR DESCRIPTION
## Summary
- Frontend no longer rewrites permanent submit failures (`op_no_trust` 422, `permanently_failed` 409) as `pending_reconcile`, which was causing endless Resubmit → 409 loops.
- API reconciles `ClaimSubmitOutcome::InProgress` instead of hard-409, and marks submitting quotes failed when Horizon has no tx and timebounds are past (unlocks sender).

## Test plan
- [x] `cargo test -p stellarroute-api --test swap_submit_integration`
- [x] `npm --prefix frontend run test -- lib/swap/api-execution.test.ts`
- [ ] Staging: Freighter add USDy trustline → fresh prepare → sign → submit succeeds; permanent failure shows Try Again (not Resubmit)