### PR TITLE
fix(deploy): simplify SSM preflight for staging ship

### DIFF
--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -114,26 +114,29 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Verbose sync: always emit breadcrumbs so empty SSM output is diagnosable.
+          # Keep commands short (SSM parameter size limits) and always print
+          # breadcrumbs. Avoid `set -x` — xtrace can overflow SSM stderr capture.
           # shellcheck disable=SC2016
-          SYNC_CMD="set -eux; export HOME=/root; echo SYNC_BEGIN; hostname; date -u; df -h / /var /opt 2>/dev/null || df -h; ls -la /opt || true; test -d /opt/stellarroute || { echo 'MISSING /opt/stellarroute'; exit 1; }; cd /opt/stellarroute; git -c safe.directory=* remote -v; git -c safe.directory=* fetch --all --prune; git -c safe.directory=* reset --hard HEAD; git -c safe.directory=* clean -fd -e .env.prod -e .env -e '.env.*'; git -c safe.directory=* checkout -B ${DEPLOY_REF} origin/${DEPLOY_REF}; git -c safe.directory=* log -1 --oneline; test \"\$(git -c safe.directory=* rev-parse HEAD)\" = \"\$(git -c safe.directory=* rev-parse origin/${DEPLOY_REF})\"; echo SYNC_OK"
-
-          # Health wait: require API JSON response, not full /health 200 (indexer lag
-          # currently marks staging unhealthy even when API+Postgres can serve CCTP).
-          HEALTH_WAIT='for i in $(seq 1 60); do code=$(curl -sS -o /tmp/sr-health.json -w "%{http_code}" http://127.0.0.1:8080/health || echo 000); echo "health_http=${code}"; if [[ "${code}" != "000" ]] && [[ -s /tmp/sr-health.json ]]; then echo API_responding; cat /tmp/sr-health.json; break; fi; sleep 5; done'
+          PREFLIGHT='echo PREFLIGHT_BEGIN; hostname; date -u; pwd; ls -la /opt; df -h /'
+          SYNC_CMD="export HOME=/root; echo SYNC_BEGIN; cd /opt/stellarroute || { echo MISSING_REPO; exit 1; }; git -c safe.directory=* fetch --all --prune; git -c safe.directory=* reset --hard HEAD; git -c safe.directory=* clean -fd -e .env.prod -e .env -e '.env.*'; git -c safe.directory=* checkout -B ${DEPLOY_REF} origin/${DEPLOY_REF}; git -c safe.directory=* log -1 --oneline; test \"\$(git -c safe.directory=* rev-parse HEAD)\" = \"\$(git -c safe.directory=* rev-parse origin/${DEPLOY_REF})\"; echo SYNC_OK"
+          HEALTH_WAIT='for i in 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 18 19 20 21 22 23 24 25 26 27 28 29 30; do code=$(curl -sS -o /tmp/sr-health.json -w "%{http_code}" http://127.0.0.1:8080/health || echo 000); echo health_http=$code; if [ "$code" != "000" ] && [ -s /tmp/sr-health.json ]; then echo API_responding; break; fi; sleep 5; done'
 
           jq -n \
+            --arg preflight "${PREFLIGHT}" \
             --arg sync "${SYNC_CMD}" \
             --arg health "${HEALTH_WAIT}" \
             --arg url "${DEPLOY_URL}" \
             '{
               commands: [
+                $preflight,
                 $sync,
                 "bash /opt/stellarroute/deploy/aws/scripts/deploy-ec2-staging.sh",
                 $health,
                 ("bash /opt/stellarroute/deploy/aws/scripts/ec2-postdeploy-smoke.sh " + $url)
               ]
             }' > /tmp/ssm-commands.json
+
+          echo "SSM parameters bytes: $(wc -c < /tmp/ssm-commands.json)"
 
           COMMAND_ID="$(aws ssm send-command \
             --region "${AWS_REGION}" \

--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -81,13 +81,14 @@ jobs:
           echo "DEPLOY_REF=${DEPLOY_REF}" >> "${GITHUB_ENV}"
           echo "DEPLOY_URL=${DEPLOY_URL}" >> "${GITHUB_ENV}"
 
-      - name: Ensure instance running and SSM online
+      - name: Ensure instance running
         if: env.SKIP != '1'
         env:
           AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
           STAGING_INSTANCE_ID: ${{ secrets.STAGING_INSTANCE_ID }}
         run: |
           set -euo pipefail
+          # Deploy role may lack ssm:DescribeInstanceInformation; do not gate on it.
           STATE="$(aws ec2 describe-instances \
             --region "${AWS_REGION}" \
             --instance-ids "${STAGING_INSTANCE_ID}" \
@@ -98,27 +99,9 @@ jobs:
             echo "Starting instance ${STAGING_INSTANCE_ID}..."
             aws ec2 start-instances --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}" >/dev/null
             aws ec2 wait instance-running --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}"
+            echo "Instance is running; waiting 30s for guest services..."
+            sleep 30
           fi
-
-          echo "Waiting for SSM agent Online..."
-          for _ in $(seq 1 36); do
-            PING="$(aws ssm describe-instance-information \
-              --region "${AWS_REGION}" \
-              --filters "Key=InstanceIds,Values=${STAGING_INSTANCE_ID}" \
-              --query 'InstanceInformationList[0].PingStatus' \
-              --output text 2>/dev/null || echo None)"
-            echo "SSM PingStatus=${PING}"
-            if [[ "${PING}" == "Online" ]]; then
-              exit 0
-            fi
-            sleep 10
-          done
-          echo "SSM agent did not become Online within 6 minutes."
-          aws ssm describe-instance-information \
-            --region "${AWS_REGION}" \
-            --filters "Key=InstanceIds,Values=${STAGING_INSTANCE_ID}" \
-            --output json || true
-          exit 1
 
       - name: Send SSM deploy command
         if: env.SKIP != '1'


### PR DESCRIPTION
## Summary
- Staging SSM still returns Failed with empty stdout/stderr before deploy runs
- Add short PREFLIGHT command + shrink payload; keep soft health wait

## Test plan
- [ ] Deploy EC2 Staging shows PREFLIGHT_BEGIN / SYNC_OK and completes