### PR TITLE
fix(cctp): classify Stellar approval vs burn submissions

### DIFF
--- a/crates/api/src/cctp/gate.rs
+++ b/crates/api/src/cctp/gate.rs
@@ -3,7 +3,7 @@
 use uuid::Uuid;
 
 use crate::cctp::access::{hash_access_token, validate_access_token_format};
-use crate::cctp::builders::BurnPrepareStep;
+use crate::cctp::builders::{BuilderError, BurnPrepareStep};
 use crate::cctp::config::CctpConfig;
 use crate::cctp::readiness::CctpRuntime;
 use crate::cctp::service::{CctpService, CctpServiceError};
@@ -329,9 +329,11 @@ pub fn map_service_error(err: CctpServiceError, transfer_id: Option<Uuid>) -> Ap
         CctpServiceError::InvalidState => {
             ApiError::Validation("Transfer is not in a valid state for this operation".into())
         }
-        CctpServiceError::QuoteExpired => {
-            ApiError::Validation("CCTP quote has expired; request a new quote".into())
-        }
+        CctpServiceError::QuoteExpired => ApiError::QuoteExpired {
+            quote_id: transfer_id
+                .map(|id| id.to_string())
+                .unwrap_or_else(|| "unknown".into()),
+        },
         CctpServiceError::FeeExpired => {
             ApiError::FeeQuoteUnavailable("CCTP fee quote has expired; request a new quote".into())
         }
@@ -362,11 +364,20 @@ pub fn map_service_error(err: CctpServiceError, transfer_id: Option<Uuid>) -> Ap
         CctpServiceError::Iris(_) => ApiError::DependencyUnavailable(
             "Circle attestation service is temporarily unavailable".into(),
         ),
-        CctpServiceError::Verifier(VerifierError::Transient(_)) => ApiError::DependencyUnavailable(
-            "On-chain verification dependency is temporarily unavailable".into(),
+        CctpServiceError::Verifier(VerifierError::Transient(_))
+        | CctpServiceError::Verifier(VerifierError::TxNotFound) => ApiError::DependencyUnavailable(
+            "Submitted transaction is not yet available for verification; retry shortly".into(),
         ),
+        CctpServiceError::Builder(err) => map_builder_error(err),
+        CctpServiceError::Verifier(VerifierError::Failed(msg))
+            if msg.contains("wrong function") || msg.contains("unsupported stellar invoke") =>
+        {
+            ApiError::Validation(
+                "Submitted transaction is a USDC approval, not a burn. Click Prepare source transaction, then sign the burn."
+                    .into(),
+            )
+        }
         CctpServiceError::Verifier(_)
-        | CctpServiceError::Builder(_)
         | CctpServiceError::InvalidMessage
         | CctpServiceError::IrisTxHashMismatch
         | CctpServiceError::MintPayloadHashMismatch => {
@@ -375,6 +386,48 @@ pub fn map_service_error(err: CctpServiceError, transfer_id: Option<Uuid>) -> Ap
         CctpServiceError::Store(_) => ApiError::Internal(std::sync::Arc::new(anyhow::anyhow!(
             "CCTP persistence error"
         ))),
+    }
+}
+
+fn map_builder_error(err: BuilderError) -> ApiError {
+    match err {
+        BuilderError::NotReady => ApiError::CctpNotEnabled(
+            "Circle CCTP transaction builder is not ready on this deployment".into(),
+        ),
+        BuilderError::QuoteExpired => ApiError::QuoteExpired {
+            quote_id: "cctp-transfer".into(),
+        },
+        BuilderError::FeeExpired => ApiError::FeeQuoteUnavailable(
+            "CCTP fee quote has expired; request a new quote".into(),
+        ),
+        BuilderError::Validation(msg) => {
+            if msg.contains("sender required") {
+                ApiError::Validation(
+                    "Connect your source wallet and request a new quote before preparing the burn"
+                        .into(),
+                )
+            } else {
+                ApiError::Validation(msg)
+            }
+        }
+        BuilderError::SimulationFailed(msg) => {
+            let lower = msg.to_ascii_lowercase();
+            if lower.contains("insufficient") || lower.contains("balance") {
+                ApiError::Validation(
+                    "Insufficient USDC balance on Stellar for this burn amount".into(),
+                )
+            } else {
+                ApiError::Validation(format!(
+                    "Could not prepare source transaction: Soroban simulation failed ({msg})"
+                ))
+            }
+        }
+        BuilderError::AccountLookup(msg) => ApiError::DependencyUnavailable(format!(
+            "Stellar account lookup failed while preparing the burn: {msg}"
+        )),
+        BuilderError::Encoding(msg) => ApiError::Validation(format!(
+            "Could not encode CCTP source transaction: {msg}"
+        )),
     }
 }
 
