### PR TITLE
feat(ops): add SSM workflow to enable CCTP on staging

### DIFF
--- a/.github/workflows/enable-cctp-staging.yml
+++ b/.github/workflows/enable-cctp-staging.yml
@@ -55,11 +55,17 @@ jobs:
             exit 1
           fi
 
+          # Sync main first so enable-cctp-staging.sh exists on the host.
+          # shellcheck disable=SC2016
+          SYNC_CMD='set -eu; cd /opt/stellarroute; export HOME=/root; git -c safe.directory=* fetch --all --prune; git -c safe.directory=* reset --hard HEAD; git -c safe.directory=* clean -fd -e .env.prod -e .env -e ".env.*"; git -c safe.directory=* checkout -B main origin/main; git -c safe.directory=* log -1 --oneline'
+
           jq -n \
+            --arg sync "${SYNC_CMD}" \
             --arg sepolia "${SEPOLIA_RPC}" \
             --arg stellar "${STELLAR_RPC}" \
             '{
               commands: [
+                $sync,
                 (
                   "set -eu; cd /opt/stellarroute; export HOME=/root; " +
                   "export CCTP_SEPOLIA_RPC_URL=" + ($sepolia | @sh) + "; " +

--- a/.github/workflows/enable-cctp-staging.yml
+++ b/.github/workflows/enable-cctp-staging.yml
@@ -1,0 +1,125 @@
+name: Enable CCTP Staging
+
+on:
+  workflow_dispatch:
+    inputs:
+      sepolia_rpc_url:
+        description: "Explicit Sepolia JSON-RPC URL (required)"
+        required: true
+        default: "https://sepolia.drpc.org"
+      stellar_rpc_url:
+        description: "Optional CCTP_STELLAR_RPC_URL override (else host SOROBAN_RPC_URL)"
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  id-token: write
+
+concurrency:
+  group: enable-cctp-staging
+  cancel-in-progress: false
+
+jobs:
+  enable:
+    name: Enable CCTP on staging EC2 via SSM
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check configuration
+        env:
+          AWS_ROLE_ARN: ${{ secrets.AWS_ROLE_ARN }}
+          STAGING_INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
+        run: |
+          if [[ -z "${AWS_ROLE_ARN}" || -z "${STAGING_INSTANCE_ID}" ]]; then
+            echo "Missing required secrets AWS_ROLE_ARN and/or STAGING_INSTANCE_ID."
+            exit 1
+          fi
+
+      - name: Configure AWS credentials (OIDC)
+        uses: aws-actions/configure-aws-credentials@v5
+        with:
+          role-to-assume: ${{ secrets.AWS_ROLE_ARN }}
+          aws-region: ${{ secrets.AWS_REGION || 'us-east-1' }}
+
+      - name: Send SSM enable-CCTP command
+        id: ssm
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          STAGING_INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
+          SEPOLIA_RPC: ${{ github.event.inputs.sepolia_rpc_url }}
+          STELLAR_RPC: ${{ github.event.inputs.stellar_rpc_url }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${SEPOLIA_RPC}" ]]; then
+            echo "sepolia_rpc_url input is required" >&2
+            exit 1
+          fi
+
+          jq -n \
+            --arg sepolia "${SEPOLIA_RPC}" \
+            --arg stellar "${STELLAR_RPC}" \
+            '{
+              commands: [
+                (
+                  "set -eu; cd /opt/stellarroute; export HOME=/root; " +
+                  "export CCTP_SEPOLIA_RPC_URL=" + ($sepolia | @sh) + "; " +
+                  (if $stellar != "" then
+                    "export CCTP_STELLAR_RPC_URL=" + ($stellar | @sh) + "; "
+                   else "" end) +
+                  "bash deploy/aws/scripts/enable-cctp-staging.sh"
+                )
+              ]
+            }' > /tmp/ssm-commands.json
+
+          COMMAND_ID="$(aws ssm send-command \
+            --region "${AWS_REGION}" \
+            --instance-ids "${STAGING_INSTANCE_ID}" \
+            --document-name "AWS-RunShellScript" \
+            --comment "Enable CCTP on StellarRoute staging" \
+            --parameters file:///tmp/ssm-commands.json \
+            --query 'Command.CommandId' \
+            --output text)"
+
+          echo "command_id=${COMMAND_ID}" >> "${GITHUB_OUTPUT}"
+          echo "Started SSM command: ${COMMAND_ID}"
+
+      - name: Wait and print SSM output
+        env:
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          STAGING_INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
+          COMMAND_ID: ${{ steps.ssm.outputs.command_id }}
+        run: |
+          set -euo pipefail
+
+          STATUS="Pending"
+          for _ in $(seq 1 90); do
+            STATUS="$(aws ssm get-command-invocation \
+              --region "${AWS_REGION}" \
+              --command-id "${COMMAND_ID}" \
+              --instance-id "${STAGING_INSTANCE_ID}" \
+              --query 'Status' \
+              --output text 2>/dev/null || echo Pending)"
+
+            case "${STATUS}" in
+              Pending|InProgress|Delayed)
+                sleep 10
+                ;;
+              *)
+                break
+                ;;
+            esac
+          done
+
+          echo "Final SSM status: ${STATUS}"
+
+          aws ssm get-command-invocation \
+            --region "${AWS_REGION}" \
+            --command-id "${COMMAND_ID}" \
+            --instance-id "${STAGING_INSTANCE_ID}" \
+            --query '{Status:Status,StatusDetails:StatusDetails,ResponseCode:ResponseCode,StandardOutputContent:StandardOutputContent,StandardErrorContent:StandardErrorContent}' \
+            --output json
+
+          if [[ "${STATUS}" != "Success" ]]; then
+            echo "Remote enable failed with status: ${STATUS}."
+            exit 1
+          fi

