### PR TITLE
fix(deploy): apply CCTP Fast finality DDL on staging

### DIFF
--- a/.github/workflows/enable-cctp-staging.yml
+++ b/.github/workflows/enable-cctp-staging.yml
@@ -58,14 +58,21 @@ jobs:
           # Sync main first so enable-cctp-staging.sh exists on the host.
           # shellcheck disable=SC2016
           SYNC_CMD='set -eu; cd /opt/stellarroute; export HOME=/root; git -c safe.directory=* fetch --all --prune; git -c safe.directory=* reset --hard HEAD; git -c safe.directory=* clean -fd -e .env.prod -e .env -e ".env.*"; git -c safe.directory=* checkout -B main origin/main; git -c safe.directory=* log -1 --oneline'
+          # Always apply CCTP SQL on the synced tree (main already has
+          # 20260814_cctp_finality_fast.sql). Deploy used to skip that file, so
+          # Fast quotes 500'd on a Standard-only CHECK constraint.
+          # shellcheck disable=SC2016
+          APPLY_DDL='set -eu; cd /opt/stellarroute; export HOME=/root; POSTGRES_USER=$(grep -E "^POSTGRES_USER=" .env.prod | head -1 | cut -d= -f2-); POSTGRES_DB=$(grep -E "^POSTGRES_DB=" .env.prod | head -1 | cut -d= -f2-); for mig in $(ls -1 crates/api/migrations/*cctp*.sql | sort); do echo APPLYING "$mig"; docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod exec -T postgres psql -v ON_ERROR_STOP=1 -U "$POSTGRES_USER" -d "$POSTGRES_DB" < "$mig"; done'
 
           jq -n \
             --arg sync "${SYNC_CMD}" \
+            --arg apply "${APPLY_DDL}" \
             --arg sepolia "${SEPOLIA_RPC}" \
             --arg stellar "${STELLAR_RPC}" \
             '{
               commands: [
                 $sync,
+                $apply,
                 (
                   "set -eu; cd /opt/stellarroute; export HOME=/root; " +
                   "export CCTP_SEPOLIA_RPC_URL=" + ($sepolia | @sh) + "; " +

--- a/deploy/aws/scripts/apply-cctp-ddl.sh
+++ b/deploy/aws/scripts/apply-cctp-ddl.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Apply every crates/api/migrations/*cctp*.sql file in sorted order.
+# Idempotent. Run from repo root on the staging host (Compose stack up).
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+cd "${ROOT}"
+
+ENV_FILE="${ROOT}/.env.prod"
+if [[ ! -f "${ENV_FILE}" ]]; then
+  echo "Missing ${ENV_FILE}." >&2
+  exit 1
+fi
+
+POSTGRES_USER="$(grep -E '^POSTGRES_USER=' "${ENV_FILE}" | head -1 | cut -d= -f2-)"
+POSTGRES_DB="$(grep -E '^POSTGRES_DB=' "${ENV_FILE}" | head -1 | cut -d= -f2-)"
+if [[ -z "${POSTGRES_USER}" || -z "${POSTGRES_DB}" ]]; then
+  echo "POSTGRES_USER / POSTGRES_DB missing from ${ENV_FILE}" >&2
+  exit 1
+fi
+
+shopt -s nullglob
+migrations=("${ROOT}"/crates/api/migrations/*cctp*.sql)
+if [[ ${#migrations[@]} -eq 0 ]]; then
+  echo "No CCTP SQL migrations found under crates/api/migrations" >&2
+  exit 1
+fi
+
+IFS=$'\n' sorted=($(printf '%s\n' "${migrations[@]}" | sort))
+unset IFS
+
+echo "Applying ${#sorted[@]} CCTP DDL files..."
+COMPOSE=(docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod)
+for mig in "${sorted[@]}"; do
+  "${COMPOSE[@]}" exec -T postgres \
+    psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
+    < "${mig}"
+  echo " - $(basename "${mig}") ready"
+done

--- a/deploy/aws/scripts/deploy-ec2-staging.sh
+++ b/deploy/aws/scripts/deploy-ec2-staging.sh
@@ -48,25 +48,8 @@ docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-fil
   < "${ROOT}/crates/indexer/migrations/0015_swap_prepared_quotes.sql"
 echo " - swap_prepared_quotes ready"
 
-CCTP_MIGRATIONS=(
-  "${ROOT}/crates/api/migrations/0015_cctp_transfers.sql"
-  "${ROOT}/crates/api/migrations/0016_cctp_transfers_hardening.sql"
-  "${ROOT}/crates/api/migrations/0017_cctp_mint_metadata.sql"
-  "${ROOT}/crates/api/migrations/0018_cctp_approval_tx_hash.sql"
-  "${ROOT}/crates/api/migrations/0019_cctp_approval_verified_at.sql"
-  "${ROOT}/crates/api/migrations/20260730_cctp_review_fixes.sql"
-  "${ROOT}/crates/api/migrations/20260731_cctp_prepare_lock_hardening.sql"
-  "${ROOT}/crates/api/migrations/20260801_cctp_http_gate.sql"
-  "${ROOT}/crates/api/migrations/20260802_cctp_http_hardening.sql"
-  "${ROOT}/crates/api/migrations/20260803_cctp_reattest_lease.sql"
-)
-echo "Applying CCTP DDL (idempotent)..."
-for mig in "${CCTP_MIGRATIONS[@]}"; do
-  docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod exec -T postgres \
-    psql -v ON_ERROR_STOP=1 -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" \
-    < "${mig}"
-  echo " - $(basename "${mig}") ready"
-done
+echo "Applying CCTP DDL (idempotent, all *cctp*.sql)..."
+bash "${ROOT}/deploy/aws/scripts/apply-cctp-ddl.sh"
 
 echo "Local health checks:"
 # API may still be booting; do not fail the whole deploy on a racing curl here.

--- a/deploy/aws/scripts/enable-cctp-staging.sh
+++ b/deploy/aws/scripts/enable-cctp-staging.sh
@@ -95,6 +95,9 @@ else
   echo "CCTP_ACCESS_TOKEN_HMAC_KEY=<missing>" >&2
 fi
 
+echo "Applying CCTP DDL before API recreate (includes Fast finality check)..."
+bash "${ROOT}/deploy/aws/scripts/apply-cctp-ddl.sh"
+
 echo "Recreating API with CCTP enabled..."
 COMPOSE=(docker compose -f docker-compose.yml -f deploy/docker-compose.prod.yml --env-file .env.prod)
 # Clear stale name conflicts from overlapping deploy/enable SSM runs.


### PR DESCRIPTION
## Summary
- Staging Fast CCTP quotes (the UI default) returned HTTP 500 / "Temporary error" because Postgres still had `CHECK (finality = 'standard')` from `0016`.
- `20260814_cctp_finality_fast.sql` existed on `main` but was missing from the hardcoded deploy migration list.
- Glob-apply every `*cctp*.sql` on deploy/enable, and apply CCTP DDL in the enable-CCTP SSM path before recreating the API.

## Test plan
- [x] `POST /api/v2/bridge/cctp/quote` with `finality: standard` already 200 on staging
- [ ] After merge + Enable CCTP Staging, Fast quote (`finality: fast`, amount `7`) returns 200
- [ ] Production `/swap` Get quote no longer shows Temporary error