### PR TITLE
fix(frontend): explain disabled CCTP quote CTA and USDC-only bridge

### DIFF
--- a/frontend/components/swap/cross-chain/CctpExecutionPanel.tsx
+++ b/frontend/components/swap/cross-chain/CctpExecutionPanel.tsx
@@ -28,6 +28,7 @@ interface CctpExecutionPanelProps {
     recovery: CctpSessionRecoveryMeta;
   } | null;
   reattestCooldownUntil?: number | null;
+  ctaHint?: string | null;
   className?: string;
 }
 
@@ -46,6 +47,7 @@ export function CctpExecutionPanel({
   walletRoleMismatch,
   sessionPublic,
   reattestCooldownUntil,
+  ctaHint,
   className,
 }: CctpExecutionPanelProps) {
   const [cooldownSec, setCooldownSec] = useState(0);
@@ -181,16 +183,26 @@ export function CctpExecutionPanel({
         </div>
       )}
 
-      <div className="flex flex-wrap gap-2">
-        <Button
-          type="button"
-          className="min-h-11"
-          disabled={primaryDisabled}
-          onClick={onPrimary}
-          data-testid="cross-chain-review-cta"
-        >
-          {primaryLabel}
-        </Button>
+      <div className="space-y-2">
+        {ctaHint && primaryDisabled && (
+          <p
+            className="text-xs text-muted-foreground"
+            role="status"
+            data-testid="cctp-cta-hint"
+          >
+            {ctaHint}
+          </p>
+        )}
+        <div className="flex flex-wrap gap-2">
+          <Button
+            type="button"
+            className="min-h-11"
+            disabled={primaryDisabled}
+            onClick={onPrimary}
+            data-testid="cross-chain-review-cta"
+          >
+            {primaryLabel}
+          </Button>
         {onReset &&
           (stage === 'failed' ||
             stage === 'completed' ||
@@ -208,6 +220,7 @@ export function CctpExecutionPanel({
               {resetLabel}
             </Button>
           )}
+        </div>
       </div>
     </section>
   );

--- a/frontend/components/swap/cross-chain/CrossChainSwapDeck.test.tsx
+++ b/frontend/components/swap/cross-chain/CrossChainSwapDeck.test.tsx
@@ -5,6 +5,9 @@ import { CrossChainSwapDeck } from './CrossChainSwapDeck';
 import { SettingsProvider } from '@/components/providers/settings-provider';
 import { WalletProvider } from '@/components/providers/wallet-provider';
 import { EXECUTING_TIMELINE_STORY_FIXTURE } from './crossChainStoryPresentation';
+import { useApiV2Readiness } from '@/hooks/useApiV2Readiness';
+import { useCrossChainWalletRoles } from '@/hooks/useCrossChainWalletRoles';
+import type { UseCrossChainWalletRolesInput } from '@/hooks/useCrossChainWalletRoles';
 
 vi.mock('next/dynamic', () => ({
   default: () => {
@@ -33,16 +36,19 @@ vi.mock('@/hooks/useApiV2Readiness', () => ({
 }));
 
 vi.mock('@/hooks/useCrossChainWalletRoles', () => ({
-  useCrossChainWalletRoles: vi.fn(() => ({
-    direction: null,
-    destRecipientAddress: '',
-    isMuxedRecipient: false,
-    showMintSubmitterChip: false,
-    sourceChipBinding: null,
-    destChipBinding: null,
-    mintSubmitterChipBinding: null,
-    sagaWallets: { recipient: '' },
-  })),
+  useCrossChainWalletRoles: vi.fn(
+    (input: UseCrossChainWalletRolesInput) => ({
+      direction: null,
+      destRecipientAddress: '',
+      isMuxedRecipient: false,
+      showMintSubmitterChip: false,
+      sourceChipBinding: null,
+      destChipBinding: null,
+      mintSubmitterChipBinding: null,
+      sagaWallets: { recipient: '' },
+      _input: input,
+    }),
+  ),
 }));
 
 vi.mock('@/hooks/useCctpSaga', () => ({
@@ -77,6 +83,28 @@ vi.mock('@/hooks/useChainWallet', () => ({
 }));
 
 import type { CrossChainDeckStoryPresentation } from './crossChainStoryPresentation';
+
+const mockUseApiV2Readiness = vi.mocked(useApiV2Readiness);
+const mockUseCrossChainWalletRoles = vi.mocked(useCrossChainWalletRoles);
+
+function mockStellarToSepoliaWalletRoles(
+  input: UseCrossChainWalletRolesInput,
+) {
+  const destRecipientAddress =
+    input.useRecipientOverride && input.recipientOverride?.trim()
+      ? input.recipientOverride.trim()
+      : '';
+  return {
+    direction: 'stellar_to_evm' as const,
+    destRecipientAddress,
+    isMuxedRecipient: false,
+    showMintSubmitterChip: false,
+    sourceChipBinding: null,
+    destChipBinding: null,
+    mintSubmitterChipBinding: null,
+    sagaWallets: { recipient: destRecipientAddress },
+  };
+}
 
 function renderDeck(presentation?: CrossChainDeckStoryPresentation) {
   return render(
@@ -194,5 +222,65 @@ describe('CrossChainSwapDeck recipient validation', () => {
     expect(
       alerts.some((el) => /Stellar account/i.test(el.textContent ?? ''))
     ).toBe(true);
+  });
+});
+
+describe('CrossChainSwapDeck CCTP CTA hints', () => {
+  beforeEach(() => {
+    mockUseApiV2Readiness.mockReturnValue({
+      loaded: true,
+      corridors: [],
+      cctpGloballyReady: true,
+      providerKilled: false,
+      error: null,
+      fetchedAt: Date.now(),
+      loading: false,
+      refresh: vi.fn(),
+    });
+    mockUseCrossChainWalletRoles.mockImplementation(mockStellarToSepoliaWalletRoles);
+  });
+
+  it('shows missing-destination hint when ETH disconnected and override is off', () => {
+    renderDeck();
+
+    expect(screen.getByTestId('cross-chain-review-cta')).toBeDisabled();
+    expect(screen.getByTestId('cctp-cta-hint')).toHaveTextContent(
+      /Connect ETH Sepolia or enable Destination recipient/i,
+    );
+    expect(screen.getByTestId('dest-wallet-setup-hint')).toHaveTextContent(
+      /Connect ETH Sepolia/i,
+    );
+    expect(screen.getByTestId('destination-recipient-setup-hint')).toHaveTextContent(
+      /paste a 0x address/i,
+    );
+  });
+
+  it('clears destination hint and enables CTA when override provides valid 0x', async () => {
+    const user = userEvent.setup();
+    renderDeck();
+
+    await user.click(screen.getByLabelText('Use custom destination recipient'));
+    const recipientInput = screen.getByTestId('destination-recipient-input');
+    await user.type(
+      recipientInput,
+      '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0',
+    );
+    await user.type(screen.getByTestId('cctp-source-amount'), '10');
+
+    expect(screen.queryByTestId('cctp-cta-hint')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('dest-wallet-setup-hint')).not.toBeInTheDocument();
+    expect(
+      screen.queryByTestId('destination-recipient-setup-hint'),
+    ).not.toBeInTheDocument();
+    expect(screen.getByTestId('cross-chain-review-cta')).toBeEnabled();
+  });
+
+  it('surfaces USDC-only guidance with swap link on CCTP corridor', () => {
+    renderDeck();
+
+    expect(screen.getByTestId('cctp-usdc-only-note')).toHaveTextContent(
+      /CCTP bridges native USDC only/i,
+    );
+    expect(screen.getByTestId('swap-to-usdc-on-stellar-link')).toBeInTheDocument();
   });
 });

--- a/frontend/components/swap/cross-chain/CrossChainSwapDeck.tsx
+++ b/frontend/components/swap/cross-chain/CrossChainSwapDeck.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
 import { NetworkMismatchBanner } from '@/components/shared/NetworkMismatchBanner';
+import { Button } from '@/components/ui/button';
 import { useFeatureFlag } from '@/hooks/useFeatureFlag';
 import { useCrossChainSwapState } from '@/hooks/useCrossChainSwapState';
 import { useApiV2Readiness } from '@/hooks/useApiV2Readiness';
@@ -23,6 +24,11 @@ import { PairedChainSelectors } from './PairedChainSelectors';
 import { RouteDisclosurePanel } from './RouteDisclosurePanel';
 import { UnsupportedCorridorState } from './UnsupportedCorridorState';
 import type { CrossChainDeckStoryPresentation } from './crossChainStoryPresentation';
+import {
+  isCctpPrimaryActionDisabled,
+  resolveCctpCtaHint,
+  resolveDestinationRecipientSetupHint,
+} from './cctpCtaHint';
 
 const SwapCard = dynamic(
   () => import('@/components/swap/SwapCard').then((m) => m.SwapCard),
@@ -154,6 +160,53 @@ export function CrossChainSwapDeck({
     setConfirmAbandon(false);
   };
 
+  const bridgeReady = readiness.cctpGloballyReady;
+  const cctpBlockInput = useMemo(
+    () => ({
+      direction: walletRoles.direction,
+      sourceAmount: state.sourceAmount,
+      destRecipientAddress: walletRoles.destRecipientAddress,
+      useRecipientOverride: state.useRecipientOverride,
+      recipientOverride: state.recipientOverride,
+      recipientValidation: state.recipientValidation,
+      bridgeReady,
+      readinessLoading: readiness.loading,
+      sagaPrimaryDisabled: saga.primaryAction.disabled,
+    }),
+    [
+      bridgeReady,
+      readiness.loading,
+      saga.primaryAction.disabled,
+      state.recipientOverride,
+      state.recipientValidation,
+      state.sourceAmount,
+      state.useRecipientOverride,
+      walletRoles.destRecipientAddress,
+      walletRoles.direction,
+    ],
+  );
+  const ctaHint = useMemo(
+    () => resolveCctpCtaHint(cctpBlockInput),
+    [cctpBlockInput],
+  );
+  const cctpPrimaryDisabled = useMemo(
+    () => isCctpPrimaryActionDisabled(cctpBlockInput),
+    [cctpBlockInput],
+  );
+  const destinationRecipientSetupHint = useMemo(
+    () =>
+      resolveDestinationRecipientSetupHint(
+        walletRoles.direction,
+        walletRoles.destRecipientAddress,
+        state.useRecipientOverride,
+      ),
+    [
+      state.useRecipientOverride,
+      walletRoles.destRecipientAddress,
+      walletRoles.direction,
+    ],
+  );
+
   return (
     <div
       className="cross-chain-deck w-full mx-auto space-y-5"
@@ -202,6 +255,7 @@ export function CrossChainSwapDeck({
         destWalletBinding={walletRoles.destChipBinding}
         mintSubmitterBinding={walletRoles.mintSubmitterChipBinding}
         inputsLocked={saga.inputsLocked}
+        destWalletHint={destinationRecipientSetupHint}
       />
 
       <div
@@ -239,11 +293,12 @@ export function CrossChainSwapDeck({
                     onChange={state.setRecipientOverride}
                     validation={state.recipientValidation}
                     disabled={saga.inputsLocked}
+                    setupHint={destinationRecipientSetupHint}
                   />
                   {state.executable && walletRoles.direction && (
                     <label className="block space-y-1">
                       <span className="text-xs font-medium text-muted-foreground">
-                        USDC amount (source)
+                        USDC amount (CCTP)
                       </span>
                       <input
                         type="text"
@@ -255,6 +310,22 @@ export function CrossChainSwapDeck({
                         data-testid="cctp-source-amount"
                         disabled={saga.inputsLocked}
                       />
+                      <p
+                        className="text-xs text-muted-foreground"
+                        data-testid="cctp-usdc-only-note"
+                      >
+                        CCTP bridges native USDC only. To move XLM or USDy, swap
+                        to USDC on Stellar first, then bridge.{' '}
+                        <Button
+                          type="button"
+                          variant="link"
+                          className="h-auto p-0 text-xs font-normal"
+                          onClick={() => state.selectCorridor('stellar-native')}
+                          data-testid="swap-to-usdc-on-stellar-link"
+                        >
+                          Swap to USDC on Stellar
+                        </Button>
+                      </p>
                     </label>
                   )}
                   {state.executable && walletRoles.direction && (
@@ -264,12 +335,8 @@ export function CrossChainSwapDeck({
                       transferStatus={saga.transferStatus}
                       error={saga.error}
                       primaryLabel={saga.primaryAction.label}
-                      primaryDisabled={
-                        saga.primaryAction.disabled ||
-                        !state.sourceAmount ||
-                        !walletRoles.destRecipientAddress ||
-                        readiness.loading
-                      }
+                      primaryDisabled={cctpPrimaryDisabled}
+                      ctaHint={ctaHint}
                       onPrimary={() => void saga.runPrimaryAction()}
                       onReset={handleAbandon}
                       resetLabel={

--- a/frontend/components/swap/cross-chain/DestinationAddressField.tsx
+++ b/frontend/components/swap/cross-chain/DestinationAddressField.tsx
@@ -14,6 +14,7 @@ interface DestinationAddressFieldProps {
   onChange: (value: string) => void;
   validation: RecipientValidationResult;
   disabled?: boolean;
+  setupHint?: string | null;
 }
 
 export function DestinationAddressField({
@@ -24,6 +25,7 @@ export function DestinationAddressField({
   onChange,
   validation,
   disabled = false,
+  setupHint,
 }: DestinationAddressFieldProps) {
   return (
     <div className="space-y-3 rounded-2xl border border-border/40 bg-muted/20 p-4">
@@ -44,6 +46,15 @@ export function DestinationAddressField({
             Override the default wallet address on {chain.label}. Required format
             must match the destination chain.
           </p>
+          {!enabled && setupHint && (
+            <p
+              className="text-xs text-muted-foreground"
+              role="status"
+              data-testid="destination-recipient-setup-hint"
+            >
+              {setupHint}
+            </p>
+          )}
         </div>
       </div>
 

--- a/frontend/components/swap/cross-chain/PairedChainSelectors.tsx
+++ b/frontend/components/swap/cross-chain/PairedChainSelectors.tsx
@@ -18,6 +18,7 @@ interface PairedChainSelectorsProps {
   destWalletBinding?: WalletChipBinding | null;
   mintSubmitterBinding?: WalletChipBinding | null;
   inputsLocked?: boolean;
+  destWalletHint?: string | null;
 }
 
 export function PairedChainSelectors({
@@ -31,6 +32,7 @@ export function PairedChainSelectors({
   destWalletBinding,
   mintSubmitterBinding,
   inputsLocked = false,
+  destWalletHint,
 }: PairedChainSelectorsProps) {
   return (
     <section
@@ -67,6 +69,7 @@ export function PairedChainSelectors({
           walletStoryState={destWalletState}
           walletBinding={destWalletBinding}
           inputsLocked={inputsLocked}
+          walletHint={destWalletHint}
         />
       </div>
       {mintSubmitterBinding && (
@@ -95,6 +98,7 @@ function ChainLegColumn({
   walletStoryState,
   walletBinding,
   inputsLocked,
+  walletHint,
 }: {
   role: 'source' | 'destination';
   chainId: ChainDisplayId;
@@ -102,6 +106,7 @@ function ChainLegColumn({
   walletStoryState?: CrossChainWalletStoryState;
   walletBinding?: WalletChipBinding | null;
   inputsLocked?: boolean;
+  walletHint?: string | null;
 }) {
   const chain = CHAIN_DEFINITIONS[chainId];
   const legLabel = role === 'source' ? 'You send from' : 'You receive on';
@@ -120,6 +125,15 @@ function ChainLegColumn({
           storyState={walletStoryState}
         />
       </div>
+      {role === 'destination' && walletHint && (
+        <p
+          className="text-xs text-muted-foreground"
+          role="status"
+          data-testid="dest-wallet-setup-hint"
+        >
+          {walletHint}
+        </p>
+      )}
       <ChainSelector
         value={chainId}
         onChange={onChange}

--- a/frontend/components/swap/cross-chain/cctpCtaHint.ts
+++ b/frontend/components/swap/cross-chain/cctpCtaHint.ts
@@ -1,0 +1,71 @@
+import type { RecipientValidationResult } from '@/lib/cross-chain/types';
+import type { CctpDirection } from '@/lib/cctp/types';
+
+export interface CctpCtaBlockInput {
+  direction: CctpDirection | null;
+  sourceAmount: string;
+  destRecipientAddress: string;
+  useRecipientOverride: boolean;
+  recipientOverride: string;
+  recipientValidation: RecipientValidationResult;
+  bridgeReady: boolean;
+  readinessLoading: boolean;
+  sagaPrimaryDisabled: boolean;
+}
+
+export function resolveDestinationRecipientSetupHint(
+  direction: CctpDirection | null,
+  destRecipientAddress: string,
+  useRecipientOverride: boolean,
+): string | null {
+  if (direction !== 'stellar_to_evm') return null;
+  if (useRecipientOverride || destRecipientAddress) return null;
+  return 'Connect ETH Sepolia or enable Destination recipient below and paste a 0x address.';
+}
+
+export function resolveCctpCtaHint(input: CctpCtaBlockInput): string | null {
+  if (input.readinessLoading) {
+    return 'Checking CCTP availability…';
+  }
+  if (!input.bridgeReady) {
+    return 'CCTP is not executable on this API right now.';
+  }
+  if (
+    input.useRecipientOverride &&
+    input.recipientOverride.trim() &&
+    !input.recipientValidation.valid
+  ) {
+    return (
+      input.recipientValidation.message ?? 'Enter a valid destination address.'
+    );
+  }
+  if (!input.destRecipientAddress) {
+    if (input.direction === 'stellar_to_evm') {
+      return 'Connect ETH Sepolia or enable Destination recipient and paste a 0x address.';
+    }
+    if (input.direction === 'evm_to_stellar') {
+      return 'Connect a Stellar recipient wallet or enable Destination recipient.';
+    }
+    return 'Set a destination recipient to continue.';
+  }
+  if (!input.sourceAmount.trim()) {
+    return 'Enter a USDC amount to get a quote.';
+  }
+  return null;
+}
+
+/** Mirrors CrossChainSwapDeck disable rules plus recipient validation from canReview. */
+export function isCctpPrimaryActionDisabled(input: CctpCtaBlockInput): boolean {
+  if (input.readinessLoading) return true;
+  if (input.sagaPrimaryDisabled) return true;
+  if (!input.destRecipientAddress) return true;
+  if (!input.sourceAmount.trim()) return true;
+  if (
+    input.useRecipientOverride &&
+    input.recipientOverride.trim() &&
+    !input.recipientValidation.valid
+  ) {
+    return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- "Get CCTP quote" was silently disabled when ETH Sepolia was disconnected and recipient override was off — now shows a one-line reason and destination setup hints.
- Clarify CCTP is native USDC only; add "Swap to USDC on Stellar" for XLM/USDy → then bridge (no fake non-USDC CCTP corridors).

## Test plan
- [x] `npm --prefix frontend run test -- components/swap/cross-chain/CrossChainSwapDeck.test.tsx`
- [ ] Production UI: Stellar connected, ETH disconnected → hint under CTA
- [ ] Paste 0x via Destination recipient override → quote enables
- [ ] Confirm USDC-only note + swap link