@@ -841,5 +894,35 @@ mod tests {
         assert!(!exec_after);
         assert_eq!(corridors.len(), 2);
         assert!(corridors.iter().all(|c| !c.executable));
+    }
+
+    #[test]
+    fn builder_simulation_failure_maps_to_prepare_message() {
+        let err = map_service_error(
+            CctpServiceError::Builder(BuilderError::SimulationFailed(
+                "insufficient balance".into(),
+            )),
+            None,
+        );
+        match err {
+            ApiError::Validation(msg) => {
+                assert!(msg.contains("Insufficient USDC balance"));
+            }
+            other => panic!("expected validation, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn verifier_tx_not_found_is_retryable_dependency() {
+        let err = map_service_error(
+            CctpServiceError::Verifier(VerifierError::TxNotFound),
+            None,
+        );
+        match err {
+            ApiError::DependencyUnavailable(msg) => {
+                assert!(msg.contains("not yet available"));
+            }
+            other => panic!("expected dependency_unavailable, got {other:?}"),
+        }
     }
 }

--- a/crates/api/src/cctp/service.rs
+++ b/crates/api/src/cctp/service.rs
@@ -28,6 +28,8 @@ use crate::cctp::prepare_payload_cache::{
 };
 use crate::cctp::readiness::CctpRuntime;
 use crate::cctp::stellar_payload::payload_hash_from_envelope_xdr;
+use crate::cctp::stellar_rpc::StellarRpcClient;
+use crate::cctp::stellar_tx::{parse_invoke_envelope, TxStatus};
 use crate::cctp::store::{CctpStoreError, CctpTransfer, CctpTransferStore, TransferPatch};
 use crate::cctp::transitions::can_cancel;
 use crate::cctp::verifiers::{facts_match, MintVerifyOutcome, VerifierError};
@@ -37,6 +39,12 @@ use crate::models::v2_cctp::{
     CctpDirection, CctpFinality, CctpQuoteRequest, CctpTransferStatus, CctpValidationError,
     PreparedWalletPayload,
 };
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum StellarSourceSubmissionKind {
+    Approval,
+    Burn,
+}
 
 #[derive(Debug, Error)]
 pub enum CctpServiceError {
@@ -807,6 +815,68 @@ impl CctpService {
         .await
     }
 
+    /// Classify a Stellar source tx by on-chain invoke target (approval vs burn).
+    async fn classify_stellar_source_submission(
+        &self,
+        tx_hash: &str,
+    ) -> Result<StellarSourceSubmissionKind, VerifierError> {
+        let rpc = StellarRpcClient::new(&self.config)?;
+        let tx = rpc.get_finalized_transaction(tx_hash).await?;
+        if tx.status != TxStatus::Success {
+            return Err(VerifierError::Failed("tx failed".into()));
+        }
+        let invoke = parse_invoke_envelope(&tx.envelope_xdr)?;
+        match invoke.function.as_str() {
+            "approve" => Ok(StellarSourceSubmissionKind::Approval),
+            "deposit_for_burn" | "deposit_for_burn_with_hook" => {
+                Ok(StellarSourceSubmissionKind::Burn)
+            }
+            other => Err(VerifierError::Failed(format!(
+                "unsupported stellar invoke: {other}"
+            ))),
+        }
+    }
+
+    /// Route `submit-burn` to approval or burn verification using on-chain evidence.
+    pub async fn record_source_submission(
+        &self,
+        transfer_id: Uuid,
+        tx_hash: &str,
+    ) -> Result<CctpTransfer, CctpServiceError> {
+        let transfer = self
+            .store
+            .get(transfer_id)
+            .await
+            .map_err(CctpServiceError::Store)?
+            .ok_or(CctpServiceError::NotFound)?;
+
+        match transfer.direction {
+            CctpDirection::StellarToEvm => {
+                let kind = self
+                    .classify_stellar_source_submission(tx_hash)
+                    .await
+                    .map_err(CctpServiceError::Verifier)?;
+                match kind {
+                    StellarSourceSubmissionKind::Approval => {
+                        self.record_approval_submission(transfer_id, tx_hash).await
+                    }
+                    StellarSourceSubmissionKind::Burn => {
+                        self.record_burn_submission(transfer_id, tx_hash).await
+                    }
+                }
+            }
+            CctpDirection::EvmToStellar => {
+                if transfer.burn_prepare_step.as_deref() == Some("approval")
+                    && transfer.source_approval_verified_at.is_none()
+                {
+                    self.record_approval_submission(transfer_id, tx_hash).await
+                } else {
+                    self.record_burn_submission(transfer_id, tx_hash).await
+                }
+            }
+        }
+    }
+
     pub async fn record_approval_submission(
         &self,
         transfer_id: Uuid,
@@ -837,18 +907,18 @@ impl CctpService {
             }
         }
 
-        let required_subunits = decimal_to_cctp_subunits(&transfer.amount)
-            .map_err(|_| CctpServiceError::Verifier(VerifierError::Failed("amount".into())))?;
-
         let verified_at = Utc::now();
         match transfer.direction {
             CctpDirection::StellarToEvm => {
                 if !self.runtime.stellar_approval_verifier.is_ready() {
                     return Err(CctpServiceError::VerifiersNotReady);
                 }
-                let required_i128: i128 = required_subunits.try_into().map_err(|_| {
-                    CctpServiceError::Verifier(VerifierError::Failed("amount".into()))
-                })?;
+                let cctp_amount = stellar_outbound_cctp_amount_strict(&transfer.amount)
+                    .map_err(|_| CctpServiceError::Verifier(VerifierError::Failed("amount".into())))?;
+                let required_i128: i128 = cctp_subunits_to_stellar_subunits(cctp_amount)
+                    .map_err(|_| CctpServiceError::Verifier(VerifierError::Failed("amount".into())))?
+                    .try_into()
+                    .map_err(|_| CctpServiceError::Verifier(VerifierError::Failed("amount".into())))?;
                 self.runtime
                     .stellar_approval_verifier
                     .verify_approval(&transfer, tx_hash, required_i128)
@@ -859,6 +929,8 @@ impl CctpService {
                 if !self.runtime.evm_approval_verifier.is_ready() {
                     return Err(CctpServiceError::VerifiersNotReady);
                 }
+                let required_subunits = decimal_to_cctp_subunits(&transfer.amount)
+                    .map_err(|_| CctpServiceError::Verifier(VerifierError::Failed("amount".into())))?;
                 self.runtime
                     .evm_approval_verifier
                     .verify_approval(&transfer, tx_hash, required_subunits)

--- a/crates/api/src/models/v2_cctp.rs
+++ b/crates/api/src/models/v2_cctp.rs
@@ -253,10 +253,12 @@ impl CctpQuoteRequest {
                 if !is_valid_evm_address(&self.recipient) {
                     return Err(CctpValidationError::InvalidRecipient);
                 }
-                if let Some(sender) = &self.sender {
-                    if !is_valid_stellar_account(sender) {
-                        return Err(CctpValidationError::InvalidSender);
-                    }
+                let sender = self
+                    .sender
+                    .as_deref()
+                    .ok_or(CctpValidationError::InvalidSender)?;
+                if !is_valid_stellar_account(sender) {
+                    return Err(CctpValidationError::InvalidSender);
                 }
                 if self.finality == CctpFinality::Fast {
                     return Err(CctpValidationError::InvalidFinality);
@@ -266,10 +268,12 @@ impl CctpQuoteRequest {
                 if !is_valid_stellar_recipient(&self.recipient) {
                     return Err(CctpValidationError::InvalidRecipient);
                 }
-                if let Some(sender) = &self.sender {
-                    if !is_valid_evm_address(sender) {
-                        return Err(CctpValidationError::InvalidSender);
-                    }
+                let sender = self
+                    .sender
+                    .as_deref()
+                    .ok_or(CctpValidationError::InvalidSender)?;
+                if !is_valid_evm_address(sender) {
+                    return Err(CctpValidationError::InvalidSender);
                 }
                 let submitter = self
                     .mint_submitter
@@ -641,14 +645,21 @@ mod tests {
     }
 
     #[test]
-    fn validates_optional_sender_per_direction() {
+    fn requires_valid_sender_per_direction() {
         let mut to_evm = base_quote(CctpDirection::StellarToEvm, CctpFinality::Standard);
+        to_evm.sender = None;
+        assert_eq!(to_evm.validate(), Err(CctpValidationError::InvalidSender));
         to_evm.sender = Some(VALID_EVM.into());
         assert_eq!(to_evm.validate(), Err(CctpValidationError::InvalidSender));
         to_evm.sender = Some(VALID_STELLAR.into());
         assert!(to_evm.validate().is_ok());
 
         let mut to_stellar = base_quote(CctpDirection::EvmToStellar, CctpFinality::Standard);
+        to_stellar.sender = None;
+        assert_eq!(
+            to_stellar.validate(),
+            Err(CctpValidationError::InvalidSender)
+        );
         to_stellar.sender = Some(VALID_STELLAR.into());
         assert_eq!(
             to_stellar.validate(),

--- a/crates/api/src/routes/v2_cctp.rs
+++ b/crates/api/src/routes/v2_cctp.rs
@@ -373,18 +373,11 @@ pub async fn cctp_submit_burn(
     gate_for_direction(&state, transfer.direction).await?;
 
     let ctx = require_cctp(&state)?;
-    let updated = if transfer.burn_prepare_step.as_deref() == Some("approval")
-        && transfer.source_approval_verified_at.is_none()
-    {
-        ctx.service
-            .record_approval_submission(transfer_id, &body.tx_hash)
-            .await
-    } else {
-        ctx.service
-            .record_burn_submission(transfer_id, &body.tx_hash)
-            .await
-    }
-    .map_err(|e| map_service_error(e, Some(transfer_id)))?;
+    let updated = ctx
+        .service
+        .record_source_submission(transfer_id, &body.tx_hash)
+        .await
+        .map_err(|e| map_service_error(e, Some(transfer_id)))?;
 
     metrics::record_cctp_endpoint_outcome("submit_burn", "success");
     Ok(Json(ApiResponse::with_version(

--- a/frontend/hooks/useCctpSaga.ts
+++ b/frontend/hooks/useCctpSaga.ts
@@ -35,6 +35,7 @@ import {
   executePreparedPayload,
   reconcileEvmTransactionHash,
 } from '@/lib/cctp/wallet-execution';
+import { submitBurnWithVerificationRetry } from '@/lib/cctp/stellar-submit';
 import { startCctpStatusPoll, type StatusPollHandle } from '@/lib/cctp/status-poll';
 import type {
   CctpPrepareBurnResponse,
@@ -158,6 +159,34 @@ export function useCctpSaga(input: UseCctpSagaInput) {
     pollRef.current?.stop();
     pollRef.current = null;
   }, []);
+
+  const abortExpiredQuote = useCallback(() => {
+    stopPoll();
+    clearCctpSession();
+    setSession(null);
+    setQuote(null);
+    setTransferStatus(null);
+    setPreparedPayload(null);
+    setPreparedFingerprint(null);
+    setBurnPrepareStep('unknown');
+    setStage('idle');
+  }, [stopPoll]);
+
+  const applyCctpFailure = useCallback(
+    (err: unknown, options?: { failedStage?: CctpSagaStage }) => {
+      const mapped = mapCctpError(err);
+      setError(mapped);
+      if (mapped.kind === 'quote_expired') {
+        abortExpiredQuote();
+        return mapped;
+      }
+      if (options?.failedStage) {
+        setStage(options.failedStage);
+      }
+      return mapped;
+    },
+    [abortExpiredQuote],
+  );
 
   useEffect(() => () => {
     stopPoll();
@@ -496,11 +525,11 @@ export function useCctpSaga(input: UseCctpSagaInput) {
       persistBurnPrepare(prepared);
       setStage('quoted');
     } catch (err) {
-      setError(mapCctpError(err));
+      applyCctpFailure(err);
     } finally {
       setBusy(false);
     }
-  }, [accessOptions, client, persistBurnPrepare, requireWalletRoles, session]);
+  }, [accessOptions, client, persistBurnPrepare, requireWalletRoles, session, applyCctpFailure]);
 
   const autoReconcileRevision = useMemo(() => {
     if (!session) return null;
@@ -574,10 +603,11 @@ export function useCctpSaga(input: UseCctpSagaInput) {
       const activeRecord = freshLoaded.ok ? freshLoaded.record : loaded.record;
       syncSession(activeRecord);
       applyResolvedBurnStep(activeRecord, preparedPayload);
+      setError(null);
       if (activeRecord.recovery.pendingEvmTx) {
         setStage('pending_reconcile');
       } else if (!['completed', 'cancelled', 'provider_killed'].includes(status.status)) {
-        setStage('quoted');
+        setStage((prev) => (prev === 'failed' ? prev : 'quoted'));
       }
       setResumeMismatch(false);
       if (!['completed', 'cancelled', 'provider_killed'].includes(status.status)) {
@@ -765,18 +795,33 @@ export function useCctpSaga(input: UseCctpSagaInput) {
         });
         return;
       }
-      await client.submitBurn(session.transferId, { tx_hash: exec.txHash }, accessOptions());
+      await submitBurnWithVerificationRetry(
+        client,
+        session.transferId,
+        exec.txHash,
+        accessOptions(),
+        'testnet',
+      );
       clearPendingEvmTx();
       const status = await client.getTransfer(session.transferId, accessOptions());
       handleStatus(status);
       setPreparedPayload(null);
+      setPreparedFingerprint(null);
       setBurnPrepareStep('unknown');
-      patchCctpSessionRecovery({ burnPrepareStep: 'unknown' });
+      patchCctpSessionRecovery({
+        burnPrepareStep: 'unknown',
+        lastPreparedFingerprint: undefined,
+      });
+      setError(null);
+      const burnPrepared = await client.prepareBurn(
+        session.transferId,
+        accessOptions(),
+      );
+      persistBurnPrepare(burnPrepared);
       setStage('quoted');
     } catch (err) {
       if (requireReprepareAfterSequenceError(err)) return;
-      setError(mapCctpError(err));
-      setStage('failed');
+      applyCctpFailure(err, { failedStage: 'failed' });
     } finally {
       setBusy(false);
     }
@@ -794,6 +839,8 @@ export function useCctpSaga(input: UseCctpSagaInput) {
     syncSession,
     commitPendingEvmTx,
     requireWalletRoles,
+    applyCctpFailure,
+    persistBurnPrepare,
   ]);
 
   const signBurnStep = useCallback(async () => {
@@ -838,7 +885,13 @@ export function useCctpSaga(input: UseCctpSagaInput) {
         commitPendingEvmTx({ txHash: exec.txHash, purpose: 'burn' });
         return;
       }
-      await client.submitBurn(session.transferId, { tx_hash: exec.txHash }, accessOptions());
+      await submitBurnWithVerificationRetry(
+        client,
+        session.transferId,
+        exec.txHash,
+        accessOptions(),
+        'testnet',
+      );
       clearPendingEvmTx();
       setPreparedPayload(null);
       setBurnPrepareStep('unknown');
@@ -847,8 +900,7 @@ export function useCctpSaga(input: UseCctpSagaInput) {
       startPoll(session.transferId, session.accessToken);
     } catch (err) {
       if (requireReprepareAfterSequenceError(err)) return;
-      setError(mapCctpError(err));
-      setStage('failed');
+      applyCctpFailure(err, { failedStage: 'failed' });
     } finally {
       setBusy(false);
     }
@@ -866,6 +918,7 @@ export function useCctpSaga(input: UseCctpSagaInput) {
     startPoll,
     syncSession,
     requireWalletRoles,
+    applyCctpFailure,
   ]);
 
   const signPreparedMintStep = useCallback(async () => {
@@ -922,7 +975,11 @@ export function useCctpSaga(input: UseCctpSagaInput) {
       if (pending.purpose === 'mint') {
         await client.submitMint(session.transferId, { tx_hash: exec.txHash }, accessOptions());
       } else {
-        await client.submitBurn(session.transferId, { tx_hash: exec.txHash }, accessOptions());
+        await client.submitBurn(
+          session.transferId,
+          { tx_hash: exec.txHash },
+          accessOptions(),
+        );
       }
       clearPendingEvmTx();
       if (pending.purpose === 'approval') {
@@ -939,6 +996,7 @@ export function useCctpSaga(input: UseCctpSagaInput) {
       }
     } catch (err) {
       setError(mapCctpError(err));
+      setStage('failed');
     } finally {
       setBusy(false);
     }

--- a/frontend/lib/cctp/errors.ts
+++ b/frontend/lib/cctp/errors.ts
@@ -133,6 +133,56 @@ export function mapCctpError(err: unknown): CctpTraderError {
           action: 'Wait and retry',
         };
       default:
+        if (
+          err.message?.includes('USDC approval, not a burn') ||
+          err.message?.includes('Prepare the burn')
+        ) {
+          return {
+            kind: 'nonretryable',
+            title: 'Approval recorded — burn is next',
+            message: err.message,
+            requestId,
+            action: 'Prepare burn',
+          };
+        }
+        if (
+          err.message?.includes('quote has expired') ||
+          err.message?.includes('request a new quote')
+        ) {
+          return {
+            kind: 'quote_expired',
+            title: 'Quote expired',
+            message: 'Request a fresh quote before preparing or signing.',
+            requestId,
+            action: 'Refresh quote',
+          };
+        }
+        if (
+          err.message?.includes('Could not prepare source transaction') ||
+          err.message?.includes('Insufficient USDC balance') ||
+          err.message?.includes('active prepare already exists')
+        ) {
+          return {
+            kind: 'nonretryable',
+            title: 'Could not prepare transaction',
+            message: err.message,
+            requestId,
+            action: 'Check balance and retry',
+          };
+        }
+        if (
+          err.message?.includes('not yet available for verification') ||
+          err.message?.includes('On-chain verification failed')
+        ) {
+          return {
+            kind: 'retryable',
+            title: 'Confirming on-chain transaction',
+            message:
+              'Your transaction was submitted but the API has not confirmed it yet. Wait a few seconds and try again.',
+            requestId,
+            action: 'Retry',
+          };
+        }
         if (err.status === 409) {
           return {
             kind: 'nonretryable',

--- a/frontend/lib/cctp/stellar-submit.ts
+++ b/frontend/lib/cctp/stellar-submit.ts
@@ -1,0 +1,89 @@
+import { StellarRouteApiError } from '@/lib/api/client';
+import type { CctpApiClient } from './client';
+import type { CctpCallOptions } from './types';
+import type { WalletNetwork } from '@/lib/wallet/types';
+
+const SUBMIT_BURN_MAX_ATTEMPTS = 6;
+const SUBMIT_BURN_BASE_MS = 400;
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isSubmitBurnRetryable(err: unknown): boolean {
+  if (err instanceof StellarRouteApiError) {
+    return err.status === 503 || err.code === 'dependency_unavailable';
+  }
+  return false;
+}
+
+/** Wait until Horizon can see the tx (Soroban RPC may lag behind). */
+export async function waitForHorizonTransaction(
+  txHash: string,
+  network: WalletNetwork | null = 'testnet',
+  options?: { signal?: AbortSignal; maxAttempts?: number },
+): Promise<void> {
+  const { getHorizonUrl } = await import('@/lib/wallet/submit');
+  const horizonUrl = getHorizonUrl(network);
+  const maxAttempts = options?.maxAttempts ?? 12;
+  const normalized = txHash.trim().toLowerCase().replace(/^0x/, '');
+
+  for (let attempt = 0; attempt < maxAttempts; attempt++) {
+    if (options?.signal?.aborted) {
+      throw new StellarRouteApiError(0, 'network_error', 'Submission cancelled');
+    }
+    try {
+      const response = await fetch(
+        `${horizonUrl}/transactions/${encodeURIComponent(normalized)}`,
+        { signal: options?.signal },
+      );
+      if (response.ok) {
+        const body = (await response.json()) as { successful?: boolean };
+        if (body.successful === false) {
+          throw new StellarRouteApiError(
+            400,
+            'validation_error',
+            'Stellar transaction failed on-chain.',
+          );
+        }
+        return;
+      }
+      if (response.status !== 404) {
+        break;
+      }
+    } catch (err) {
+      if (err instanceof StellarRouteApiError) throw err;
+      if (options?.signal?.aborted) {
+        throw new StellarRouteApiError(0, 'network_error', 'Submission cancelled');
+      }
+    }
+    await sleep(350 + attempt * 200);
+  }
+}
+
+export async function submitBurnWithVerificationRetry(
+  client: CctpApiClient,
+  transferId: string,
+  txHash: string,
+  options?: CctpCallOptions,
+  network: WalletNetwork | null = 'testnet',
+): Promise<void> {
+  await waitForHorizonTransaction(txHash, network, { signal: options?.signal });
+
+  let lastErr: unknown;
+  for (let attempt = 0; attempt < SUBMIT_BURN_MAX_ATTEMPTS; attempt++) {
+    if (options?.signal?.aborted) {
+      throw new StellarRouteApiError(0, 'network_error', 'Submission cancelled');
+    }
+    try {
+      await client.submitBurn(transferId, { tx_hash: txHash }, options);
+      return;
+    } catch (err) {
+      lastErr = err;
+      if (isSubmitBurnRetryable(err) && attempt + 1 < SUBMIT_BURN_MAX_ATTEMPTS) {
+        await sleep(SUBMIT_BURN_BASE_MS * Math.pow(2, attempt));
+        continue;
+      }
+      throw err;
+    }
+  }
+  throw lastErr;
+}


### PR DESCRIPTION
## Summary
- Route `submit-burn` by on-chain function (`approve` vs `deposit_for_burn`) so approval txs are never verified as burns
- Map `prepare-burn` builder/validation failures to clear trader-facing errors (not generic on-chain verification failed)
- Require `sender` on CCTP quote validation for both directions
- Frontend: auto-prepare burn after approval, Horizon wait + retry on submit-burn 503, clearer error mapping

## Test plan
- [x] `cargo test -p stellarroute-api --lib cctp::gate::` (7 passed)
- [x] `npm --prefix frontend run test -- lib/cctp/errors.test.ts` (2 passed)
- [ ] Deploy to staging (`34.224.110.144.sslip.io`) and retry stuck Stellar→Sepolia transfer