### PR TITLE
[899] [frontend] Fix SwapCard ESLint errors blocking CI lint step

### DIFF
--- a/frontend/components/swap/SwapCard.lifecycle-errors.test.tsx
+++ b/frontend/components/swap/SwapCard.lifecycle-errors.test.tsx
@@ -63,13 +63,16 @@ vi.mock('@/hooks/useFeatureFlag', () => ({
 
 vi.mock('@/lib/api/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/api/client')>();
+  const makeMockClient = () => {
+    const client = actual.createStellarRouteClient();
+    client.prepareSwap = (...args: unknown[]) => prepareSwapMock(...args);
+    client.submitSwap = vi.fn();
+    return client;
+  };
   return {
     ...actual,
-    stellarRouteClient: {
-      ...actual.stellarRouteClient,
-      prepareSwap: (...args: unknown[]) => prepareSwapMock(...args),
-      submitSwap: vi.fn(),
-    },
+    createStellarRouteClient: makeMockClient,
+    stellarRouteClient: makeMockClient(),
   };
 });
 

--- a/frontend/components/swap/SwapCard.test.tsx
+++ b/frontend/components/swap/SwapCard.test.tsx
@@ -201,17 +201,20 @@ vi.mock('@/lib/wallet', () => ({
 
 vi.mock('@/lib/api/client', async (importOriginal) => {
   const actual = await importOriginal<typeof import('@/lib/api/client')>();
+  const makeMockClient = () => {
+    const client = actual.createStellarRouteClient();
+    client.prepareSwap = (...args: unknown[]) => prepareSwapMock(...args);
+    client.submitSwap = vi.fn().mockResolvedValue({
+      quote_id: 'q-1',
+      tx_hash: 'test_submit_hash',
+      status: 'pending',
+    });
+    return client;
+  };
   return {
     ...actual,
-    stellarRouteClient: {
-      ...actual.stellarRouteClient,
-      prepareSwap: (...args: unknown[]) => prepareSwapMock(...args),
-      submitSwap: vi.fn().mockResolvedValue({
-        quote_id: 'q-1',
-        tx_hash: 'test_submit_hash',
-        status: 'pending',
-      }),
-    },
+    createStellarRouteClient: makeMockClient,
+    stellarRouteClient: makeMockClient(),
   };
 });
 
@@ -992,14 +995,17 @@ describe('SwapCard Freighter signing wiring (#735)', () => {
 
     await user.click(screen.getByRole('button', { name: /review swap/i }));
 
-    await waitFor(() => {
-      expect(prepareSwapMock).toHaveBeenCalled();
-      expect(signTransactionWithWallet).toHaveBeenCalledWith(
-        'AAAAtest_unsigned_xdr',
-        'freighter',
-        expect.any(String)
-      );
-    });
+    await waitFor(
+      () => {
+        expect(prepareSwapMock).toHaveBeenCalled();
+        expect(signTransactionWithWallet).toHaveBeenCalledWith(
+          'AAAAtest_unsigned_xdr',
+          'freighter',
+          expect.any(String)
+        );
+      },
+      { timeout: 5000 }
+    );
   });
 
   it('does not call signTransactionWithWallet when wallet is disconnected', async () => {

--- a/frontend/components/swap/SwapCard.tsx
+++ b/frontend/components/swap/SwapCard.tsx
@@ -126,8 +126,6 @@ export function SwapCard({ storyFixture, showRoutePicker = false }: SwapCardProp
     fromAmount,
     setFromAmount,
     toAmount,
-    side,
-    setSide,
     slippage,
     setSlippage,
     deadline,


### PR DESCRIPTION
Closes 899

## Summary
The CI lint/test gates for the frontend were red because SwapCard tests mocked only the \stellarRouteClient\ singleton, while \SwapCard\ resolves its API client through \useStellarRouteClient()\ -> \createStellarRouteClient()\. As a result \prepareSwap\/\submitSwap\ were never invoked in tests and the suites failed.

## Changes
- \rontend/components/swap/SwapCard.tsx\: removed unused \side\/\setSide\ destructuring (clears remaining ESLint warnings on the file).
- \rontend/components/swap/SwapCard.test.tsx\: route \prepareSwap\/\submitSwap\ through \createStellarRouteClient\ (the factory) while spreading the actual module; added a \waitFor\ timeout on the Freighter signing assertion.
- \rontend/components/swap/SwapCard.lifecycle-errors.test.tsx\: applied the same factory-routing mock fix.

## Verification
- \
pm --prefix frontend run lint\ -> exit 0
- \
pm --prefix frontend run build\ -> success
- \
pm --prefix frontend run storybook:ci\ -> success
- All frontend unit-test jobs pass locally (swap: 233 tests, hooks: 242, lib: 467, shared: 126, providers: 35, settings: 34, rest: 69, app: 26).