### PR TITLE
feat(deploy): wire CCTP env and DDL into EC2 staging

### DIFF
--- a/deploy/aws/scripts/deploy-ec2-staging.sh
+++ b/deploy/aws/scripts/deploy-ec2-staging.sh
@@ -48,8 +48,36 @@ docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-fil
   < "${ROOT}/crates/indexer/migrations/0015_swap_prepared_quotes.sql"
 echo " - swap_prepared_quotes ready"
 
+CCTP_MIGRATIONS=(
+  "${ROOT}/crates/api/migrations/0015_cctp_transfers.sql"
+  "${ROOT}/crates/api/migrations/0016_cctp_transfers_hardening.sql"
+  "${ROOT}/crates/api/migrations/0017_cctp_mint_metadata.sql"
+  "${ROOT}/crates/api/migrations/0018_cctp_approval_tx_hash.sql"
+  "${ROOT}/crates/api/migrations/0019_cctp_approval_verified_at.sql"
+  "${ROOT}/crates/api/migrations/20260730_cctp_review_fixes.sql"
+  "${ROOT}/crates/api/migrations/20260731_cctp_prepare_lock_hardening.sql"
+  "${ROOT}/crates/api/migrations/20260801_cctp_http_gate.sql"
+  "${ROOT}/crates/api/migrations/20260802_cctp_http_hardening.sql"
+  "${ROOT}/crates/api/migrations/20260803_cctp_reattest_lease.sql"
+)
+echo "Applying CCTP DDL (idempotent)..."
+for mig in "${CCTP_MIGRATIONS[@]}"; do
+  docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod exec -T postgres \
+    psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+    < "${mig}"
+  echo " - $(basename "${mig}") ready"
+done
+
 echo "Local health checks:"
 # API may still be booting; do not fail the whole deploy on a racing curl here.
 # Post-deploy smoke waits for readiness separately.
-curl -sf http://127.0.0.1:${API_HOST_PORT:-8080}/health && echo " - /health OK" || echo " - /health not ready yet"
-curl -sf http://127.0.0.1:${API_HOST_PORT:-8080}/health/deps && echo " - /health/deps OK" || echo " - /health/deps not ready yet"
+API_PORT="${API_HOST_PORT:-8080}"
+curl -sf "http://127.0.0.1:${API_PORT}/health" && echo " - /health OK" || echo " - /health not ready yet"
+curl -sf "http://127.0.0.1:${API_PORT}/health/deps" && echo " - /health/deps OK" || echo " - /health/deps not ready yet"
+
+if v2_json="$(curl -sf "http://127.0.0.1:${API_PORT}/api/v2" 2>/dev/null)"; then
+  printf '%s' "${v2_json}" | python3 -c 'import json,sys; d=json.load(sys.stdin).get("data",{}); print(" - /api/v2 OK bridge_settlement_executable={} corridors={}".format(d.get("bridge_settlement_executable"), len(d.get("supported_corridors") or [])))' \
+    || echo " - /api/v2 response shape unexpected"
+else
+  echo " - /api/v2 not ready yet (warn-only)"
+fi

--- a/deploy/docker-compose.prod.yml
+++ b/deploy/docker-compose.prod.yml
@@ -75,6 +75,12 @@ services:
       PUBLIC_GET_ROUTES: ${PUBLIC_GET_ROUTES:-/api/v1/quote,/api/v1/pairs,/api/v1/markets,/api/v1/orderbook,/api/v1/routes,/api/v1/price-history,/health}
       ADMIN_AUTH_TOKEN: ${ADMIN_AUTH_TOKEN:?required}
       ENABLE_ADMIN_ROUTES: ${ENABLE_ADMIN_ROUTES:-false}
+      CCTP_ENABLED: ${CCTP_ENABLED:-false}
+      CCTP_ACCESS_TOKEN_HMAC_KEY: ${CCTP_ACCESS_TOKEN_HMAC_KEY:-}
+      CCTP_SEPOLIA_RPC_URL: ${CCTP_SEPOLIA_RPC_URL:-}
+      SEPOLIA_RPC_URL: ${SEPOLIA_RPC_URL:-}
+      CCTP_STELLAR_RPC_URL: ${CCTP_STELLAR_RPC_URL:-}
+      CCTP_IRIS_BASE_URL: ${CCTP_IRIS_BASE_URL:-}
       OTEL_EXPORTER_OTLP_ENDPOINT: ${OTEL_EXPORTER_OTLP_ENDPOINT:-}
     depends_on:
       postgres:

--- a/deploy/env.prod.example
+++ b/deploy/env.prod.example
@@ -28,6 +28,19 @@ ENABLE_ADMIN_ROUTES=false
 RUST_LOG=stellarroute=info,warn
 # OTEL_EXPORTER_OTLP_ENDPOINT=
 
+# Circle CCTP v2 bridge (default-off; see docs/development/environment-variables.md)
+# CCTP_ENABLED=false
+# Required when CCTP_ENABLED=true (≥32 random bytes; base64 / hex / base64url):
+# CCTP_ACCESS_TOKEN_HMAC_KEY=
+# Required when enabled — explicit Sepolia JSON-RPC (no silent rpc.sepolia.org fallback):
+# CCTP_SEPOLIA_RPC_URL=
+# Optional alias if CCTP_SEPOLIA_RPC_URL is unset:
+# SEPOLIA_RPC_URL=
+# Optional Soroban RPC override for CCTP probes/builders (else SOROBAN_RPC_URL):
+# CCTP_STELLAR_RPC_URL=
+# Optional Iris sandbox override (default https://iris-api-sandbox.circle.com):
+# CCTP_IRIS_BASE_URL=
+
 # After Cloudflare Tunnel is up, set Vercel production env to the tunnel URL:
 #   NEXT_PUBLIC_API_URL=https://api.your-domain
 #   NEXT_PUBLIC_API_URL_TESTNET=https://api.your-domain

