### PR TITLE
fix(cctp): refresh burn sequence on re-prepare after tx_bad_seq

### DIFF
--- a/crates/api/src/cctp/prepare_lock.rs
+++ b/crates/api/src/cctp/prepare_lock.rs
@@ -1,8 +1,8 @@
 //! Per-Stellar-source active unsigned prepare reservation (multi-instance safe).
 //!
 //! Mirrors swap `ActivePrepareExists` semantics: at most one live unsigned prepare
-//! per source account across API replicas. Same-transfer retries return the cached
-//! payload without regenerating sequence.
+//! per source account across API replicas. Same-transfer re-prepare with a new
+//! payload hash replaces the cached payload (e.g. fresh Stellar sequence).
 
 use async_trait::async_trait;
 use chrono::{DateTime, Utc};
@@ -99,7 +99,8 @@ fn map_active_row_conflict(
         if active.payload_hash == reservation.payload_hash {
             return Ok(PrepareAcquireResult::Idempotent(active));
         }
-        return Err(CctpPrepareLockError::PayloadHashMismatch);
+        // Same transfer, new payload (e.g. refreshed sequence) — caller updates the row.
+        return Ok(PrepareAcquireResult::Acquired);
     }
     Ok(PrepareAcquireResult::ConflictOtherTransfer {
         holder_transfer_id: active.transfer_id,
@@ -179,7 +180,14 @@ impl CctpPrepareLockStore for InMemoryCctpPrepareLockStore {
                     if existing.payload_hash == reservation.payload_hash {
                         return Ok(PrepareAcquireResult::Idempotent(existing.clone()));
                     }
-                    return Err(CctpPrepareLockError::PayloadHashMismatch);
+                    guard.insert(
+                        reservation.source_account.clone(),
+                        CctpActivePrepare {
+                            updated_at: Utc::now(),
+                            ..reservation.clone()
+                        },
+                    );
+                    return Ok(PrepareAcquireResult::Acquired);
                 }
                 return Ok(PrepareAcquireResult::ConflictOtherTransfer {
                     holder_transfer_id: existing.transfer_id,
@@ -327,6 +335,37 @@ impl CctpPrepareLockStore for PgCctpPrepareLockStore {
 
         if let Some(row) = existing {
             let active = Self::map_row(row.0, row.1, row.2, row.3, row.4, row.5, row.6);
+            if active.transfer_id == reservation.transfer_id {
+                if active.payload_hash == reservation.payload_hash {
+                    tx.rollback()
+                        .await
+                        .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                    return Ok(PrepareAcquireResult::Idempotent(active));
+                }
+                let now = Utc::now();
+                sqlx::query(
+                    r#"
+                    UPDATE cctp_active_prepares
+                    SET prepare_kind = $2, payload_hash = $3, prepared_payload = $4,
+                        expires_at = $5, updated_at = $6
+                    WHERE source_account = $1 AND transfer_id = $7
+                    "#,
+                )
+                .bind(&reservation.source_account)
+                .bind(reservation.kind.as_str())
+                .bind(&reservation.payload_hash)
+                .bind(&reservation.prepared_payload)
+                .bind(reservation.expires_at)
+                .bind(now)
+                .bind(reservation.transfer_id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                tx.commit()
+                    .await
+                    .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                return Ok(PrepareAcquireResult::Acquired);
+            }
             tx.rollback()
                 .await
                 .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
@@ -387,6 +426,37 @@ impl CctpPrepareLockStore for PgCctpPrepareLockStore {
 
                 if let Some(row) = row {
                     let active = Self::map_row(row.0, row.1, row.2, row.3, row.4, row.5, row.6);
+                    if active.transfer_id == reservation.transfer_id {
+                        if active.payload_hash == reservation.payload_hash {
+                            tx.rollback()
+                                .await
+                                .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                            return Ok(PrepareAcquireResult::Idempotent(active));
+                        }
+                        let now = Utc::now();
+                        sqlx::query(
+                            r#"
+                            UPDATE cctp_active_prepares
+                            SET prepare_kind = $2, payload_hash = $3, prepared_payload = $4,
+                                expires_at = $5, updated_at = $6
+                            WHERE source_account = $1 AND transfer_id = $7
+                            "#,
+                        )
+                        .bind(&reservation.source_account)
+                        .bind(reservation.kind.as_str())
+                        .bind(&reservation.payload_hash)
+                        .bind(&reservation.prepared_payload)
+                        .bind(reservation.expires_at)
+                        .bind(now)
+                        .bind(reservation.transfer_id)
+                        .execute(&mut *tx)
+                        .await
+                        .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                        tx.commit()
+                            .await
+                            .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
+                        return Ok(PrepareAcquireResult::Acquired);
+                    }
                     tx.rollback()
                         .await
                         .map_err(|e| CctpPrepareLockError::Database(e.to_string()))?;
@@ -538,6 +608,26 @@ mod tests {
             store.try_acquire(&r2).await.unwrap(),
             PrepareAcquireResult::Idempotent(_)
         ));
+    }
+
+    #[tokio::test]
+    async fn same_transfer_new_hash_replaces_payload() {
+        let store = InMemoryCctpPrepareLockStore::default();
+        let source = "GAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAWHF";
+        let tid = Uuid::new_v4();
+        let r1 = reservation(source, tid, CctpPrepareKind::Burn, "hash-a", Some("payload-a"));
+        assert!(matches!(
+            store.try_acquire(&r1).await.unwrap(),
+            PrepareAcquireResult::Acquired
+        ));
+        let r2 = reservation(source, tid, CctpPrepareKind::Burn, "hash-b", Some("payload-b"));
+        assert!(matches!(
+            store.try_acquire(&r2).await.unwrap(),
+            PrepareAcquireResult::Acquired
+        ));
+        let active = store.get_active(source).await.unwrap().unwrap();
+        assert_eq!(active.payload_hash, "hash-b");
+        assert_eq!(active.prepared_payload.as_deref(), Some("payload-b"));
     }
 
     #[tokio::test]

--- a/crates/api/src/cctp/service.rs
+++ b/crates/api/src/cctp/service.rs
@@ -220,30 +220,6 @@ impl CctpService {
             .map_err(Self::map_prepare_lock_error)
     }
 
-    async fn active_burn_bundle_for_transfer(
-        &self,
-        transfer_id: Uuid,
-        source: &str,
-    ) -> Result<Option<PreparedBurnBundle>, CctpServiceError> {
-        let active = self
-            .prepare_lock
-            .get_for_transfer(transfer_id)
-            .await
-            .map_err(Self::map_prepare_lock_error)?;
-        let Some(active) = active else {
-            return Ok(None);
-        };
-        if active.source_account != source || active.expires_at <= Utc::now() {
-            return Ok(None);
-        }
-        let Some(payload) = active.prepared_payload else {
-            return Ok(None);
-        };
-        Ok(Some(
-            deserialize_burn_bundle(&payload).map_err(Self::map_payload_cache_error)?,
-        ))
-    }
-
     async fn active_mint_bundle_for_transfer(
         &self,
         transfer_id: Uuid,
@@ -953,12 +929,6 @@ impl CctpService {
         }
 
         let source = burn_prepare_source(&transfer)?;
-        if let Some(cached) = self
-            .active_burn_bundle_for_transfer(transfer_id, source)
-            .await?
-        {
-            return Ok(cached);
-        }
 
         let bundle = match transfer.direction {
             CctpDirection::StellarToEvm => self

--- a/crates/api/tests/cctp_service_burn_prepare.rs
+++ b/crates/api/tests/cctp_service_burn_prepare.rs
@@ -42,6 +42,38 @@ impl IrisClient for MockIris {
     }
 }
 
+struct SequenceRefreshBurnBuilder {
+    sequence: AtomicUsize,
+}
+
+#[async_trait]
+impl StellarCctpBurnBuilder for SequenceRefreshBurnBuilder {
+    fn is_ready(&self) -> bool {
+        true
+    }
+
+    async fn prepare_burn(
+        &self,
+        transfer: &CctpTransfer,
+        _: &CctpConfig,
+    ) -> Result<PreparedBurnBundle, BuilderError> {
+        let seq = self.sequence.fetch_add(1, Ordering::SeqCst) + 100;
+        let expires = transfer.quote_expires_at.timestamp();
+        Ok(PreparedBurnBundle {
+            step: BurnPrepareStep::Burn,
+            approval_required: false,
+            primary: PreparedWalletPayload::StellarXdr {
+                network_passphrase: "Test SDF Network ; September 2015".into(),
+                xdr_envelope: format!("AAAA-burn-seq-{seq}"),
+            },
+            required_approvals: vec![],
+            required_prior_payloads: vec![],
+            expires_at: expires,
+            approval_expiration_ledger: None,
+        })
+    }
+}
+
 struct SteppedBurnBuilder {
     calls: AtomicUsize,
 }
@@ -167,6 +199,7 @@ impl stellarroute_api::cctp::verifiers::StellarBurnVerifier for ReadyBurnVerifie
 fn test_service(builder: Arc<dyn StellarCctpBurnBuilder>) -> CctpService {
     let mut cfg = CctpConfig::default_testnet();
     cfg.enabled = true;
+    cfg.sepolia_rpc_url = "https://ethereum-sepolia-rpc.publicnode.com".into();
     let mut runtime = CctpRuntime::for_tests(
         Arc::new(NotReadyStellarBurnVerifier),
         Arc::new(NotReadyEvmBurnVerifier),
@@ -182,6 +215,33 @@ fn test_service(builder: Arc<dyn StellarCctpBurnBuilder>) -> CctpService {
         kill_switch: Arc::new(KillSwitchManager::new(None)),
         runtime,
     }
+}
+
+#[tokio::test]
+async fn re_prepare_same_transfer_refreshes_sequence() {
+    let builder: Arc<dyn StellarCctpBurnBuilder> = Arc::new(SequenceRefreshBurnBuilder {
+        sequence: AtomicUsize::new(0),
+    });
+    let svc = test_service(builder);
+    let t = sample_transfer();
+    let id = t.transfer_id;
+    svc.store.insert(&t).await.unwrap();
+
+    let first = svc.prepare_burn_wallet(id).await.unwrap();
+    assert_eq!(first.step, BurnPrepareStep::Burn);
+    let first_xdr = match &first.primary {
+        PreparedWalletPayload::StellarXdr { xdr_envelope, .. } => xdr_envelope.clone(),
+        _ => panic!("expected stellar xdr"),
+    };
+    assert!(first_xdr.contains("seq-100"));
+
+    let second = svc.prepare_burn_wallet(id).await.unwrap();
+    let second_xdr = match &second.primary {
+        PreparedWalletPayload::StellarXdr { xdr_envelope, .. } => xdr_envelope.clone(),
+        _ => panic!("expected stellar xdr"),
+    };
+    assert!(second_xdr.contains("seq-101"));
+    assert_ne!(first_xdr, second_xdr);
 }
 
 #[tokio::test]

--- a/frontend/hooks/useCctpSaga.test.ts
+++ b/frontend/hooks/useCctpSaga.test.ts
@@ -259,6 +259,57 @@ describe('useCctpSaga server-driven burn staging', () => {
     expect(fp1).not.toBe(fp2);
   });
 
+  it('Stellar burn tx_bad_seq returns to re-prepare without failed stage', async () => {
+    const input = {
+      sourceChainId: 'stellar' as const,
+      destChainId: 'ethereum-sepolia' as const,
+      amount: '10',
+      recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0',
+      wallets: {
+        recipient: '0x742d35Cc6634C0532925a3b844Bc9e7595f0bEb0',
+        sourceStellarAdapterId: 'freighter',
+        sourceAddress: STELLAR_G,
+        evmDestinationAdapterId: 'evm:dest',
+      },
+      bridgeReady: true,
+      quoteInputsKey: 'k-seq',
+      sender: STELLAR_G,
+    };
+    prepareBurn.mockResolvedValue({
+      approval_required: false,
+      payload: stellarBurnPayload,
+      expires_at: 9999999999,
+    });
+    const { HorizonSubmitError } = await import('@/lib/wallet/submit');
+    executePreparedPayload.mockRejectedValue(
+      new HorizonSubmitError('Transaction failed: tx_bad_seq', {
+        code: 'tx_bad_seq',
+        transactionCode: 'tx_bad_seq',
+        status: 400,
+      }),
+    );
+
+    const { result } = renderHook(() => useCctpSaga(input));
+    await act(async () => {
+      await result.current.requestQuote();
+    });
+    await act(async () => {
+      await result.current.prepareSourceBurn();
+    });
+    expect(result.current.burnPrepareStep).toBe('burn_ready');
+
+    await act(async () => {
+      await result.current.signBurnStep();
+    });
+
+    expect(result.current.stage).toBe('quoted');
+    expect(result.current.burnPrepareStep).toBe('reprepare_required');
+    expect(result.current.primaryAction.label).toBe('Re-prepare transaction');
+    expect(result.current.primaryAction.action).toBe('prepare');
+    expect(result.current.error?.kind).toBe('sequence_stale');
+    expect(submitBurn).not.toHaveBeenCalled();
+  });
+
   it('does not submit burn when EVM receipt is pending', async () => {
     prepareBurn.mockResolvedValue({
       approval_required: false,

--- a/frontend/hooks/useCctpSaga.ts
+++ b/frontend/hooks/useCctpSaga.ts
@@ -6,7 +6,7 @@ import { StellarRouteApiError } from '@/lib/api/client';
 import { buildCctpQuoteRequest } from '@/lib/cctp/corridor-bridge';
 import { classifyStellarRecipient } from '@/lib/cctp/wallet-role-binding';
 import { getCctpApiClient } from '@/lib/cctp/client';
-import { mapCctpError, type CctpTraderError } from '@/lib/cctp/errors';
+import { mapCctpError, isStaleSequenceError, type CctpTraderError } from '@/lib/cctp/errors';
 import { fingerprintPreparedPayload } from '@/lib/cctp/payload-fingerprint';
 import {
   buildCctpSessionRecord,
@@ -367,6 +367,20 @@ export function useCctpSaga(input: UseCctpSagaInput) {
     },
     [],
   );
+
+  const requireReprepareAfterSequenceError = useCallback((err: unknown) => {
+    if (!isStaleSequenceError(err)) return false;
+    setPreparedPayload(null);
+    setPreparedFingerprint(null);
+    setBurnPrepareStep('reprepare_required');
+    patchCctpSessionRecovery({
+      burnPrepareStep: 'reprepare_required',
+      lastPreparedFingerprint: undefined,
+    });
+    setError(mapCctpError(err));
+    setStage('quoted');
+    return true;
+  }, []);
 
   const requestQuote = useCallback(async () => {
     if (!input.bridgeReady) {
@@ -760,6 +774,7 @@ export function useCctpSaga(input: UseCctpSagaInput) {
       patchCctpSessionRecovery({ burnPrepareStep: 'unknown' });
       setStage('quoted');
     } catch (err) {
+      if (requireReprepareAfterSequenceError(err)) return;
       setError(mapCctpError(err));
       setStage('failed');
     } finally {
@@ -773,6 +788,7 @@ export function useCctpSaga(input: UseCctpSagaInput) {
     input.wallets,
     preparedFingerprint,
     preparedPayload,
+    requireReprepareAfterSequenceError,
     resolveEvmAdapterForPayload,
     session,
     syncSession,
@@ -830,6 +846,7 @@ export function useCctpSaga(input: UseCctpSagaInput) {
       setStage('awaiting_attestation');
       startPoll(session.transferId, session.accessToken);
     } catch (err) {
+      if (requireReprepareAfterSequenceError(err)) return;
       setError(mapCctpError(err));
       setStage('failed');
     } finally {
@@ -843,6 +860,7 @@ export function useCctpSaga(input: UseCctpSagaInput) {
     input.wallets,
     preparedFingerprint,
     preparedPayload,
+    requireReprepareAfterSequenceError,
     resolveEvmAdapterForPayload,
     session,
     startPoll,

--- a/frontend/lib/cctp/errors.test.ts
+++ b/frontend/lib/cctp/errors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { HorizonSubmitError } from '@/lib/wallet/submit';
+import { isStaleSequenceError, mapCctpError } from './errors';
+
+describe('mapCctpError sequence stale', () => {
+  it('maps Horizon tx_bad_seq to re-prepare guidance', () => {
+    const err = new HorizonSubmitError('Transaction failed: tx_bad_seq', {
+      code: 'tx_bad_seq',
+      transactionCode: 'tx_bad_seq',
+      status: 400,
+    });
+    const mapped = mapCctpError(err);
+    expect(mapped.kind).toBe('sequence_stale');
+    expect(mapped.title).toBe('Account sequence out of date');
+    expect(mapped.action).toBe('Re-prepare transaction');
+    expect(mapped.message).toContain('Re-prepare the burn');
+  });
+
+  it('detects classic bad_sequence status on generic errors', () => {
+    const err = new Error('Account sequence mismatch') as Error & {
+      status?: string;
+    };
+    err.status = 'bad_sequence';
+    expect(isStaleSequenceError(err)).toBe(true);
+    const mapped = mapCctpError(err);
+    expect(mapped.kind).toBe('sequence_stale');
+    expect(mapped.action).toBe('Re-prepare transaction');
+  });
+});

--- a/frontend/lib/cctp/errors.ts
+++ b/frontend/lib/cctp/errors.ts
@@ -1,5 +1,6 @@
 import { StellarRouteApiError } from '@/lib/api/client';
 import { isUserRejection, WalletAdapterError } from '@/lib/wallet/adapters';
+import { HorizonSubmitError } from '@/lib/wallet/submit';
 
 export type CctpErrorKind =
   | 'retryable'
@@ -8,6 +9,7 @@ export type CctpErrorKind =
   | 'wrong_network'
   | 'quote_expired'
   | 'payload_expired'
+  | 'sequence_stale'
   | 'provider_killed'
   | 'dependency_unavailable'
   | 'authorization_lost'
@@ -45,6 +47,16 @@ export function mapCctpError(err: unknown): CctpTraderError {
         action: 'Switch network in wallet',
       };
     }
+  }
+
+  if (isStaleSequenceError(err)) {
+    return {
+      kind: 'sequence_stale',
+      title: 'Account sequence out of date',
+      message:
+        'Your Stellar account changed while this burn was being prepared. Re-prepare the burn using the same quote if it is still valid.',
+      action: 'Re-prepare transaction',
+    };
   }
 
   if (err instanceof StellarRouteApiError) {
@@ -194,6 +206,25 @@ function isWalletRejection(err: unknown): boolean {
   if (!(err instanceof Error)) return false;
   const code = (err as Error & { code?: string }).code;
   return code === 'user_rejected' || /reject|denied|cancel/i.test(err.message);
+}
+
+export function isStaleSequenceError(err: unknown): boolean {
+  if (err instanceof HorizonSubmitError) {
+    return (
+      err.code === 'tx_bad_seq' ||
+      err.transactionCode === 'tx_bad_seq' ||
+      err.transactionCode === 'bad_sequence'
+    );
+  }
+  if (err instanceof Error) {
+    const code = (err as Error & { code?: string }).code;
+    if (code === 'tx_bad_seq' || code === 'bad_sequence') return true;
+    const status = (err as Error & { status?: string }).status;
+    if (status === 'bad_sequence') return true;
+    const message = err.message.toLowerCase();
+    return message.includes('tx_bad_seq') || message.includes('bad_sequence');
+  }
+  return false;
 }
 
 function extractRequestId(details: unknown): string | undefined {

--- a/frontend/lib/wallet/submit.test.ts
+++ b/frontend/lib/wallet/submit.test.ts
@@ -78,6 +78,21 @@ describe('submitToHorizon', () => {
     });
   });
 
+  it('classifies tx_bad_seq as typed submit errors', async () => {
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: false,
+      status: 400,
+      json: async () => ({
+        extras: { result_codes: { transaction: 'tx_bad_seq' } },
+      }),
+    } as Response);
+
+    await expect(submitToHorizon('bad_xdr', 'testnet')).rejects.toMatchObject({
+      code: 'tx_bad_seq',
+      transactionCode: 'tx_bad_seq',
+    });
+  });
+
   it('classifies op_underfunded operation failures', async () => {
     global.fetch = vi.fn().mockResolvedValueOnce({
       ok: false,

--- a/frontend/lib/wallet/submit.ts
+++ b/frontend/lib/wallet/submit.ts
@@ -20,6 +20,7 @@ export interface HorizonSubmitResult {
 
 export type HorizonSubmitErrorCode =
   | 'tx_bad_auth'
+  | 'tx_bad_seq'
   | 'op_underfunded'
   | 'timeout'
   | 'horizon_error';
@@ -71,6 +72,7 @@ function classifyHorizonError(
   opCodes: string[] = [],
 ): HorizonSubmitErrorCode {
   if (txCode === 'tx_bad_auth') return 'tx_bad_auth';
+  if (txCode === 'tx_bad_seq') return 'tx_bad_seq';
   if (opCodes.includes('op_underfunded')) return 'op_underfunded';
   return 'horizon_error';
 }


### PR DESCRIPTION
## Summary
- Stellar CCTP burn failed with `tx_bad_seq` when Freighter signed a prepare whose account sequence had already advanced; re-prepare returned the same cached XDR.
- API now always rebuilds burn payloads with a fresh sequence and updates the prepare lock when the hash changes; UI maps `tx_bad_seq` to **Re-prepare transaction**.

## Test plan
- [x] `cargo test -p stellarroute-api prepare_lock --lib`
- [x] `cargo test -p stellarroute-api --test cctp_service_burn_prepare`
- [x] `npm --prefix frontend run test -- lib/cctp/errors.test.ts lib/wallet/submit.test.ts hooks/useCctpSaga.test.ts`
- [ ] Staging: quote → prepare → sign after delay → on `tx_bad_seq`, Re-prepare → sign succeeds