--- a/deploy/aws/scripts/enable-cctp-staging.sh
+++ b/deploy/aws/scripts/enable-cctp-staging.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# Enable CCTP on EC2 staging by upserting .env.prod and recreating the API container.
+#
+# Usage (on the staging host, from repo root):
+#   CCTP_SEPOLIA_RPC_URL=https://sepolia.drpc.org bash deploy/aws/scripts/enable-cctp-staging.sh
+#
+# Defaults:
+#   CCTP_ENABLED=true
+#   CCTP_SEPOLIA_RPC_URL / SEPOLIA_RPC_URL required (or pass explicitly)
+#   CCTP_ACCESS_TOKEN_HMAC_KEY generated if missing/empty
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT}"
+
+ENV_FILE="${ROOT}/.env.prod"
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}. Copy deploy/env.prod.example and fill required values first." >&2
+  exit 1
+fi
+
+SEPOLIA_RPC="${CCTP_SEPOLIA_RPC_URL:-${SEPOLIA_RPC_URL:-}}"
+if [[ -z "${SEPOLIA_RPC}" ]]; then
+  echo "CCTP_SEPOLIA_RPC_URL or SEPOLIA_RPC_URL is required (explicit Sepolia JSON-RPC; no silent default)." >&2
+  exit 1
+fi
+
+upsert_env() {
+  local key="$1"
+  local value="$2"
+  local tmp
+  tmp="$(mktemp)"
+  if grep -qE "^${key}=" "${ENV_FILE}"; then
+    # Preserve other lines; replace matching key only.
+    awk -v k="${key}" -v v="${value}" '
+      BEGIN { found=0 }
+      index($0, k "=") == 1 { print k "=" v; found=1; next }
+      { print }
+      END { if (!found) print k "=" v }
+    ' "${ENV_FILE}" > "${tmp}"
+  else
+    cat "${ENV_FILE}" > "${tmp}"
+    printf '%s=%s\n' "${key}" "${value}" >> "${tmp}"
+  fi
+  mv "${tmp}" "${ENV_FILE}"
+  chmod 600 "${ENV_FILE}" || true
+}
+
+# shellcheck disable=SC1090
+set -a
+# Load existing values without exporting secrets to logs later.
+source "${ENV_FILE}"
+set +a
+
+HMAC_KEY="${CCTP_ACCESS_TOKEN_HMAC_KEY:-}"
+if [[ -z "${HMAC_KEY}" ]]; then
+  HMAC_KEY="$(python3 -c 'import os,base64; print(base64.urlsafe_b64encode(os.urandom(32)).decode().rstrip("="))')"
+  echo "Generated new CCTP_ACCESS_TOKEN_HMAC_KEY (not printed)."
+else
+  echo "Reusing existing CCTP_ACCESS_TOKEN_HMAC_KEY."
+fi
+
+upsert_env "CCTP_ENABLED" "true"
+upsert_env "CCTP_ACCESS_TOKEN_HMAC_KEY" "${HMAC_KEY}"
+upsert_env "CCTP_SEPOLIA_RPC_URL" "${SEPOLIA_RPC}"
+
+if [[ -n "${CCTP_STELLAR_RPC_URL:-}" ]]; then
+  upsert_env "CCTP_STELLAR_RPC_URL" "${CCTP_STELLAR_RPC_URL}"
+fi
+if [[ -n "${CCTP_IRIS_BASE_URL:-}" ]]; then
+  upsert_env "CCTP_IRIS_BASE_URL" "${CCTP_IRIS_BASE_URL}"
+fi
+
+echo "Recreating API with CCTP enabled..."
+docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod up -d --no-deps api
+
+API_PORT="${API_HOST_PORT:-8080}"
+echo "Waiting for API health..."
+for _ in $(seq 1 60); do
+  if curl -fsS "http://127.0.0.1:${API_PORT}/health" >/dev/null \
+    && curl -fsS "http://127.0.0.1:${API_PORT}/health/deps" >/dev/null; then
+    echo "API healthy."
+    break
+  fi
+  sleep 5
+done
+
+if v2_json="$(curl -sf "http://127.0.0.1:${API_PORT}/api/v2" 2>/dev/null)"; then
+  printf '%s' "${v2_json}" | python3 -c '
+import json,sys
+d=json.load(sys.stdin).get("data",{})
+print("bridge_settlement_executable={}".format(d.get("bridge_settlement_executable")))
+for c in d.get("supported_corridors") or []:
+    print(" corridor direction={} executable={}".format(c.get("direction"), c.get("executable")))
+'
+else
+  echo "WARN: /api/v2 not ready yet" >&2
+fi


### PR DESCRIPTION
## Summary
- Adds `deploy/aws/scripts/enable-cctp-staging.sh` to upsert CCTP vars in `.env.prod` (fail-closed until run) and recreate the API.
- Adds `Enable CCTP Staging` workflow_dispatch that runs the script on EC2 via SSM with an explicit Sepolia RPC input.

## Test plan
- [ ] Wait for Deploy EC2 Staging from #1170 to finish (CCTP DDL applied)
- [ ] Run **Enable CCTP Staging** with `https://sepolia.drpc.org`
- [ ] `GET https://34.224.110.144.sslip.io/api/v2` shows Stellar→EVM executable when probes pass