--- a/deploy/secrets.checklist.md
+++ b/deploy/secrets.checklist.md
@@ -21,6 +21,10 @@ Copy `deploy/env.prod.example` → repo-root `.env.prod` and fill:
 - [ ] `PUBLIC_GET_ROUTES` — keep the defaults from `env.prod.example` for browser GETs
 - [ ] `ADMIN_AUTH_TOKEN` — strong random; required when `STELLARROUTE_ENV=production`
 - [ ] `ENABLE_ADMIN_ROUTES=false` until kill-switch security review is done
+- [ ] `CCTP_ENABLED=false` until operator is ready to open bridge settlement (default-off / fail-closed)
+- [ ] When enabling CCTP: `CCTP_ACCESS_TOKEN_HMAC_KEY` (≥32 random bytes; generate per `docs/development/environment-variables.md`)
+- [ ] When enabling CCTP: `CCTP_SEPOLIA_RPC_URL` (explicit Sepolia JSON-RPC — no `rpc.sepolia.org` fallback)
+- [ ] Optional: `CCTP_STELLAR_RPC_URL` (else API uses `SOROBAN_RPC_URL`)
 - [ ] Cloudflare Tunnel named hostname (record as `STAGING_API_BASE_URL` / Vercel `NEXT_PUBLIC_API_URL`)
 - [ ] `OTEL_EXPORTER_OTLP_ENDPOINT` — optional
 

--- a/docs/cctp/attestation-verification.md
+++ b/docs/cctp/attestation-verification.md
@@ -51,7 +51,7 @@ Protocol caps: `MAX_IRIS_PUBLIC_KEYS=256`, `MAX_ENABLED_ATTESTERS=256`, `MAX_SIG
 
 ## Public safety (current phase)
 
-- HTTP handlers remain **503**; capabilities **false**.
+- When `CCTP_ENABLED=false` (default), `/api/v2/bridge/cctp/*` handlers return **503** `cctp_not_enabled`.
 - `CircleAttestationVerifier` may become **ready** when Iris + EVM + Stellar RPC readers bootstrap, but **corridor is not live** until Stellar burn/approval/mint verifiers ship.
 - `is_public_executable()` stays **false** until all runtime components ready.
 

--- a/docs/development/environment-variables.md
+++ b/docs/development/environment-variables.md
@@ -93,7 +93,7 @@ PostgreSQL connection strings and pool tuning. Used by the API, indexer, replay 
 
 ## Circle CCTP v2 bridge (API)
 
-Default-off public bridge settlement. See [`docs/api/cctp-v2-contract.md`](../api/cctp-v2-contract.md).
+Default-off public bridge settlement. See [`docs/api/cctp-v2-contract.md`](../api/cctp-v2-contract.md). EC2 / Oracle staging copies: set these in repo-root `.env.prod` (see [`deploy/env.prod.example`](../../deploy/env.prod.example)).
 
 | Variable | Type | Default | Required | Service(s) | Description |
 |----------|------|---------|----------|------------|-------------|

--- a/scripts/staging-smoke.sh
+++ b/scripts/staging-smoke.sh
@@ -63,6 +63,32 @@ check_endpoint "health_deps" "${ORIGIN}/health/deps" "${DEPS_BUDGET_MS}"
 QUOTE_URL="${ORIGIN}/api/v1/quote/${QUOTE_BASE}/${QUOTE_ASSET}?amount=${QUOTE_AMOUNT}"
 check_endpoint "quote" "${QUOTE_URL}" "${QUOTE_BUDGET_MS}"
 
+API_V2_BUDGET_MS="${API_V2_BUDGET_MS:-3000}"
+check_endpoint "api_v2" "${ORIGIN}/api/v2" "${API_V2_BUDGET_MS}"
+
+python3 - "${tmpdir}/api_v2.body" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+payload = data.get("data", data)
+if not isinstance(payload, dict):
+    print("FAIL api_v2: missing data object", file=sys.stderr)
+    sys.exit(1)
+if "bridge_settlement_executable" not in payload:
+    print("FAIL api_v2: missing bridge_settlement_executable", file=sys.stderr)
+    sys.exit(1)
+corridors = payload.get("supported_corridors")
+if not isinstance(corridors, list):
+    print("FAIL api_v2: supported_corridors must be a list", file=sys.stderr)
+    sys.exit(1)
+print(
+    "OK   api_v2: shape valid "
+    f"(bridge_settlement_executable={payload['bridge_settlement_executable']}, "
+    f"corridors={len(corridors)})"
+)
+PY
+
 python3 - "${tmpdir}/quote.body" <<'PY'
 import json, sys
 path = sys.argv[1]


### PR DESCRIPTION
## Summary
- Pass `CCTP_*` env vars into the staging API compose service (default `CCTP_ENABLED=false`).
- Apply CCTP Postgres migrations during `deploy-ec2-staging.sh` (same order as the configured-ready proof).
- Document operator secrets and extend staging smoke with a non-secret `/api/v2` shape check.

## Test plan
- [x] `bash -n` on edited deploy/smoke scripts
- [ ] Merge + deploy EC2 staging
- [ ] On EC2 `.env.prod`: set `CCTP_ENABLED=true`, `CCTP_ACCESS_TOKEN_HMAC_KEY`, `CCTP_SEPOLIA_RPC_URL`, redeploy
- [ ] `GET /api/v2` shows `bridge_settlement_executable` / `stellar_to_evm` when RPC probes pass