### PR TITLE
fix(deploy): cycle staging EC2 stop/start for SSM recovery

### DIFF
--- a/.github/workflows/deploy-ec2-staging.yml
+++ b/.github/workflows/deploy-ec2-staging.yml
@@ -102,12 +102,15 @@ jobs:
           fi
 
           # SSM has been returning Failed/empty output while the API still serves traffic.
-          # Reboot once per deploy to recover a wedged amazon-ssm-agent (common after disk pressure).
-          echo "Rebooting instance to refresh SSM agent..."
-          aws ec2 reboot-instances --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}"
-          aws ec2 wait instance-status-ok --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}"
-          echo "Instance status checks ok; waiting 45s for SSM agent..."
-          sleep 45
+          # Deploy role lacks ec2:RebootInstances; use stop/start (StartInstances is already allowed).
+          echo "Cycling instance power to refresh SSM agent..."
+          aws ec2 stop-instances --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}" >/dev/null
+          aws ec2 wait instance-stopped --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}"
+          aws ec2 start-instances --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}" >/dev/null
+          aws ec2 wait instance-running --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}"
+          aws ec2 wait instance-status-ok --region "${AWS_REGION}" --instance-ids "${STAGING_INSTANCE_ID}" || true
+          echo "Instance running again; waiting 60s for SSM agent..."
+          sleep 60
 
       - name: Send SSM deploy command
         if: env.SKIP != '1'


### PR DESCRIPTION
## Summary
- `ec2:RebootInstances` denied on deploy role (#1190)
- Use stop/start to recover wedged SSM so CCTP approve/burn fix can ship

## Test plan
- [ ] Deploy shows PREFLIGHT_BEGIN / SYNC_OK