### PR TITLE
fix(cctp): use next account sequence (+1) for Stellar burn XDR

### DIFF
--- a/crates/api/src/cctp/builders/stellar/encoder.rs
+++ b/crates/api/src/cctp/builders/stellar/encoder.rs
@@ -161,7 +161,7 @@ pub fn build_unsigned_invoke_tx(params: &InvokeTxParams) -> Result<Transaction, 
     })
 }
 
-/// Encode unsigned invoke envelope at explicit account sequence (Horizon/RPC value).
+/// Encode unsigned invoke envelope at explicit next-transaction sequence number.
 pub fn encode_invoke_at_sequence(
     source: &str,
     contract: &str,

--- a/crates/api/src/cctp/builders/stellar/mod.rs
+++ b/crates/api/src/cctp/builders/stellar/mod.rs
@@ -242,11 +242,12 @@ impl ProductionStellarCctpBuilder {
         transfer: &CctpTransfer,
     ) -> Result<String, BuilderError> {
         Self::ensure_testnet_config(config)?;
-        let sequence = self
+        let current = self
             .sequences
             .current_sequence(source)
             .await
             .map_err(|e| BuilderError::AccountLookup(e.to_string()))?;
+        let sequence = current.saturating_add(1);
         let latest = self.latest_ledger().await?;
         let quote_exp = transfer.quote_expires_at.timestamp();
         let params = InvokeTxParams {
@@ -641,6 +642,79 @@ mod tests {
     #[test]
     fn offline_encoder_is_not_production_ready() {
         assert!(!OfflineStellarXdrEncoder.is_ready());
+    }
+
+    #[tokio::test]
+    async fn prepared_burn_envelope_uses_next_tx_sequence() {
+        use crate::models::v2_cctp::PreparedWalletPayload;
+        use serde_json::json;
+        use stellar_xdr::curr::{
+            LedgerFootprint, Limits, SorobanResources, SorobanTransactionData,
+            SorobanTransactionDataExt, WriteXdr,
+        };
+        use wiremock::matchers::{body_string_contains, method};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let transaction_data = SorobanTransactionData {
+            ext: SorobanTransactionDataExt::V0,
+            resources: SorobanResources {
+                footprint: LedgerFootprint {
+                    read_only: Default::default(),
+                    read_write: Default::default(),
+                },
+                instructions: 0,
+                disk_read_bytes: 0,
+                write_bytes: 0,
+            },
+            resource_fee: 0,
+        }
+        .to_xdr_base64(Limits::none())
+        .expect("soroban tx data xdr");
+
+        let server = MockServer::start().await;
+        let mut cfg = CctpConfig::default_testnet();
+        cfg.stellar_rpc_url = server.uri();
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("getLatestLedger"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": { "sequence": 50_000 }
+            })))
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(body_string_contains("simulateTransaction"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "jsonrpc": "2.0",
+                "id": 1,
+                "result": {
+                    "transactionData": transaction_data,
+                    "minResourceFee": "100",
+                    "results": [{ "xdr": "AAAAAA==" }]
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let rpc = Arc::new(StellarRpcClient::new(&cfg).unwrap());
+        let builder = ProductionStellarCctpBuilder {
+            sequences: Arc::new(FixedAccountSequences::new(100)),
+            rpc,
+            allowance: Arc::new(FixedAllowanceChecker { sufficient: true }),
+            probe_ok: true,
+            base_fee: DEFAULT_BASE_FEE,
+        };
+        let bundle = builder
+            .prepare_burn(&sample_stellar_burn_transfer(None), &cfg)
+            .await
+            .expect("prepare_burn");
+        let PreparedWalletPayload::StellarXdr { xdr_envelope, .. } = bundle.primary else {
+            panic!("expected stellar xdr payload");
+        };
+        assert_eq!(envelope_sequence(&xdr_envelope).unwrap(), 101);
     }
 
     #[tokio::test]

--- a/crates/api/src/cctp/stellar_builder_simulation.rs
+++ b/crates/api/src/cctp/stellar_builder_simulation.rs
@@ -289,10 +289,11 @@ pub async fn probe_strict_simulation_assembly_with_evidence(
         .await
         .map_err(|e| format!("latest_ledger: {e}"))?;
     let sequences = RpcAccountSequenceSource::new(config, Arc::new(rpc.clone()));
-    let sequence = sequences
+    let current = sequences
         .current_sequence(&source)
         .await
         .map_err(|e| format!("sequence: {e}"))?;
+    let sequence = current.saturating_add(1);
     let quote_exp = chrono::Utc::now().timestamp() + 600;
     let contract = config.contracts.stellar_usdc.clone();
     let params = InvokeTxParams {

--- a/crates/api/src/cctp/stellar_rpc.rs
+++ b/crates/api/src/cctp/stellar_rpc.rs
@@ -117,7 +117,7 @@ impl StellarRpcClient {
         Ok(result.sequence)
     }
 
-    /// Current account sequence for the next transaction (Horizon-compatible value).
+    /// Current on-ledger account sequence (Horizon/RPC value; next tx uses +1).
     pub async fn get_account_sequence(&self, account_id: &str) -> Result<i64, VerifierError> {
         use stellar_xdr::curr::{
             AccountId, LedgerEntry, LedgerEntryData, LedgerKey, LedgerKeyAccount, Limits,

--- a/crates/api/src/cctp/stellar_sequence.rs
+++ b/crates/api/src/cctp/stellar_sequence.rs
@@ -66,9 +66,13 @@ impl RpcAccountSequenceSource {
 #[async_trait]
 impl AccountSequenceSource for RpcAccountSequenceSource {
     async fn current_sequence(&self, account_id: &str) -> Result<i64, TxBuildError> {
-        match self.rpc.get_account_sequence(account_id).await {
-            Ok(seq) => Ok(seq),
-            Err(_) => self.horizon.current_sequence(account_id).await,
+        let rpc_result = self.rpc.get_account_sequence(account_id).await;
+        let horizon_result = self.horizon.current_sequence(account_id).await;
+        match (rpc_result, horizon_result) {
+            (Ok(rpc), Ok(horizon)) => Ok(rpc.max(horizon)),
+            (Ok(rpc), Err(_)) => Ok(rpc),
+            (Err(_), Ok(horizon)) => Ok(horizon),
+            (Err(_), Err(e)) => Err(e),
         }
     }
 }


### PR DESCRIPTION
## Summary
- CCTP burn/approval XDR used the on-ledger account sequence as `seq_num`; Horizon requires the **next** sequence (`current + 1`), matching classic swap.
- That made every Freighter-signed burn fail with `tx_bad_seq`; re-prepare could not help because it rebuilt the same wrong math.
- Also take `max(rpc, horizon)` before incrementing to reduce RPC lag issues.

## Test plan
- [x] `cargo test -p stellarroute-api --lib builders::stellar`
- [x] `cargo test -p stellarroute-api --test cctp_stellar_builder`
- [x] `cargo test -p stellarroute-api --test cctp_service_burn_prepare`
- [ ] Staging: **Start new transfer** → quote → prepare → Freighter sign succeeds without `tx_bad_seq`